### PR TITLE
feat(items): add campaign-specific currency system

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ dm-hero/
 
 ## Database
 
-- **SQLite** with 13 migrations (auto-run on startup)
+- **SQLite** with auto-migrations on startup
 - **FTS5** for full-text search with Unicode normalization
 - **Soft-delete** everywhere (deleted_at timestamps)
 - **Auto-backup** before each migration

--- a/packages/app/app/components/campaigns/CurrencyManageDialog.vue
+++ b/packages/app/app/components/campaigns/CurrencyManageDialog.vue
@@ -1,0 +1,338 @@
+<template>
+  <v-dialog v-model="dialogVisible" max-width="700" scrollable>
+    <v-card>
+      <v-card-title class="d-flex align-center">
+        <v-icon icon="mdi-cash-multiple" class="mr-2" color="primary" />
+        {{ $t('campaigns.currencies.title') }}
+      </v-card-title>
+      <v-card-subtitle>{{ $t('campaigns.currencies.subtitle') }}</v-card-subtitle>
+
+      <v-card-text class="pt-4">
+        <!-- Currency List -->
+        <v-list v-if="currencies.length > 0" lines="two">
+          <v-list-item
+            v-for="currency in currencies"
+            :key="currency.id"
+            class="mb-2 rounded border"
+          >
+            <template #prepend>
+              <v-avatar color="primary" size="40">
+                <span class="text-body-1 font-weight-bold">{{ currency.symbol }}</span>
+              </v-avatar>
+            </template>
+
+            <v-list-item-title class="font-weight-medium">
+              {{ getCurrencyDisplayName(currency.name) }}
+              <v-chip v-if="currency.is_default" size="x-small" color="primary" class="ml-2">
+                {{ $t('campaigns.currencies.isDefault') }}
+              </v-chip>
+            </v-list-item-title>
+            <v-list-item-subtitle>
+              {{ currency.code }} &bull; {{ $t('campaigns.currencies.exchangeRate') }}: {{ currency.exchange_rate }}
+            </v-list-item-subtitle>
+
+            <template #append>
+              <v-btn icon="mdi-pencil" variant="text" size="small" @click="editCurrency(currency)" />
+              <v-btn
+                icon="mdi-delete"
+                variant="text"
+                size="small"
+                color="error"
+                @click="confirmDeleteCurrency(currency)"
+              />
+            </template>
+          </v-list-item>
+        </v-list>
+
+        <!-- Empty State -->
+        <div v-else class="text-center py-8 text-medium-emphasis">
+          <v-icon icon="mdi-cash-remove" size="48" class="mb-2" />
+          <p>{{ $t('campaigns.currencies.empty') }}</p>
+          <p class="text-body-2">{{ $t('campaigns.currencies.emptyText') }}</p>
+        </div>
+      </v-card-text>
+
+      <v-card-actions>
+        <v-btn prepend-icon="mdi-plus" color="primary" @click="addCurrency">
+          {{ $t('campaigns.currencies.add') }}
+        </v-btn>
+        <v-spacer />
+        <v-btn variant="text" @click="dialogVisible = false">
+          {{ $t('common.close') }}
+        </v-btn>
+      </v-card-actions>
+    </v-card>
+
+    <!-- Add/Edit Currency Dialog -->
+    <v-dialog v-model="showEditDialog" max-width="500" persistent>
+      <v-card>
+        <v-card-title>
+          {{ editingCurrency ? $t('campaigns.currencies.edit') : $t('campaigns.currencies.add') }}
+        </v-card-title>
+        <v-card-text>
+          <v-text-field
+            v-model="currencyForm.code"
+            :label="$t('campaigns.currencies.code')"
+            :placeholder="$t('campaigns.currencies.codePlaceholder')"
+            variant="outlined"
+            class="mb-3"
+            :rules="[(v) => !!v || $t('campaigns.nameRequired')]"
+            maxlength="10"
+          />
+          <v-text-field
+            v-model="currencyForm.name"
+            :label="$t('campaigns.currencies.name')"
+            :placeholder="$t('campaigns.currencies.namePlaceholder')"
+            variant="outlined"
+            class="mb-3"
+            :rules="[(v) => !!v || $t('campaigns.nameRequired')]"
+          />
+          <v-text-field
+            v-model="currencyForm.symbol"
+            :label="$t('campaigns.currencies.symbol')"
+            :placeholder="$t('campaigns.currencies.symbolPlaceholder')"
+            variant="outlined"
+            class="mb-3"
+            maxlength="10"
+          />
+          <v-text-field
+            v-model.number="currencyForm.exchange_rate"
+            :label="$t('campaigns.currencies.exchangeRate')"
+            :hint="$t('campaigns.currencies.exchangeRateHint')"
+            persistent-hint
+            variant="outlined"
+            type="number"
+            min="1"
+            class="mb-3"
+          />
+          <v-switch
+            v-model="currencyForm.is_default"
+            :label="$t('campaigns.currencies.isDefault')"
+            color="primary"
+            hide-details
+          />
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn variant="text" @click="closeEditDialog">
+            {{ $t('common.cancel') }}
+          </v-btn>
+          <v-btn
+            color="primary"
+            :disabled="!currencyForm.code || !currencyForm.name"
+            :loading="saving"
+            @click="saveCurrency"
+          >
+            {{ $t('common.save') }}
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+
+    <!-- Delete Confirmation Dialog -->
+    <v-dialog v-model="showDeleteDialog" max-width="400">
+      <v-card>
+        <v-card-title>{{ $t('campaigns.currencies.deleteTitle') }}</v-card-title>
+        <v-card-text>
+          <p>{{ $t('campaigns.currencies.deleteConfirm', { name: deletingCurrency ? getCurrencyDisplayName(deletingCurrency.name) : '' }) }}</p>
+          <v-alert
+            v-if="deleteItemsAffected > 0"
+            type="warning"
+            variant="tonal"
+            class="mt-3"
+          >
+            {{ $t('campaigns.currencies.deleteWarning', { count: deleteItemsAffected }) }}
+          </v-alert>
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn variant="text" @click="showDeleteDialog = false">
+            {{ $t('common.cancel') }}
+          </v-btn>
+          <v-btn color="error" :loading="deleting" @click="deleteCurrency">
+            {{ $t('common.delete') }}
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+  </v-dialog>
+</template>
+
+<script setup lang="ts">
+interface Currency {
+  id: number
+  campaign_id: number
+  code: string
+  name: string
+  symbol: string | null
+  exchange_rate: number
+  sort_order: number
+  is_default: number
+  created_at: string
+}
+
+const { t, te } = useI18n()
+
+// Default currency keys that have translations
+const DEFAULT_CURRENCY_KEYS = ['copper', 'silver', 'gold', 'platinum']
+
+// Translate currency name if it's a known key, otherwise return as-is
+function getCurrencyDisplayName(name: string): string {
+  if (DEFAULT_CURRENCY_KEYS.includes(name)) {
+    const key = `campaigns.currencies.defaults.${name}`
+    return te(key) ? t(key) : name
+  }
+  return name
+}
+
+const props = defineProps<{
+  show: boolean
+  campaignId: number
+}>()
+
+const emit = defineEmits<{
+  'update:show': [boolean]
+}>()
+
+const dialogVisible = computed({
+  get: () => props.show,
+  set: (val) => emit('update:show', val),
+})
+
+// State
+const currencies = ref<Currency[]>([])
+const loading = ref(false)
+const showEditDialog = ref(false)
+const showDeleteDialog = ref(false)
+const editingCurrency = ref<Currency | null>(null)
+const deletingCurrency = ref<Currency | null>(null)
+const deleteItemsAffected = ref(0)
+const saving = ref(false)
+const deleting = ref(false)
+
+const currencyForm = ref({
+  code: '',
+  name: '',
+  symbol: '',
+  exchange_rate: 1,
+  is_default: false,
+})
+
+// Load currencies when dialog opens
+watch(
+  () => props.show,
+  async (show) => {
+    if (show && props.campaignId) {
+      await loadCurrencies()
+    }
+  },
+  { immediate: true },
+)
+
+async function loadCurrencies() {
+  loading.value = true
+  try {
+    currencies.value = await $fetch<Currency[]>('/api/currencies', {
+      query: { campaignId: props.campaignId },
+    })
+  } catch (error) {
+    console.error('Failed to load currencies:', error)
+  } finally {
+    loading.value = false
+  }
+}
+
+function addCurrency() {
+  editingCurrency.value = null
+  currencyForm.value = {
+    code: '',
+    name: '',
+    symbol: '',
+    exchange_rate: 1,
+    is_default: false,
+  }
+  showEditDialog.value = true
+}
+
+function editCurrency(currency: Currency) {
+  editingCurrency.value = currency
+  currencyForm.value = {
+    code: currency.code,
+    // Show translated name in edit form for default currencies
+    name: getCurrencyDisplayName(currency.name),
+    symbol: currency.symbol || '',
+    exchange_rate: currency.exchange_rate,
+    is_default: Boolean(currency.is_default),
+  }
+  showEditDialog.value = true
+}
+
+function closeEditDialog() {
+  showEditDialog.value = false
+  editingCurrency.value = null
+}
+
+async function saveCurrency() {
+  saving.value = true
+  try {
+    if (editingCurrency.value) {
+      // Update existing
+      await $fetch(`/api/currencies/${editingCurrency.value.id}`, {
+        method: 'PATCH',
+        body: currencyForm.value,
+      })
+    } else {
+      // Create new
+      await $fetch('/api/currencies', {
+        method: 'POST',
+        body: {
+          campaignId: props.campaignId,
+          ...currencyForm.value,
+        },
+      })
+    }
+    await loadCurrencies()
+    closeEditDialog()
+  } catch (error) {
+    console.error('Failed to save currency:', error)
+  } finally {
+    saving.value = false
+  }
+}
+
+async function confirmDeleteCurrency(currency: Currency) {
+  deletingCurrency.value = currency
+  deleteItemsAffected.value = 0
+
+  // Check how many items would be affected
+  try {
+    const result = await $fetch<{ itemsAffected: number }>(`/api/currencies/${currency.id}`, {
+      method: 'DELETE',
+      query: { dryRun: true },
+    }).catch(() => ({ itemsAffected: 0 }))
+    deleteItemsAffected.value = result.itemsAffected || 0
+  } catch {
+    // Ignore error, just show dialog
+  }
+
+  showDeleteDialog.value = true
+}
+
+async function deleteCurrency() {
+  if (!deletingCurrency.value) return
+
+  deleting.value = true
+  try {
+    await $fetch(`/api/currencies/${deletingCurrency.value.id}`, {
+      method: 'DELETE',
+    })
+    await loadCurrencies()
+    showDeleteDialog.value = false
+    deletingCurrency.value = null
+  } catch (error) {
+    console.error('Failed to delete currency:', error)
+  } finally {
+    deleting.value = false
+  }
+}
+</script>

