### PR TITLE
fix: images don't refresh after upload or generation

### DIFF
--- a/app/components/items/ItemEditDialog.vue
+++ b/app/components/items/ItemEditDialog.vue
@@ -519,6 +519,9 @@ import EntityDocuments from '~/components/shared/EntityDocuments.vue'
 import EntityImageGallery from '~/components/shared/EntityImageGallery.vue'
 import EntityImageUpload from '~/components/shared/EntityImageUpload.vue'
 import EntityPlayersTab from '~/components/shared/EntityPlayersTab.vue'
+import { useEntitiesStore } from '~/stores/entities'
+
+const entitiesStore = useEntitiesStore()
 
 // Component-specific types for relations
 interface ItemOwner {
@@ -690,6 +693,9 @@ async function handleImageUpload(event: Event) {
     }
 
     await response.json()
+
+    // Refresh the item in the store to update the image reactively
+    await entitiesStore.refreshItem(props.editingItem.id)
     emit('image-changed')
   } catch (error) {
     console.error('Failed to upload image:', error)
@@ -751,6 +757,8 @@ async function generateImage() {
         },
       })
 
+      // Refresh the item in the store to update the image reactively
+      await entitiesStore.refreshItem(props.editingItem.id)
       emit('image-changed')
     }
   } catch (error) {

--- a/app/components/npcs/NpcEditDialog.vue
+++ b/app/components/npcs/NpcEditDialog.vue
@@ -483,8 +483,10 @@ import NpcNotesTab from './NpcNotesTab.vue'
 import EntityDocuments from '../shared/EntityDocuments.vue'
 import EntityImageUpload from '../shared/EntityImageUpload.vue'
 import { useImageDownload } from '~/composables/useImageDownload'
+import { useEntitiesStore } from '~/stores/entities'
 
 const { locale, t } = useI18n()
+const entitiesStore = useEntitiesStore()
 const { downloadImage: downloadImageFile } = useImageDownload()
 
 // NPC Type Icons
@@ -687,7 +689,8 @@ async function handleImageUpload(event: Event) {
 
     await response.json()
 
-    // Emit event to parent to update the NPC
+    // Refresh the NPC in the store to update the image reactively
+    await entitiesStore.refreshNPC(props.editingNpc.id)
     emit('image-changed')
   } catch (error) {
     console.error('Failed to upload image:', error)
@@ -787,7 +790,8 @@ async function generateImage() {
       )
 
       if (response.success) {
-        // Emit event to parent to update the NPC
+        // Refresh the NPC in the store to update the image reactively
+        await entitiesStore.refreshNPC(props.editingNpc.id)
         emit('image-changed')
       }
     }

--- a/app/components/players/PlayerEditDialog.vue
+++ b/app/components/players/PlayerEditDialog.vue
@@ -369,9 +369,11 @@ import PlayerCharactersTab from './PlayerCharactersTab.vue'
 import PlayerItemsTab from './PlayerItemsTab.vue'
 import PlayerLoreTab from './PlayerLoreTab.vue'
 import { useImageDownload } from '~/composables/useImageDownload'
+import { useEntitiesStore } from '~/stores/entities'
 
 const { t } = useI18n()
 const { downloadImage: downloadImageFile } = useImageDownload()
+const entitiesStore = useEntitiesStore()
 
 // Interfaces
 interface PlayerForm {
@@ -446,6 +448,9 @@ async function handleImageUpload(event: Event) {
     }
 
     await response.json()
+
+    // Refresh the player in the store to update the image reactively
+    await entitiesStore.refreshPlayer(props.editingPlayer.id)
     emit('image-changed')
   } catch (error) {
     console.error('Failed to upload image:', error)
@@ -496,6 +501,8 @@ async function generateImage() {
       )
 
       if (response.success) {
+        // Refresh the player in the store to update the image reactively
+        await entitiesStore.refreshPlayer(props.editingPlayer.id)
         emit('image-changed')
       }
     }

--- a/app/pages/factions/index.vue
+++ b/app/pages/factions/index.vue
@@ -929,13 +929,11 @@ async function generateImage() {
         },
       })
 
