### PR TITLE
feat: improve keyboard shortcut display with v-hotkey component

### DIFF
--- a/packages/app/app/components/shared/EntityMarkdownEditor.vue
+++ b/packages/app/app/components/shared/EntityMarkdownEditor.vue
@@ -114,9 +114,9 @@
           </NormalToolbar>
         </template>
       </MdEditor>
-      <div class="editor-hint text-caption text-medium-emphasis mt-1">
-        <v-icon size="x-small" class="mr-1">mdi-keyboard</v-icon>
-        {{ $t('editor.quickSearchHint', { modifier: modifierKey }) }}
+      <div class="editor-hint text-caption text-medium-emphasis mt-1 d-flex align-center">
+        <v-hotkey keys="ctrl+space" :platform="platform" class="mr-2" />
+        <span>{{ $t('editor.quickSearchHintText') }}</span>
       </div>
     </ClientOnly>
 
@@ -322,12 +322,18 @@ const editorTheme = computed<'light' | 'dark'>(() =>
   theme.global.current.value.dark ? 'dark' : 'light',
 )
 
-// Platform detection for hotkey hint (Mac uses Cmd, others use Ctrl)
-const isMac = computed(() => {
-  if (import.meta.server) return false
-  return navigator.platform.toUpperCase().indexOf('MAC') >= 0
+// Platform detection for hotkey display (Mac uses Cmd, others use Ctrl)
+// Works in browser and Electron - v-hotkey uses 'mac' | 'pc'
+const platform = computed<'mac' | 'pc'>(() => {
+  if (import.meta.server) return 'pc'
+  // Check userAgentData first (modern API)
+  const uaData = (navigator as Navigator & { userAgentData?: { platform?: string } }).userAgentData
+  if (uaData?.platform) {
+    return uaData.platform.toLowerCase().includes('mac') ? 'mac' : 'pc'
+  }
+  // Fallback to userAgent (works in Electron too)
+  return navigator.userAgent.toLowerCase().includes('mac') ? 'mac' : 'pc'
 })
-const modifierKey = computed(() => (isMac.value ? '⌘' : 'Ctrl'))
 
 // Toolbar config
 type ToolbarOrSlot = ToolbarNames | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7

--- a/packages/app/app/pages/sessions/index.vue
+++ b/packages/app/app/pages/sessions/index.vue
@@ -114,18 +114,21 @@
       </v-timeline-item>
     </v-timeline>
 
-    <v-empty-state
-      v-else
-      icon="mdi-book-open-page-variant"
-      :title="$t('sessions.empty')"
-      :text="$t('sessions.emptyText')"
-    >
-      <template #actions>
-        <v-btn color="primary" prepend-icon="mdi-plus" @click="showCreateDialog = true">
-          {{ $t('sessions.create') }}
-        </v-btn>
-      </template>
-    </v-empty-state>
+    <template v-else>
+      <ClientOnly>
+        <v-empty-state
+          icon="mdi-book-open-page-variant"
+          :title="$t('sessions.empty')"
+          :text="$t('sessions.emptyText')"
+        >
+          <template #actions>
+            <v-btn color="primary" prepend-icon="mdi-plus" @click="showCreateDialog = true">
+              {{ $t('sessions.create') }}
+            </v-btn>
+          </template>
+        </v-empty-state>
+      </ClientOnly>
+    </template>
 
     <!-- Create/Edit Session Dialog -->
     <v-dialog v-model="showCreateDialog" max-width="1000" scrollable :persistent="saving || uploadingAudio">
@@ -1174,6 +1177,7 @@ function closeDialog() {
 
 .session-card {
   width: 100%;
+  min-width: 350px;
 }
 
 .markdown-content {

--- a/packages/app/i18n/locales/de.json
+++ b/packages/app/i18n/locales/de.json
@@ -29,7 +29,7 @@
   "editor": {
     "quickInsert": "Schnell einfügen",
     "quickSearchPlaceholder": "Tippe z.B. 'npc gandalf' oder 'loc taverne'...",
-    "quickSearchHint": "{modifier}+Leertaste für Schnellsuche"
+    "quickSearchHintText": "für Schnellsuche"
   },
   "categories": {
     "npcs": {

--- a/packages/app/i18n/locales/en.json
+++ b/packages/app/i18n/locales/en.json
@@ -29,7 +29,7 @@
   "editor": {
     "quickInsert": "Quick Insert",
     "quickSearchPlaceholder": "Type e.g. 'npc gandalf' or 'loc tavern'...",
-    "quickSearchHint": "{modifier}+Space for quick search"
+    "quickSearchHintText": "for quick search"
   },
   "categories": {
     "npcs": {


### PR DESCRIPTION
## Summary
- Replace text-based keyboard hint with Vuetify v-hotkey component for better visual display
- Add platform detection (Mac/PC) including Electron support for correct modifier key icons
- Fix session cards minimum width (350px)
- Fix v-empty-state hydration mismatch on sessions page

## Test plan
- [ ] Open any entity edit dialog with markdown editor (NPC, Session, etc.)
- [ ] Verify keyboard shortcut shows with proper icons (Ctrl on PC, Cmd on Mac)
- [ ] Test Ctrl+Space opens quick search
- [ ] Verify sessions page has no hydration warnings
- [ ] Check session cards have proper minimum width

🤖 Generated with [Claude Code](https://claude.com/claude-code)