--- a/packages/app/app/pages/campaigns.vue
+++ b/packages/app/app/pages/campaigns.vue
@@ -126,6 +126,7 @@
       @confirm="confirmDelete"
       @cancel="showDeleteDialog = false"
     />
+
   </v-container>
 </template>
 

--- a/packages/app/i18n/locales/de.json
+++ b/packages/app/i18n/locales/de.json
@@ -84,7 +84,34 @@
     "empty": "Keine Kampagnen vorhanden",
     "emptyText": "Erstelle deine erste Kampagne um loszulegen",
     "deleteTitle": "Kampagne löschen",
-    "deleteConfirm": "Möchtest du die Kampagne '{name}' wirklich löschen? Alle zugehörigen Daten werden archiviert."
+    "deleteConfirm": "Möchtest du die Kampagne '{name}' wirklich löschen? Alle zugehörigen Daten werden archiviert.",
+    "settings": "Einstellungen",
+    "currencies": {
+      "title": "Währungen",
+      "subtitle": "Verwalte Währungen für diese Kampagne",
+      "add": "Währung hinzufügen",
+      "edit": "Währung bearbeiten",
+      "code": "Code",
+      "codePlaceholder": "z.B. GP, SP",
+      "name": "Name",
+      "namePlaceholder": "z.B. Gold, Silber",
+      "symbol": "Symbol",
+      "symbolPlaceholder": "z.B. GP, G",
+      "exchangeRate": "Wechselkurs",
+      "exchangeRateHint": "Wert in Kupfer (kleinste Einheit)",
+      "isDefault": "Standard-Währung",
+      "deleteTitle": "Währung löschen",
+      "deleteConfirm": "Möchtest du '{name}' wirklich löschen?",
+      "deleteWarning": "{count} Item(s) verwenden diese Währung. Diese Items behalten ihren Wert, aber die Währung wird entfernt.",
+      "empty": "Keine Währungen vorhanden",
+      "emptyText": "Erstelle deine erste Währung",
+      "defaults": {
+        "copper": "Kupfer",
+        "silver": "Silber",
+        "gold": "Gold",
+        "platinum": "Platin"
+      }
+    }
   },
   "npcs": {
     "title": "NPCs",
@@ -786,6 +813,7 @@
     "type": "Typ",
     "rarity": "Seltenheit",
     "value": "Wert",
+    "currency": "Währung",
     "valuePlaceholder": "z.B. 50 GM",
     "weight": "Gewicht",
     "weightPlaceholder": "z.B. 2 kg",
@@ -942,6 +970,7 @@
     "notes": "Notizen",
     "weightUnit": "kg",
     "valueUnit": "GM",
+    "valueHint": "Dezimalwerte erlaubt (z.B. 10.5 oder 10,5)",
     "badgeTooltips": {
       "owners": "Besitzer (NPCs)",
       "locations": "Orte",
@@ -978,6 +1007,7 @@
     "deleteClassConfirm": "Möchtest du die Klasse '{name}' wirklich löschen?",
     "saveError": "Fehler beim Speichern",
     "deleteError": "Fehler beim Löschen",
+    "noCampaignSelected": "Bitte wähle zuerst eine Kampagne aus, um Währungen zu verwalten.",
     "raceNames": {
       "human": "Mensch",
       "elf": "Elf",
@@ -1190,7 +1220,12 @@
     "subtitle": "Konfiguriere API-Keys und Präferenzen",
     "sections": {
       "openai": "OpenAI Integration",
-      "preferences": "Präferenzen"
+      "preferences": "Präferenzen",
+      "campaign": "Kampagne"
+    },
+    "campaign": {
+      "title": "Kampagnen-Einstellungen",
+      "subtitle": "Einstellungen für die aktive Kampagne"
     },
     "openai": {
       "apiKey": "OpenAI API-Key",

--- a/packages/app/i18n/locales/en.json
+++ b/packages/app/i18n/locales/en.json
@@ -84,7 +84,34 @@
     "empty": "No campaigns available",
     "emptyText": "Create your first campaign to get started",
     "deleteTitle": "Delete Campaign",
-    "deleteConfirm": "Do you really want to delete the campaign '{name}'? All associated data will be archived."
+    "deleteConfirm": "Do you really want to delete the campaign '{name}'? All associated data will be archived.",
+    "settings": "Settings",
+    "currencies": {
+      "title": "Currencies",
+      "subtitle": "Manage currencies for this campaign",
+      "add": "Add Currency",
+      "edit": "Edit Currency",
+      "code": "Code",
+      "codePlaceholder": "e.g. GP, SP",
+      "name": "Name",
+      "namePlaceholder": "e.g. Gold, Silver",
+      "symbol": "Symbol",
+      "symbolPlaceholder": "e.g. GP, G",
+      "exchangeRate": "Exchange Rate",
+      "exchangeRateHint": "Value in copper (smallest unit)",
+      "isDefault": "Default Currency",
+      "deleteTitle": "Delete Currency",
+      "deleteConfirm": "Do you really want to delete '{name}'?",
+      "deleteWarning": "{count} item(s) use this currency. These items will keep their value, but the currency will be removed.",
+      "empty": "No currencies available",
+      "emptyText": "Create your first currency",
+      "defaults": {
+        "copper": "Copper",
+        "silver": "Silver",
+        "gold": "Gold",
+        "platinum": "Platinum"
+      }
+    }
   },
   "npcs": {
     "title": "NPCs",
@@ -791,6 +818,7 @@
     "type": "Type",
     "rarity": "Rarity",
     "value": "Value",
+    "currency": "Currency",
     "valuePlaceholder": "e.g. 50 gp",
     "weight": "Weight",
     "weightPlaceholder": "e.g. 2 lbs",
@@ -947,6 +975,7 @@
     "notes": "Notes",
     "weightUnit": "kg",
     "valueUnit": "GP",
+    "valueHint": "Decimal values allowed (e.g. 10.5)",
     "badgeTooltips": {
       "owners": "Owners (NPCs)",
       "locations": "Locations",
@@ -983,6 +1012,7 @@
     "deleteClassConfirm": "Do you really want to delete the class '{name}'?",
     "saveError": "Error saving",
     "deleteError": "Error deleting",
+    "noCampaignSelected": "Please select a campaign first to manage currencies.",
     "raceNames": {
       "human": "Human",
       "elf": "Elf",
@@ -1195,7 +1225,12 @@
     "subtitle": "Configure API keys and preferences",
     "sections": {
       "openai": "OpenAI Integration",
-      "preferences": "Preferences"
+      "preferences": "Preferences",
+      "campaign": "Campaign"
+    },
+    "campaign": {
+      "title": "Campaign Settings",
+      "subtitle": "Settings for the active campaign"
     },
     "openai": {
       "apiKey": "OpenAI API Key",

--- a/packages/app/server/api/campaigns/index.post.ts
+++ b/packages/app/server/api/campaigns/index.post.ts
@@ -1,5 +1,14 @@
 import { getDb } from '../../utils/db'
 
+// Default currencies for new campaigns (D&D standard)
+// Names are i18n keys (copper, silver, gold, platinum) for frontend translation
+const DEFAULT_CURRENCIES = [
+  { code: 'CP', name: 'copper', symbol: 'CP', exchange_rate: 1, sort_order: 0, is_default: 0 },
+  { code: 'SP', name: 'silver', symbol: 'SP', exchange_rate: 10, sort_order: 1, is_default: 0 },
+  { code: 'GP', name: 'gold', symbol: 'GP', exchange_rate: 100, sort_order: 2, is_default: 1 },
+  { code: 'PP', name: 'platinum', symbol: 'PP', exchange_rate: 1000, sort_order: 3, is_default: 0 },
+]
+
 export default defineEventHandler(async (event) => {
   const db = getDb()
   const body = await readBody(event)
@@ -22,13 +31,33 @@ export default defineEventHandler(async (event) => {
     )
     .run(name, description || null)
 
+  const campaignId = result.lastInsertRowid
+
+  // Insert default currencies for the new campaign
+  const insertCurrency = db.prepare(`
+    INSERT INTO currencies (campaign_id, code, name, symbol, exchange_rate, sort_order, is_default)
+    VALUES (?, ?, ?, ?, ?, ?, ?)
+  `)
+
+  for (const currency of DEFAULT_CURRENCIES) {
+    insertCurrency.run(
+      campaignId,
+      currency.code,
+      currency.name,
+      currency.symbol,
+      currency.exchange_rate,
+      currency.sort_order,
+      currency.is_default,
+    )
+  }
+
   const campaign = db
     .prepare(
       `
     SELECT * FROM campaigns WHERE id = ?
   `,
     )
-    .get(result.lastInsertRowid)
+    .get(campaignId)
 
   return campaign
 })

--- a/packages/app/server/api/currencies/[id]/index.delete.ts
+++ b/packages/app/server/api/currencies/[id]/index.delete.ts
@@ -1,0 +1,62 @@
+import { getDb } from '../../../utils/db'
+
+export default defineEventHandler((event) => {
+  const db = getDb()
+  const id = getRouterParam(event, 'id')
+
+  if (!id) {
+    throw createError({
+      statusCode: 400,
+      message: 'Currency ID is required',
+    })
+  }
+
+  // Check if currency exists and get info
+  const currency = db
+    .prepare('SELECT id, campaign_id, is_default, code FROM currencies WHERE id = ?')
+    .get(id) as { id: number; campaign_id: number; is_default: number; code: string } | undefined
+
+  if (!currency) {
+    throw createError({
+      statusCode: 404,
+      message: 'Currency not found',
+    })
+  }
+
+  // Count items using this currency (stored in metadata as currency_id)
+  // Items store value in metadata JSON, we need to check for currency_id
+  const itemTypeId = db.prepare("SELECT id FROM entity_types WHERE name = 'Item'").get() as { id: number } | undefined
+
+  let itemsUsingCurrency = 0
+  if (itemTypeId) {
+    const items = db
+      .prepare(
+        `
+        SELECT COUNT(*) as count FROM entities
+        WHERE type_id = ? AND deleted_at IS NULL
+        AND json_extract(metadata, '$.currency_id') = ?
+      `,
+      )
+      .get(itemTypeId.id, Number(id)) as { count: number }
+    itemsUsingCurrency = items.count
+  }
+
+  // Delete the currency
+  db.prepare('DELETE FROM currencies WHERE id = ?').run(id)
+
+  // If this was the default, set another one as default
+  if (currency.is_default) {
+    const firstOther = db
+      .prepare('SELECT id FROM currencies WHERE campaign_id = ? ORDER BY sort_order LIMIT 1')
+      .get(currency.campaign_id) as { id: number } | undefined
+
+    if (firstOther) {
+      db.prepare('UPDATE currencies SET is_default = 1 WHERE id = ?').run(firstOther.id)
+    }
+  }
+
+  return {
+    success: true,
+    itemsAffected: itemsUsingCurrency,
+  }
+})

--- a/packages/app/server/api/currencies/[id]/index.patch.ts
+++ b/packages/app/server/api/currencies/[id]/index.patch.ts
@@ -1,0 +1,83 @@
+import { getDb } from '../../../utils/db'
+
+interface UpdateCurrencyBody {
+  code?: string
+  name?: string
+  symbol?: string
+  exchange_rate?: number
+  sort_order?: number
+  is_default?: boolean
+}
+
+export default defineEventHandler(async (event) => {
+  const db = getDb()
+  const id = getRouterParam(event, 'id')
+  const body = await readBody<UpdateCurrencyBody>(event)
+
+  if (!id) {
+    throw createError({
+      statusCode: 400,
+      message: 'Currency ID is required',
+    })
+  }
+
+  // Get current currency to find campaign_id
+  const current = db
+    .prepare('SELECT campaign_id FROM currencies WHERE id = ?')
+    .get(id) as { campaign_id: number } | undefined
+
+  if (!current) {
+    throw createError({
+      statusCode: 404,
+      message: 'Currency not found',
+    })
+  }
+
+  // If setting as default, unset other defaults in same campaign
+  if (body.is_default) {
+    db.prepare('UPDATE currencies SET is_default = 0 WHERE campaign_id = ?').run(current.campaign_id)
+  }
+
+  // Build update query dynamically
+  const updates: string[] = []
+  const values: unknown[] = []
+
+  if (body.code !== undefined) {
+    updates.push('code = ?')
+    values.push(body.code.toUpperCase())
+  }
+  if (body.name !== undefined) {
+    updates.push('name = ?')
+    values.push(body.name)
+  }
+  if (body.symbol !== undefined) {
+    updates.push('symbol = ?')
+    values.push(body.symbol)
+  }
+  if (body.exchange_rate !== undefined) {
+    updates.push('exchange_rate = ?')
+    values.push(body.exchange_rate)
+  }
+  if (body.sort_order !== undefined) {
+    updates.push('sort_order = ?')
+    values.push(body.sort_order)
+  }
+  if (body.is_default !== undefined) {
+    updates.push('is_default = ?')
+    values.push(body.is_default ? 1 : 0)
+  }
+
+  if (updates.length === 0) {
+    throw createError({
+      statusCode: 400,
+      message: 'No fields to update',
+    })
+  }
+
+  values.push(id)
+  db.prepare(`UPDATE currencies SET ${updates.join(', ')} WHERE id = ?`).run(...values)
+
+  // Return updated currency
+  const updated = db.prepare('SELECT * FROM currencies WHERE id = ?').get(id)
+  return updated
+})

--- a/packages/app/server/api/currencies/[id]/usage.get.ts
+++ b/packages/app/server/api/currencies/[id]/usage.get.ts
@@ -1,0 +1,45 @@
+import { getDb } from '../../../utils/db'
+
+export default defineEventHandler((event) => {
+  const db = getDb()
+  const id = getRouterParam(event, 'id')
+
+  if (!id) {
+    throw createError({
+      statusCode: 400,
+      message: 'Currency ID is required',
+    })
+  }
+
+  // Check if currency exists
+  const currency = db.prepare('SELECT id FROM currencies WHERE id = ?').get(id) as { id: number } | undefined
+
+  if (!currency) {
+    throw createError({
+      statusCode: 404,
+      message: 'Currency not found',
+    })
+  }
+
+  // Count items using this currency
+  const itemTypeId = db.prepare("SELECT id FROM entity_types WHERE name = 'Item'").get() as { id: number } | undefined
+
+  let itemCount = 0
+  if (itemTypeId) {
+    const result = db
+      .prepare(
+        `
+        SELECT COUNT(*) as count FROM entities
+        WHERE type_id = ? AND deleted_at IS NULL
+        AND json_extract(metadata, '$.currency_id') = ?
+      `,
+      )
+      .get(itemTypeId.id, Number(id)) as { count: number }
+    itemCount = result.count
+  }
+
+  return {
+    currencyId: Number(id),
+    itemCount,
+  }
+})

--- a/packages/app/server/api/currencies/index.get.ts
+++ b/packages/app/server/api/currencies/index.get.ts
@@ -1,0 +1,39 @@
+import { getDb } from '../../utils/db'
+
+interface Currency {
+  id: number
+  campaign_id: number
+  code: string
+  name: string
+  symbol: string | null
+  exchange_rate: number
+  sort_order: number
+  is_default: number
+  created_at: string
+}
+
+export default defineEventHandler((event) => {
+  const db = getDb()
+  const query = getQuery(event)
+  const campaignId = query.campaignId
+
+  if (!campaignId) {
+    throw createError({
+      statusCode: 400,
+      message: 'Campaign ID is required',
+    })
+  }
+
+  const currencies = db
+    .prepare<unknown[], Currency>(
+      `
+      SELECT id, campaign_id, code, name, symbol, exchange_rate, sort_order, is_default, created_at
+      FROM currencies
+      WHERE campaign_id = ?
+      ORDER BY sort_order ASC, name ASC
+    `,
+    )
+    .all(campaignId)
+
+  return currencies
+})

--- a/packages/app/server/api/currencies/index.post.ts
+++ b/packages/app/server/api/currencies/index.post.ts
@@ -1,0 +1,63 @@
+import { getDb } from '../../utils/db'
+
+interface CreateCurrencyBody {
+  campaignId: number
+  code: string
+  name: string
+  symbol?: string
+  exchange_rate: number
+  sort_order?: number
+  is_default?: boolean
+}
+
+export default defineEventHandler(async (event) => {
+  const db = getDb()
+  const body = await readBody<CreateCurrencyBody>(event)
+
+  if (!body.campaignId || !body.code || !body.name || body.exchange_rate === undefined) {
+    throw createError({
+      statusCode: 400,
+      message: 'Campaign ID, code, name, and exchange_rate are required',
+    })
+  }
+
+  // Get max sort_order for this campaign
+  const maxOrder = db
+    .prepare('SELECT MAX(sort_order) as max_order FROM currencies WHERE campaign_id = ?')
+    .get(body.campaignId) as { max_order: number | null }
+
+  const sortOrder = body.sort_order ?? (maxOrder.max_order ?? -1) + 1
+
+  // If this is set as default, unset other defaults
+  if (body.is_default) {
+    db.prepare('UPDATE currencies SET is_default = 0 WHERE campaign_id = ?').run(body.campaignId)
+  }
+
+  const result = db
+    .prepare(
+      `
+      INSERT INTO currencies (campaign_id, code, name, symbol, exchange_rate, sort_order, is_default)
+      VALUES (?, ?, ?, ?, ?, ?, ?)
+    `,
+    )
+    .run(
+      body.campaignId,
+      body.code.toUpperCase(),
+      body.name,
+      body.symbol || body.code.toUpperCase(),
+      body.exchange_rate,
+      sortOrder,
+      body.is_default ? 1 : 0,
+    )
+
+  return {
+    id: result.lastInsertRowid,
+    campaign_id: body.campaignId,
+    code: body.code.toUpperCase(),
+    name: body.name,
+    symbol: body.symbol || body.code.toUpperCase(),
+    exchange_rate: body.exchange_rate,
+    sort_order: sortOrder,
+    is_default: body.is_default ? 1 : 0,
+  }
+})

--- a/packages/app/types/item.ts
+++ b/packages/app/types/item.ts
@@ -89,6 +89,7 @@ export interface ItemMetadata {
   type?: ItemType | null
   rarity?: ItemRarity | null
   value?: number | null
+  currency_id?: number | null
   weight?: number | null
   attunement?: boolean
   damage?: string


### PR DESCRIPTION
- Add currencies table with campaign_id (Migration 28)
- Add default currencies (Copper, Silver, Gold, Platinum) per campaign
- Convert currency names to i18n keys (Migration 29)
- Add currency CRUD API endpoints (/api/currencies)
- Add currency selection dropdown to ItemEditDialog
- Move currency management to Reference Data page (first tab)
- Add sort arrows for manual currency ordering
- Show warning when deleting currency used by items
- Remove unused item-types and item-rarities tabs
- Translate default currency names (DE: Kupfer/Silber/Gold/Platin)