-      // Update local state
-      editingFaction.value.image_url = filename
+      // Refresh the faction in the store to update the image reactively
+      await entitiesStore.refreshFaction(editingFaction.value.id)
 
-      // Reload factions from server to get updated data
-      if (activeCampaignId.value!) {
-        await entitiesStore.fetchFactions(activeCampaignId.value!)
-      }
+      // Update local state for the dialog
+      editingFaction.value.image_url = filename
     }
   } catch (error: unknown) {
     console.error('[Faction] Failed to generate image:', error)

--- a/app/pages/items/index.vue
+++ b/app/pages/items/index.vue
@@ -677,9 +677,12 @@ async function handleDocumentsChanged() {
 // Handle image changed event (from EntityImageUpload)
 async function handleImageChanged() {
   if (editingItem.value) {
-    // Reload the item to get updated image_url
-    const updatedItem = await $fetch<Item>(`/api/items/${editingItem.value.id}`)
-    editingItem.value = updatedItem
+    // Get the updated item from the store (already refreshed by the dialog)
+    const updatedItem = entitiesStore.getItemById(editingItem.value.id)
+    if (updatedItem) {
+      // Update the local editingItem to reflect the new image
+      editingItem.value = { ...editingItem.value, image_url: updatedItem.image_url }
+    }
     await reloadItemCounts(editingItem.value)
   }
 }

--- a/app/pages/npcs/index.vue
+++ b/app/pages/npcs/index.vue
@@ -138,7 +138,7 @@
       :npc-relation-count="npcRelationCount"
       @save="saveNpc"
       @close="closeDialog"
-      @image-changed="handleDocumentsChanged"
+      @image-changed="handleImageChanged"
       @open-image-preview="(url: string, name: string) => openImagePreview(url, name)"
       @add-npc-relation="addNpcRelation"
       @add-membership="addFactionMembership"
@@ -1207,6 +1207,18 @@ async function removeLoreRelation(relationId: number) {
 // Handle documents changed event (from EntityDocuments)
 async function handleDocumentsChanged() {
   if (editingNpc.value) {
+    await reloadNpcCounts(editingNpc.value)
+  }
+}
+
+async function handleImageChanged() {
+  if (editingNpc.value) {
+    // Get the updated NPC from the store (already refreshed by the dialog)
+    const updatedNpc = entitiesStore.getNpcById(editingNpc.value.id)
+    if (updatedNpc) {
+      // Update the local editingNpc to reflect the new image
+      editingNpc.value = { ...editingNpc.value, image_url: updatedNpc.image_url }
+    }
     await reloadNpcCounts(editingNpc.value)
   }
 }

--- a/app/pages/players/index.vue
+++ b/app/pages/players/index.vue
@@ -93,7 +93,7 @@
       @update:active-tab="activeTab = $event"
       @save="savePlayer"
       @close="closeDialog"
-      @image-changed="reloadPlayerCounts"
+      @image-changed="handleImageChanged"
       @counts-changed="reloadPlayerCounts"
       @open-image-preview="openImagePreview"
     />
@@ -318,6 +318,18 @@ async function reloadPlayerCounts() {
     editingPlayer.value = { ...editingPlayer.value }
   } catch (error) {
     console.error('Failed to reload player counts:', error)
+  }
+}
+
+async function handleImageChanged() {
+  if (editingPlayer.value) {
+    // Get the updated player from the store (already refreshed by the dialog)
+    const updatedPlayer = entitiesStore.getPlayerById(editingPlayer.value.id)
+    if (updatedPlayer) {
+      // Update the local editingPlayer to reflect the new image
+      editingPlayer.value = { ...editingPlayer.value, image_url: updatedPlayer.image_url }
+    }
+    await reloadPlayerCounts()
   }
 }
 

--- a/app/stores/entities.ts
+++ b/app/stores/entities.ts
@@ -150,6 +150,22 @@ export const useEntitiesStore = defineStore('entities', {
       this.npcs = this.npcs.filter((n) => n.id !== id)
     },
 
+    async refreshNPC(id: number) {
+      console.log('[Store] refreshNPC called for id:', id)
+      const npc = await $fetch<NPC>(`/api/npcs/${id}`)
+      console.log('[Store] Fetched NPC:', npc.name, 'image_url:', npc.image_url)
+      const index = this.npcs.findIndex((n) => n.id === id)
+      if (index !== -1) {
+        console.log('[Store] Updating NPC at index:', index, 'old image:', this.npcs[index]?.image_url)
+        // Preserve _counts from the old NPC (not returned by API)
+        this.npcs[index] = { ...this.npcs[index], ...npc }
+        console.log('[Store] Updated NPC image_url:', this.npcs[index]?.image_url)
+      } else {
+        console.log('[Store] NPC not found in store!')
+      }
+      return npc
+    },
+
     // ==================== Factions ====================
 
     async fetchFactions(campaignId: string | number, force = false) {
@@ -199,6 +215,16 @@ export const useEntitiesStore = defineStore('entities', {
         method: 'DELETE',
       })
       this.factions = this.factions.filter((f) => f.id !== id)
+    },
+
+    async refreshFaction(id: number) {
+      const faction = await $fetch<Faction>(`/api/factions/${id}`)
+      const index = this.factions.findIndex((f) => f.id === id)
+      if (index !== -1) {
+        // Preserve _counts from the old entity (not returned by API)
+        this.factions[index] = { ...this.factions[index], ...faction }
+      }
+      return faction
     },
 
     // ==================== Locations ====================
@@ -252,6 +278,16 @@ export const useEntitiesStore = defineStore('entities', {
       this.locations = this.locations.filter((l) => l.id !== id)
     },
 
+    async refreshLocation(id: number) {
+      const location = await $fetch<Location>(`/api/locations/${id}`)
+      const index = this.locations.findIndex((l) => l.id === id)
+      if (index !== -1) {
+        // Preserve _counts from the old entity (not returned by API)
+        this.locations[index] = { ...this.locations[index], ...location }
+      }
+      return location
+    },
+
     // ==================== Items ====================
 
     async fetchItems(campaignId: string | number, force = false) {
@@ -301,6 +337,16 @@ export const useEntitiesStore = defineStore('entities', {
         method: 'DELETE',
       })
       this.items = this.items.filter((i) => i.id !== id)
+    },
+
+    async refreshItem(id: number) {
+      const item = await $fetch<Item>(`/api/items/${id}`)
+      const index = this.items.findIndex((i) => i.id === id)
+      if (index !== -1) {
+        // Preserve _counts from the old entity (not returned by API)
+        this.items[index] = { ...this.items[index], ...item }
+      }
+      return item
     },
 
     // ==================== Lore ====================
@@ -354,6 +400,16 @@ export const useEntitiesStore = defineStore('entities', {
       this.lore = this.lore.filter((l) => l.id !== id)
     },
 
+    async refreshLore(id: number) {
+      const lore = await $fetch<Lore>(`/api/lore/${id}`)
+      const index = this.lore.findIndex((l) => l.id === id)
+      if (index !== -1) {
+        // Preserve _counts from the old entity (not returned by API)
+        this.lore[index] = { ...this.lore[index], ...lore }
+      }
+      return lore
+    },
+
     // ==================== Players ====================
 
     async fetchPlayers(campaignId: string | number, force = false) {
@@ -403,6 +459,16 @@ export const useEntitiesStore = defineStore('entities', {
         method: 'DELETE',
       })
       this.players = this.players.filter((p) => p.id !== id)
+    },
+
+    async refreshPlayer(id: number) {
+      const player = await $fetch<Player>(`/api/players/${id}`)
+      const index = this.players.findIndex((p) => p.id === id)
+      if (index !== -1) {
+        // Preserve _counts from the old entity (not returned by API)
+        this.players[index] = { ...this.players[index], ...player }
+      }
+      return player
     },
 
     // ==================== Utility ====================


### PR DESCRIPTION
- Add refresh functions to entities store (refreshNPC, refreshItem, etc.)
- Call store refresh after image upload/generation in edit dialogs
- Add handleImageChanged handlers to update local editing state
- Preserve _counts when refreshing entities (not returned by API)