### PR TITLE
feat(maps): add drag functionality for location areas (#96)

### DIFF
--- a/packages/app/i18n/locales/de.json
+++ b/packages/app/i18n/locales/de.json
@@ -1166,6 +1166,7 @@
     "details": "Details",
     "yes": "Ja",
     "no": "Nein",
+    "confirm": "Bestätigen",
     "uploading": "Wird hochgeladen...",
     "loading": "Wird geladen...",
     "images": "Bilder",
@@ -1561,7 +1562,9 @@
     "update": "Aktualisieren",
     "helpClick": "Klick = Anzeigen",
     "helpRightClick": "Rechtsklick = Bearbeiten",
-    "helpDrag": "Ziehen = Verschieben",
+    "helpDrag": "Ziehen = Verschieben (Marker)",
+    "helpDragArea": "Gedrückt halten + Bewegen = Verschieben (Bereiche)",
+    "helpResize": "Rand ziehen = Größe ändern",
     "addArea": "Bereich hinzufügen",
     "editArea": "Bereich bearbeiten",
     "selectLocation": "Ort auswählen",
@@ -1589,6 +1592,11 @@
     "measureTotal": "Gesamt: {distance} {unit}",
     "measureClick": "Klicke um Messpunkte zu setzen",
     "measureFinish": "Doppelklick oder ESC zum Beenden",
-    "measureNoScale": "Kein Maßstab definiert - bitte in den Karteneinstellungen setzen"
+    "measureNoScale": "Kein Maßstab definiert - bitte in den Karteneinstellungen setzen",
+    "areaConflict": "Markierungen außerhalb des Bereichs",
+    "areaConflictMessage": "{count} Markierung(en) würden nach dieser Änderung außerhalb von '{location}' liegen:",
+    "areaConflictMove": "Markierungen mit dem Bereich verschieben",
+    "areaConflictKeep": "Markierungen an aktueller Position belassen",
+    "areaConflictRemove": "Standort-Zuweisung der Markierungen entfernen"
   }
 }

--- a/packages/app/i18n/locales/en.json
+++ b/packages/app/i18n/locales/en.json
@@ -1171,6 +1171,7 @@
     "details": "Details",
     "yes": "Yes",
     "no": "No",
+    "confirm": "Confirm",
     "uploading": "Uploading...",
     "loading": "Loading...",
     "images": "Images",
@@ -1566,7 +1567,9 @@
     "update": "Update",
     "helpClick": "Click = View",
     "helpRightClick": "Right-click = Edit",
-    "helpDrag": "Drag = Move",
+    "helpDrag": "Drag = Move (Markers)",
+    "helpDragArea": "Hold + Move = Drag (Areas)",
+    "helpResize": "Drag edge = Resize",
     "addArea": "Add Area",
     "editArea": "Edit Area",
     "selectLocation": "Select Location",
@@ -1594,6 +1597,11 @@
     "measureTotal": "Total: {distance} {unit}",
     "measureClick": "Click to add measurement points",
     "measureFinish": "Double-click or ESC to finish",
-    "measureNoScale": "No scale defined - please set in map settings"
+    "measureNoScale": "No scale defined - please set in map settings",
+    "areaConflict": "Markers Outside Area",
+    "areaConflictMessage": "{count} marker(s) would be outside '{location}' after this change:",
+    "areaConflictMove": "Move markers with the area",
+    "areaConflictKeep": "Keep markers at current position",
+    "areaConflictRemove": "Remove location assignment from markers"
   }
 }


### PR DESCRIPTION
- Add hold-and-drag to move location areas (circles) on map
- Add conflict detection when markers fall outside area after move
- Add conflict resolution dialog with 3 options:
  - Move markers with the area
  - Keep markers in place
  - Remove location assignment from markers
- Add help chip explaining area drag functionality
- Add 6 tests for area drag and conflict resolution
- Add i18n translations for conflict dialog (DE/EN)