### PR TITLE
fix: update NPC relation counts on delete

### DIFF
--- a/.changeset/npc-relation-counts.md
+++ b/.changeset/npc-relation-counts.md
@@ -1,0 +1,7 @@
+---
+"@dm-hero/app": patch
+---
+
+fix: update NPC relation counts when deleting an NPC
+
+When an NPC is deleted, all other NPCs that had relations to it now have their relation counts decremented automatically. This ensures the relation count badges on NPC cards stay accurate without requiring a page refresh.

--- a/packages/app/server/api/npcs/[id]/index.delete.ts
+++ b/packages/app/server/api/npcs/[id]/index.delete.ts
@@ -11,6 +11,43 @@ export default defineEventHandler((event) => {
     })
   }
 
+  // Get the NPC entity type ID
+  const npcTypeId = db.prepare("SELECT id FROM entity_types WHERE name = 'NPC'").get() as
+    | { id: number }
+    | undefined
+
+  // Find all NPCs that have relations to this NPC (before we delete)
+  // These NPCs will need their relation counts updated in the frontend
+  const affectedNpcIds: number[] = []
+
+  if (npcTypeId) {
+    const affected = db
+      .prepare<unknown[], { npc_id: number }>(
+        `
+        SELECT DISTINCT
+          CASE
+            WHEN er.from_entity_id = ? THEN er.to_entity_id
+            ELSE er.from_entity_id
+          END as npc_id
+        FROM entity_relations er
+        INNER JOIN entities e ON (
+          CASE
+            WHEN er.from_entity_id = ? THEN er.to_entity_id
+            ELSE er.from_entity_id
+          END = e.id
+        )
+        WHERE (er.from_entity_id = ? OR er.to_entity_id = ?)
+          AND e.type_id = ?
+          AND e.deleted_at IS NULL
+      `,
+      )
+      .all(id, id, id, id, npcTypeId.id)
+
+    for (const row of affected) {
+      affectedNpcIds.push(row.npc_id)
+    }
+  }
+
   // Soft-delete: set deleted_at timestamp
   db.prepare(
     `
@@ -20,5 +57,8 @@ export default defineEventHandler((event) => {
   `,
   ).run(id)
 
-  return { success: true }
+  return {
+    success: true,
+    affectedNpcIds,
+  }
 })


### PR DESCRIPTION
## Summary
- DELETE API now returns affected NPC IDs (NPCs that had relations to deleted NPC)
- Store decrements relation counts for affected NPCs
- Relation count badges on NPC cards update immediately without page refresh

## Technical Details
When an NPC is deleted, the API first queries all NPCs that have relations (bidirectional) to the deleted NPC. These IDs are returned in the response. The frontend store then decrements `_counts.relations` for each affected NPC, keeping the UI in sync.

Partial fix for #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)