### PR TITLE
fix: add @changed event to EntityLocationsTab for live badge updates

### DIFF
--- a/packages/app/app/components/npcs/NpcEditDialog.vue
+++ b/packages/app/app/components/npcs/NpcEditDialog.vue
@@ -242,7 +242,11 @@
 
             <!-- Locations Tab -->
             <v-tabs-window-item value="locations">
-              <EntityLocationsTab v-if="npc" :entity-id="npc.id" />
+              <EntityLocationsTab
+                v-if="npc"
+                :entity-id="npc.id"
+                @changed="refreshNpc"
+              />
             </v-tabs-window-item>
 
             <!-- Memberships Tab -->

--- a/packages/app/app/components/players/PlayerEditDialog.vue
+++ b/packages/app/app/components/players/PlayerEditDialog.vue
@@ -210,7 +210,11 @@
 
           <!-- Locations Tab -->
           <v-tabs-window-item value="locations">
-            <EntityLocationsTab v-if="player" :entity-id="player.id" />
+            <EntityLocationsTab
+              v-if="player"
+              :entity-id="player.id"
+              @changed="loadCounts(player!.id)"
+            />
           </v-tabs-window-item>
 
           <!-- Factions Tab -->

--- a/packages/app/app/components/shared/EntityLocationsTab.vue
+++ b/packages/app/app/components/shared/EntityLocationsTab.vue
@@ -166,6 +166,10 @@ interface Props {
 
 const props = defineProps<Props>()
 
+const emit = defineEmits<{
+  changed: []
+}>()
+
 // State
 const locationRelations = ref<LocationRelation[]>([])
 const availableLocations = ref<{ id: number; name: string }[]>([])
@@ -279,6 +283,8 @@ async function handleAdd() {
     localLocationId.value = null
     localRelationType.value = ''
     localNotes.value = ''
+
+    emit('changed')
   } catch (error) {
     console.error('Failed to add location relation:', error)
   } finally {
@@ -317,6 +323,7 @@ async function saveRelation() {
     }
 
     closeEditDialog()
+    emit('changed')
   } catch (error) {
     console.error('Failed to update relation:', error)
   } finally {
@@ -332,6 +339,8 @@ async function removeRelation(relationId: number) {
 
     // Remove from local array
     locationRelations.value = locationRelations.value.filter((r) => r.id !== relationId)
+
+    emit('changed')
   } catch (error) {
     console.error('Failed to remove relation:', error)
   }


### PR DESCRIPTION
## Summary

- Add `emit('changed')` to EntityLocationsTab after add/update/remove operations
- Add `@changed` handler in NpcEditDialog for EntityLocationsTab
- Add `@changed` handler in PlayerEditDialog for EntityLocationsTab

The location tab badges now update in real-time when adding or removing location relations, matching the behavior of other entity tabs.

Closes #64

## Test plan

- [ ] Open NPC edit dialog, go to Locations tab
- [ ] Add a location relation → badge count should increase immediately
- [ ] Remove a location relation → badge count should decrease immediately
- [ ] Same test for Player edit dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)