### PR TITLE
feat(items): add NPC relation types to items

### DIFF
--- a/packages/app/app/components/items/ItemViewDialog.vue
+++ b/packages/app/app/components/items/ItemViewDialog.vue
@@ -35,9 +35,9 @@
           <v-icon start>mdi-information</v-icon>
           {{ $t('common.details') }}
         </v-tab>
-        <v-tab value="owners">
+        <v-tab value="npcs">
           <v-icon start>mdi-account-group</v-icon>
-          {{ $t('items.owners') }}
+          {{ $t('npcs.title') }}
           <v-chip size="x-small" class="ml-2">{{ counts?.owners || 0 }}</v-chip>
         </v-tab>
         <v-tab value="locations">
@@ -145,14 +145,15 @@
             </div>
           </v-window-item>
 
-          <!-- Owners Tab -->
-          <v-window-item value="owners">
+          <!-- NPCs Tab -->
+          <v-window-item value="npcs">
             <EntityRelationsList
               :entities="owners || []"
               :loading="loadingOwners"
               entity-type="npc"
               :empty-message="$t('items.noOwners')"
               :show-relation-type="true"
+              relation-type-translation-path="items.ownerRelationTypes"
               :clickable="false"
             />
           </v-window-item>

--- a/packages/app/app/components/shared/EntityRelationsList.vue
+++ b/packages/app/app/components/shared/EntityRelationsList.vue
@@ -94,12 +94,14 @@ interface Props {
   emptyMessage: string
   showRelationType?: boolean
   clickable?: boolean
+  relationTypeTranslationPath?: string
 }
 
 const props = withDefaults(defineProps<Props>(), {
   loading: false,
   showRelationType: true,
   clickable: true,
+  relationTypeTranslationPath: undefined,
 })
 
 defineEmits<{
@@ -144,6 +146,13 @@ function getRarityColor(rarity: string): string {
 }
 
 function getRelationTypeLabel(relationType: string): string {
+  // If custom translation path is provided, try that first
+  if (props.relationTypeTranslationPath) {
+    const customKey = `${props.relationTypeTranslationPath}.${relationType}`
+    const customTranslated = t(customKey)
+    if (customTranslated !== customKey) return customTranslated
+  }
+
   // Try entity-specific translation first
   const entitySpecificKey = `${props.entityType}s.relationTypes.${relationType}`
   const translated = t(entitySpecificKey)

--- a/packages/app/i18n/locales/de.json
+++ b/packages/app/i18n/locales/de.json
@@ -306,7 +306,9 @@
       "contact": "Kontakt",
       "informant": "Informant",
       "debtor": "Schuldner",
-      "creditor": "Gläubiger"
+      "creditor": "Gläubiger",
+      "believesIn": "glaubt an",
+      "worships": "verehrt"
     },
     "incomingRelationTooltip": "Verknüpfung wurde vom anderen NPC erstellt",
     "items": "Items",
@@ -923,17 +925,18 @@
       "guards": "bewacht",
       "stole": "hat gestohlen",
       "lost": "hat verloren",
-      "stored": "lagert",
-      "uses": "benutzt",
-      "sells": "verkauft",
-      "crafted": "hat hergestellt",
+      "created": "hat erschaffen",
+      "destroyed": "hat zerstört",
+      "sold": "hat verkauft",
+      "bought": "hat gekauft",
+      "borrowed": "hat geliehen",
+      "lent": "hat verliehen",
+      "hides": "versteckt",
+      "inherited": "hat geerbt",
+      "gifted": "hat geschenkt",
+      "found": "hat gefunden",
       "enchanted": "hat verzaubert",
-      "inherited": "geerbt",
-      "found": "gefunden",
-      "bought": "gekauft",
-      "gifted": "geschenkt bekommen",
-      "loaned": "geliehen",
-      "hidden": "versteckt"
+      "repaired": "hat repariert"
     },
     "locations": "Orte",
     "locationsList": "Orte & Aufenthaltsorte",
@@ -1348,7 +1351,9 @@
       "met": "Begegnet",
       "heard_of": "Gehört von",
       "researched": "Erforscht",
