### PR TITLE
feat: add entity type filter for chaos graph

### DIFF
--- a/packages/app/app/pages/maps/index.vue
+++ b/packages/app/app/pages/maps/index.vue
@@ -1100,6 +1100,7 @@ watch(activeCampaignId, () => {
 .map-card-description {
   flex: 1;
   display: -webkit-box;
+  line-clamp: 2;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
   overflow: hidden;

--- a/packages/app/i18n/locales/de.json
+++ b/packages/app/i18n/locales/de.json
@@ -1421,6 +1421,7 @@
     "title": "Chaos-Graph",
     "subtitle": "Alle Verbindungen auf einen Blick",
     "connections": "Verbindungen",
+    "total": "gesamt",
     "noConnections": "Keine Verbindungen",
     "noConnectionsText": "Diese Entität hat noch keine Verknüpfungen"
   },

--- a/packages/app/i18n/locales/en.json
+++ b/packages/app/i18n/locales/en.json
@@ -1426,6 +1426,7 @@
     "title": "Chaos Graph",
     "subtitle": "All connections at a glance",
     "connections": "Connections",
+    "total": "total",
     "noConnections": "No connections",
     "noConnectionsText": "This entity has no links yet"
   },


### PR DESCRIPTION
## Fixes
Fixes #76

## Summary
- Add filter chips in header to filter connections by entity type (NPC, Item, Location, Faction, Lore, Player)
- Filter chips show count of connections per type
- Active filters highlighted with entity color
- Shows filtered count with total in parentheses when filters active
- Inter-connection lines only show between visible entities

Closes #73

## Test plan
- [ ] Open chaos graph for an entity with multiple connection types
- [ ] Click filter chips to toggle entity types
- [ ] Verify count updates correctly