-      "forgotten": "Vergessen"
+      "forgotten": "Vergessen",
+      "believesIn": "Glaubt an",
+      "worships": "Verehrt"
     },
     "itemRelationTypes": {
       "owns": "Besitzt",
@@ -1384,7 +1389,9 @@
       "met": "Begegnet",
       "heard_of": "Gehört von",
       "researched": "Erforscht",
-      "forgotten": "Vergessen"
+      "forgotten": "Vergessen",
+      "believesIn": "Glaubt an",
+      "worships": "Verehrt"
     }
   },
   "calendar": {

--- a/packages/app/i18n/locales/en.json
+++ b/packages/app/i18n/locales/en.json
@@ -306,7 +306,9 @@
       "contact": "Contact",
       "informant": "Informant",
       "debtor": "Debtor",
-      "creditor": "Creditor"
+      "creditor": "Creditor",
+      "believesIn": "believes in",
+      "worships": "worships"
     },
     "incomingRelationTooltip": "Relation created by the other NPC",
     "items": "Items",
@@ -928,17 +930,18 @@
       "guards": "guards",
       "stole": "stole",
       "lost": "lost",
-      "stored": "stored",
-      "uses": "uses",
-      "sells": "sells",
-      "crafted": "crafted",
-      "enchanted": "enchanted",
-      "inherited": "inherited",
-      "found": "found",
+      "created": "created",
+      "destroyed": "destroyed",
+      "sold": "sold",
       "bought": "bought",
-      "gifted": "received as gift",
-      "loaned": "borrowed",
-      "hidden": "hidden"
+      "borrowed": "borrowed",
+      "lent": "lent",
+      "hides": "hides",
+      "inherited": "inherited",
+      "gifted": "gifted",
+      "found": "found",
+      "enchanted": "enchanted",
+      "repaired": "repaired"
     },
     "locations": "Locations",
     "locationsList": "Locations & Whereabouts",
@@ -1353,7 +1356,9 @@
       "met": "Met",
       "heard_of": "Heard of",
       "researched": "Researched",
-      "forgotten": "Forgotten"
+      "forgotten": "Forgotten",
+      "believesIn": "Believes in",
+      "worships": "Worships"
     },
     "itemRelationTypes": {
       "owns": "Owns",
@@ -1389,7 +1394,9 @@
       "forgot": "Forgot",
       "misunderstands": "Misunderstands",
       "teaches": "Teaches",
-      "studies": "Studies"
+      "studies": "Studies",
+      "believesIn": "Believes in",
+      "worships": "Worships"
     }
   },
   "calendar": {

--- a/packages/app/types/npc.ts
+++ b/packages/app/types/npc.ts
@@ -98,6 +98,8 @@ export const NPC_RELATION_TYPES = [
   'informant',
   'debtor',
   'creditor',
+  'believesIn',
+  'worships',
 ] as const
 
 export type NpcRelationType = (typeof NPC_RELATION_TYPES)[number]

--- a/packages/app/types/player.ts
+++ b/packages/app/types/player.ts
@@ -12,6 +12,8 @@ export const PLAYER_RELATION_TYPES = [
   'heard_of',
   'researched',
   'forgotten',
+  'believesIn',
+  'worships',
 ] as const
 
 export type PlayerRelationType = (typeof PLAYER_RELATION_TYPES)[number]


### PR DESCRIPTION
## Summary
- Renamed "Besitzer" (Owners) tab to "NPCs" in Item dialogs
- Added relation type dropdown (owns, carries, wields, seeks, etc.) when linking NPCs to items
- Relation type is now displayed as a chip in the NPC list
- Also includes `believesIn` and `worships` relation types for NPC-NPC and Player-NPC relations

## Changes
- `ItemEditDialog.vue`: Tab renamed, relation type select added
- `ItemViewDialog.vue`: Tab renamed, uses new translation path
- `EntityRelationsList.vue`: New `relationTypeTranslationPath` prop
- i18n: All 20 `NPC_ITEM_RELATION_TYPES` translated (DE/EN)
- `types/npc.ts` & `types/player.ts`: Added `believesIn` and `worships`

## Test plan
- [ ] Open an Item in edit mode
- [ ] Go to "NPCs" tab (formerly "Besitzer")
- [ ] Add an NPC with a relation type (e.g., "trägt bei sich")
- [ ] Verify relation type chip is shown in the list
- [ ] Open Item view dialog and verify relation types are displayed

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)