### PR TITLE
feat(ai): enhance DALL-E prompts with structured entity data and safety-filter handling

### DIFF
--- a/packages/app/app/components/shared/EntityImageUpload.vue
+++ b/packages/app/app/components/shared/EntityImageUpload.vue
@@ -60,13 +60,23 @@
             color="primary"
             variant="tonal"
             block
-            class="mb-2"
+            class="mb-1"
             :loading="generating"
             :disabled="generateDisabled"
             @click="$emit('generate')"
           >
             {{ $t(generateImageKey) }}
           </v-btn>
+          <!-- Unsaved changes warning -->
+          <v-alert
+            v-if="generateDisabled && generateDisabledReason"
+            type="warning"
+            variant="tonal"
+            density="compact"
+            class="mb-2"
+          >
+            {{ generateDisabledReason }}
+          </v-alert>
 
           <!-- Download Button (only if image exists) -->
           <v-btn
@@ -116,6 +126,7 @@ interface Props {
   deleting?: boolean
   hasApiKey?: boolean
   generateDisabled?: boolean
+  generateDisabledReason?: string
   avatarSize?: number
   defaultIcon?: string
 }
@@ -127,6 +138,7 @@ const props = withDefaults(defineProps<Props>(), {
   deleting: false,
   hasApiKey: false,
   generateDisabled: false,
+  generateDisabledReason: '',
   avatarSize: 160,
   defaultIcon: 'mdi-image',
 })

--- a/packages/app/app/pages/sessions/index.vue
+++ b/packages/app/app/pages/sessions/index.vue
@@ -131,7 +131,7 @@
     </template>
 
     <!-- Create/Edit Session Dialog -->
-    <v-dialog v-model="showCreateDialog" max-width="1000" scrollable :persistent="saving || uploadingAudio">
+    <v-dialog v-model="showCreateDialog" max-width="1000" scrollable :persistent="saving || uploadingAudio || generatingImage">
       <v-card>
         <v-card-title>
           {{ editingSession ? $t('sessions.edit') : $t('sessions.create') }}
@@ -289,9 +289,9 @@
                 v-if="editingSession"
                 :session-id="editingSession.id"
                 :session-title="sessionForm.title"
-                :session-summary="sessionForm.summary"
                 @preview-image="openImagePreview"
                 @images-updated="reloadSessions"
+                @generating="generatingImage = $event"
               />
             </v-tabs-window-item>
 
@@ -457,12 +457,12 @@
 
         <v-card-actions>
           <v-spacer />
-          <v-btn variant="text" :disabled="saving || uploadingAudio" @click="closeDialog">
+          <v-btn variant="text" :disabled="saving || uploadingAudio || generatingImage" @click="closeDialog">
             {{ $t('common.cancel') }}
           </v-btn>
           <v-btn
             color="primary"
-            :disabled="!sessionForm.title || uploadingAudio"
+            :disabled="!sessionForm.title || uploadingAudio || generatingImage"
             :loading="saving"
             @click="saveSession"
           >
@@ -667,6 +667,7 @@ const saving = ref(false)
 const deleting = ref(false)
 const uploadingImage = ref(false)
 const uploadingAudio = ref(false)
+const generatingImage = ref(false)
 const sessionDialogTab = ref('details')
 
 // Image preview state

--- a/packages/app/i18n/locales/de.json
+++ b/packages/app/i18n/locales/de.json
@@ -757,7 +757,21 @@
       "monastery": "Kloster",
       "lighthouse": "Leuchtturm",
       "windmill": "Windmühle",
-      "quarry": "Steinbruch"
+      "quarry": "Steinbruch",
+      "underground": "Untergrund",
+      "district": "Stadtviertel",
+      "smithy": "Schmiede",
+      "warehouse": "Lagerhaus",
+      "sewers": "Kanalisation",
+      "throne_room": "Thronsaal",
+      "barracks": "Kaserne",
+      "stable": "Stall",
+      "garden": "Garten",
+      "cemetery": "Friedhof",
+      "dock": "Dock",
+      "alley": "Gasse",
+      "plaza": "Platz",
+      "outpost": "Außenposten"
     },
     "uploadImage": "Bild hochladen",
     "changeImage": "Bild ändern",
@@ -1087,7 +1101,11 @@
     "goToPage": "Zur Seite",
     "cover": "Cover",
     "coverImages": "Cover-Bilder",
-    "noCoverImagesText": "Lade ein Cover-Bild hoch oder generiere eines mit KI"
+    "noCoverImagesText": "Lade ein Cover-Bild hoch oder generiere eines mit KI",
+    "generateCoverImage": "Bild mit KI generieren",
+    "coverImageDescription": "Bildbeschreibung",
+    "coverImageDescriptionPlaceholder": "Beschreibe die Szene, z.B.: Eine Gruppe Abenteurer steht vor einem riesigen Drachen in einer Höhle voller Gold...",
+    "coverImageSafetyError": "Die Beschreibung wurde vom KI-Sicherheitsfilter abgelehnt. Bitte formuliere die Szene anders - vermeide direkte Gewaltbeschreibungen und verwende stattdessen allgemeinere Begriffe wie 'epischer Kampf' oder 'dramatische Konfrontation'."
   },
   "documents": {
     "title": "Dokumente",
@@ -1167,6 +1185,7 @@
     "yes": "Ja",
     "no": "Nein",
     "confirm": "Bestätigen",
+    "saveChangesFirst": "Bitte erst speichern - Daten für Bildgenerierung wurden geändert",
     "uploading": "Wird hochgeladen...",
     "loading": "Wird geladen...",
     "images": "Bilder",

--- a/packages/app/i18n/locales/en.json
+++ b/packages/app/i18n/locales/en.json
@@ -762,7 +762,21 @@
       "monastery": "Monastery",
       "lighthouse": "Lighthouse",
       "windmill": "Windmill",
-      "quarry": "Quarry"
+      "quarry": "Quarry",
+      "underground": "Underground",
+      "district": "District",
+      "smithy": "Smithy",
+      "warehouse": "Warehouse",
+      "sewers": "Sewers",
+      "throne_room": "Throne Room",
+      "barracks": "Barracks",
+      "stable": "Stable",
+      "garden": "Garden",
+      "cemetery": "Cemetery",
+      "dock": "Dock",
+      "alley": "Alley",
+      "plaza": "Plaza",
+      "outpost": "Outpost"
     },
     "uploadImage": "Upload Image",
     "changeImage": "Change Image",
@@ -1092,7 +1106,11 @@
     "goToPage": "Go to Page",
     "cover": "Cover",
     "coverImages": "Cover Images",
-    "noCoverImagesText": "Upload a cover image or generate one with AI"
+    "noCoverImagesText": "Upload a cover image or generate one with AI",
+    "generateCoverImage": "Generate Image with AI",
+    "coverImageDescription": "Image Description",
+    "coverImageDescriptionPlaceholder": "Describe the scene, e.g.: A group of adventurers standing before a huge dragon in a cave full of gold...",
+    "coverImageSafetyError": "The description was rejected by the AI safety filter. Please rephrase the scene - avoid direct violence descriptions and use more general terms like 'epic battle' or 'dramatic confrontation' instead."
   },
   "documents": {
     "title": "Documents",
@@ -1201,6 +1219,7 @@
     "linkItem": "Link item",
     "noLinkedItems": "No linked items",
     "noLinkedItemsText": "Add relevant items to this entity",
+    "saveChangesFirst": "Please save first - data for image generation was changed",
     "relationType": "Relation type",
     "quantity": "Quantity",
     "quantityPlaceholder": "1",

--- a/packages/app/server/api/ai/generate-image.post.ts
+++ b/packages/app/server/api/ai/generate-image.post.ts
@@ -5,11 +5,63 @@ import { join } from 'node:path'
 import { getUploadPath } from '../../utils/paths'
 import { randomUUID } from 'node:crypto'
 
+// Entity-specific data interfaces for richer prompts
+interface NpcData {
+  name: string
+  race?: string
+  class?: string
+  age?: number
+  gender?: string
+  type?: string // friendly, neutral, enemy
+  status?: string // alive, dead, missing
+  alignment?: string
+  description?: string
+}
+
+interface LocationData {
+  name: string
+  type?: string // tavern, forest, dungeon, etc.
+  description?: string
+}
+
+interface ItemData {
+  name: string
+  type?: string // weapon, armor, potion, etc.
+  rarity?: string // common, uncommon, rare, etc.
+  material?: string
+  description?: string
+}
+
+interface FactionData {
+  name: string
+  type?: string // guild, religious order, criminal organization, etc.
+  goals?: string
+  description?: string
+}
+
+interface PlayerData {
+  name: string
+  characterName?: string
+  race?: string
+  class?: string
+  level?: number
+  description?: string
+}
+
+interface SessionData {
+  title: string
+  sessionNumber?: number
+  summary?: string
+  notes?: string // First part of session notes for context
+}
+
 interface GenerateImageRequest {
-  prompt: string // User-provided description
+  prompt: string // User-provided description (can be empty if entityData provided)
   entityName?: string // Entity name for better prompts
-  entityType?: 'NPC' | 'Location' | 'Item' | 'Faction'
+  entityType?: 'NPC' | 'Location' | 'Item' | 'Faction' | 'Player' | 'Session'
   style?: 'realistic' | 'fantasy-art' | 'sketch' | 'oil-painting'
+  // Structured entity data for richer prompts
+  entityData?: NpcData | LocationData | ItemData | FactionData | PlayerData | SessionData
 }
 
 interface GenerateImageResponse {
@@ -17,14 +69,78 @@ interface GenerateImageResponse {
   revisedPrompt?: string // DALL-E's revised prompt
 }
 
+// Build a detailed description from structured entity data
+function buildEntityDescription(
+  entityType: string,
+  entityData: NpcData | LocationData | ItemData | FactionData | PlayerData | SessionData | undefined,
+  fallbackPrompt: string,
+): string {
+  if (!entityData) return fallbackPrompt
+
+  const parts: string[] = []
+
+  if (entityType === 'NPC') {
+    const data = entityData as NpcData
+    if (data.race) parts.push(`Race: ${data.race}`)
+    if (data.class) parts.push(`Class: ${data.class}`)
+    if (data.gender) parts.push(`Gender: ${data.gender}`)
+    if (data.age) parts.push(`Age: ${data.age}`)
+    if (data.alignment) parts.push(`Alignment: ${data.alignment}`)
+    if (data.type) parts.push(`NPC Type: ${data.type}`)
+    if (data.status) parts.push(`Status: ${data.status}`)
+    parts.push(`Name: ${data.name}`)
+    if (data.description) parts.push(`Description: ${data.description}`)
+  } else if (entityType === 'Location') {
+    const data = entityData as LocationData
+    if (data.type) parts.push(`Location Type: ${data.type}`)
+    parts.push(`Name: ${data.name}`)
+    if (data.description) parts.push(`Description: ${data.description}`)
+  } else if (entityType === 'Item') {
+    const data = entityData as ItemData
+    if (data.type) parts.push(`Item Type: ${data.type}`)
+    if (data.rarity) parts.push(`Rarity: ${data.rarity}`)
+    if (data.material) parts.push(`Material: ${data.material}`)
+    parts.push(`Name: ${data.name}`)
+    if (data.description) parts.push(`Description: ${data.description}`)
+  } else if (entityType === 'Faction') {
+    const data = entityData as FactionData
+    if (data.type) parts.push(`Faction Type: ${data.type}`)
+    parts.push(`Name: ${data.name}`)
+    if (data.goals) parts.push(`Goals: ${data.goals}`)
+    if (data.description) parts.push(`Description: ${data.description}`)
+  } else if (entityType === 'Player') {
+    const data = entityData as PlayerData
+    if (data.characterName) parts.push(`Character Name: ${data.characterName}`)
+    if (data.race) parts.push(`Race: ${data.race}`)
+    if (data.class) parts.push(`Class: ${data.class}`)
+    if (data.level) parts.push(`Level: ${data.level}`)
+    parts.push(`Player Name: ${data.name}`)
+    if (data.description) parts.push(`Description: ${data.description}`)
+  } else if (entityType === 'Session') {
+    const data = entityData as SessionData
+    if (data.sessionNumber) parts.push(`Session Number: ${data.sessionNumber}`)
+    parts.push(`Session Title: ${data.title}`)
+    if (data.summary) parts.push(`Summary: ${data.summary}`)
+    if (data.notes) parts.push(`Scene Notes: ${data.notes}`)
+  }
+
+  // Combine structured data with any additional user prompt
+  const structuredPart = parts.join('\n')
+  if (fallbackPrompt && fallbackPrompt.trim()) {
+    return `${structuredPart}\n\nAdditional details: ${fallbackPrompt}`
+  }
+  return structuredPart
+}
+
 export default defineEventHandler(async (event): Promise<GenerateImageResponse> => {
   const body = await readBody<GenerateImageRequest>(event)
 
-  // Validate input
-  if (!body || !body.prompt || body.prompt.trim().length === 0) {
+  // Validate input - allow empty prompt if entityData is provided
+  const hasEntityData = body?.entityData && Object.keys(body.entityData).length > 0
+  if (!body || (!body.prompt?.trim() && !hasEntityData)) {
     throw createError({
       statusCode: 400,
-      message: 'Prompt is required',
+      message: 'Prompt or entity data is required',
     })
   }
 
@@ -55,60 +171,81 @@ export default defineEventHandler(async (event): Promise<GenerateImageResponse> 
   // ChatGPT uses GPT-4 to rewrite prompts before sending to DALL-E
   // We'll do the same thing!
 
-  const objectDescription = body.prompt.trim()
+  const entityType = body.entityType || 'Item'
+
+  // Build rich description from structured entity data + user prompt
+  const objectDescription = buildEntityDescription(
+    entityType,
+    body.entityData,
+    body.prompt?.trim() || '',
+  )
 
   // Style definitions for GPT-4 to use
-  const style = body.style || 'fantasy-art'
+  // IMPORTANT: Explicitly avoid 3D/CGI look which DALL-E 3 tends to produce
+  const style = body.style || 'realistic'
   const styleMap: Record<string, string> = {
-    realistic: 'photorealistic with studio lighting',
-    'fantasy-art': 'fantasy digital illustration',
-    sketch: 'pencil sketch',
-    'oil-painting': 'oil painting',
+    realistic:
+      'real photograph, NOT 3D rendered, NOT CGI, NOT computer generated, NOT video game graphics. Shot on professional camera, natural film grain, real human features, cinematic movie still quality, like a photo from a high-budget fantasy film set',
+    'fantasy-art':
+      'traditional oil painting on canvas, visible brushstrokes, NOT digital art, NOT 3D, classic fantasy art style like Alan Lee or John Howe, painterly texture',
+    sketch: 'hand-drawn pencil sketch on paper, visible paper texture, crosshatching, NOT digital, traditional artist drawing',
+    'oil-painting':
+      'classical oil painting, Renaissance masters technique, visible brushstrokes on canvas, NOT digital, dramatic chiaroscuro lighting, museum quality fine art',
   }
 
   // Step 1: Use GPT-4 to optimize the prompt for DALL-E
   // Choose system prompt based on entity type
-  const entityType = body.entityType || 'Item'
   let systemPrompt: string
 
   if (entityType === 'NPC') {
-    systemPrompt = `You are a DALL-E 3 prompt expert specializing in fantasy character portraits.
+    systemPrompt = `You are a DALL-E 3 prompt expert. Your prompts must produce REALISTIC photographs, NOT 3D renders or CGI.
 
-YOUR GOAL: Generate prompts that produce detailed character portraits - full body or waist-up shots with personality and atmosphere.
+YOUR GOAL: Generate prompts that look like REAL PHOTOGRAPHS of actors in costume on a fantasy film set - like stills from Lord of the Rings or Game of Thrones movies.
 
-CRITICAL RULES:
-1. Describe the character's appearance (race, age, clothing, equipment, facial features, posture)
-2. Art style: ${styleMap[style]}
-3. Include environment hints (tavern, forest clearing, castle hall) but keep background slightly blurred
-4. Use ONLY positive descriptions - NEVER say "no text", "no frame", "no border" (this triggers DALL-E to add them!)
-5. Keep under 100 words
-6. Emphasize: character portrait, personality visible, atmospheric lighting
-7. FORBIDDEN WORDS: "inventory", "icon", "UI", "card", "interface", "banner", "label", "frame", "border", "game asset", "profile picture"
-8. Think: fantasy art character commission, D&D character portrait
+CRITICAL ANTI-3D RULES (ALWAYS INCLUDE):
+- ALWAYS add: "real photograph, NOT 3D rendered, NOT CGI, NOT video game"
+- ALWAYS add: "shot on Arri Alexa camera, natural film grain, real human skin texture"
+- Describe REAL physical features, not idealized CGI faces
+
+SETTING: Medieval fantasy by default. Adapt to sci-fi/other if description indicates.
+
+CONTENT RULES:
+1. Art style: ${styleMap[style]}
+2. Race-appropriate features (elves: pointed ears, elegant; dwarves: stocky, bearded)
+3. Class-appropriate medieval gear (wizard: robes, staff; fighter: real metal armor)
+4. Real costume materials: actual leather, real chainmail, wool cloaks
+5. Cinematic lighting: practical lights, golden hour, candlelight
+6. Keep under 100 words
+7. Focus on: real human expression, authentic costume, film set atmosphere
 
 EXAMPLE:
-Bad: "An elf warrior character icon with no frame"
-Good: "A wise elven ranger with long silver hair and weathered leather armor, holding a wooden longbow, standing in a misty forest clearing, determined expression, warm afternoon light filtering through trees, waist-up portrait"
+Input: "Race: Elf, Class: Wizard, Name: Elara"
+Output: "Real photograph of an elegant elven woman with long silver hair and pointed ears, wearing hand-sewn midnight-blue velvet robes with silver embroidery, holding a gnarled wooden staff, standing in a candlelit medieval library, wise expression, shot on Arri Alexa, natural film grain, cinematic lighting like Lord of the Rings, NOT 3D rendered, NOT CGI"
 
 Output ONLY the optimized prompt.`
   } else if (entityType === 'Location') {
-    systemPrompt = `You are a DALL-E 3 prompt expert specializing in fantasy location and environment art.
+    systemPrompt = `You are a DALL-E 3 prompt expert. Your prompts must produce REALISTIC photographs, NOT 3D renders or CGI.
 
-YOUR GOAL: Generate prompts that produce immersive fantasy locations - landscapes, buildings, interiors with rich atmosphere.
+YOUR GOAL: Generate prompts that look like REAL PHOTOGRAPHS of actual locations - like movie set photography from Lord of the Rings or Game of Thrones, or National Geographic travel photos.
 
-CRITICAL RULES:
-1. Describe the location's key features (architecture, terrain, natural elements, mood)
-2. Art style: ${styleMap[style]}
-3. Include atmospheric details (weather, lighting, time of day, ambient effects)
-4. Use ONLY positive descriptions - NEVER say "no text", "no frame", "no border" (this triggers DALL-E to add them!)
+CRITICAL ANTI-3D RULES (ALWAYS INCLUDE):
+- ALWAYS add: "real photograph, NOT 3D rendered, NOT CGI, NOT digital art"
+- ALWAYS add: "shot on professional camera, natural lighting, real materials and textures"
+- Describe REAL physical materials: actual stone, real wood, authentic weathering
+
+DEFAULT SETTING: Medieval fantasy. Adapt to sci-fi/other if description indicates.
+
+CONTENT RULES:
+1. Art style: ${styleMap[style]}
+2. Real architecture and materials (actual stone walls, real wooden beams, authentic wear)
+3. Cinematic composition: establishing shots, dramatic angles, depth of field
+4. Natural lighting: golden hour sun, real fire light, moonlight through windows
 5. Keep under 100 words
-6. Emphasize: establishing shot, cinematic composition, depth and scale
-7. FORBIDDEN WORDS: "inventory", "icon", "UI", "card", "interface", "banner", "label", "frame", "border", "game asset", "map marker"
-8. Think: fantasy concept art, environment matte painting, D&D setting illustration
+6. Focus on: authentic textures, real weathering, lived-in atmosphere
 
 EXAMPLE:
-Bad: "A tavern location icon with no frame"
-Good: "Cozy medieval tavern interior, warm firelight casting dancing shadows on wooden beams, stone fireplace with crackling fire, round tables with adventurers, barrels and bottles on shelves, comfortable atmosphere, golden hour light streaming through small windows"
+Input: "Location Type: Tavern, Name: The Prancing Pony"
+Output: "Real photograph of a rustic medieval tavern interior, actual stone fireplace with crackling fire, heavy oak beams blackened by centuries of smoke, worn wooden tables and benches, pewter tankards and tallow candles, dust motes in shafts of window light, shot on Arri Alexa, cinematic wide shot, NOT 3D rendered, NOT CGI, like a film location from Lord of the Rings"
 
 Output ONLY the optimized prompt.`
   } else if (entityType === 'Faction') {
@@ -131,8 +268,68 @@ Bad: "A guild icon with no frame or text"
 Good: "Heraldic emblem featuring crossed golden swords behind a silver shield, dark blue and gold color scheme, laurel wreath border, majestic and noble appearance, fantasy guild crest, detailed metalwork"
 
 Output ONLY the optimized prompt.`
-  } else {
-    // For Items, etc. - keep the object-focused prompt
+  } else if (entityType === 'Player') {
+    systemPrompt = `You are a DALL-E 3 prompt expert specializing in fantasy player character portraits.
+
+YOUR GOAL: Generate prompts that produce heroic player character portraits - detailed, dynamic poses showing the character's class and abilities.
+
+CRITICAL RULES:
+1. Describe the character based on their race, class, and level - show their experience and power
+2. Art style: ${styleMap[style]}
+3. Include equipment and abilities typical for their class (weapons, armor, magical effects)
+4. Use ONLY positive descriptions - NEVER say "no text", "no frame", "no border" (this triggers DALL-E to add them!)
+5. Keep under 100 words
+6. Emphasize: heroic pose, class identity visible, character personality, atmospheric lighting
+7. FORBIDDEN WORDS: "inventory", "icon", "UI", "card", "interface", "banner", "label", "frame", "border", "game asset", "profile picture"
+8. Think: D&D player character commission, fantasy hero portrait
+
+EXAMPLE:
+Bad: "A player character icon with no frame"
+Good: "A confident half-orc barbarian with tribal tattoos and a massive greataxe, muscular build, weathered leather armor, fierce but noble expression, standing in dramatic battle pose, warm campfire lighting, waist-up portrait"
+
+Output ONLY the optimized prompt.`
+  } else if (entityType === 'Session') {
+    systemPrompt = `You are a DALL-E 3 prompt expert. Your prompts must produce REALISTIC photographs, NOT 3D renders or CGI.
+
+CONTEXT: This is for a Dungeons & Dragons tabletop roleplaying game session recap. All content is FICTIONAL FANTASY for entertainment - epic battles, mythical creatures, magic spells are collaborative storytelling like in movies/books. Think Lord of the Rings, Game of Thrones - epic fantasy cinema.
+
+YOUR GOAL: Generate prompts that look like REAL PHOTOGRAPHS from a fantasy film set - movie stills from Lord of the Rings, Game of Thrones, or The Witcher series. These are COVER IMAGES for D&D session recaps.
+
+CRITICAL SAFETY-FILTER-FRIENDLY REPHRASING:
+The user's input may contain dramatic D&D descriptions. ALWAYS rephrase them into CINEMATIC, ARTISTIC terms that focus on VISUAL SPECTACLE rather than conflict:
+- "battle", "war", "fight", "attack" → "epic confrontation", "dramatic standoff", "climactic moment"
+- "giant creature attacking" → "majestic creature towering over heroes", "awe-inspiring beast"
+- "lightning strikes heroes" → "dramatic storm with lightning in sky, heroes silhouetted"
+- "10 meter fox", "giant animal" → "majestic mythical beast", "legendary creature from folklore"
+- "gods at war" → "divine beings in dramatic celestial scene", "mythological tableau"
+- Any violence → focus on DRAMA, TENSION, AWE - like a movie poster, not action scene
+
+CRITICAL ANTI-3D RULES (ALWAYS INCLUDE):
+- ALWAYS add: "real photograph, NOT 3D rendered, NOT CGI, NOT video game graphics"
+- ALWAYS add: "shot on Arri Alexa, 35mm anamorphic lens, natural film grain, cinematic color grading"
+- Describe REAL actors in costumes, real locations, practical lighting
+
+IMAGE FORMAT: This will be a WIDE 16:9 cover image - compose for horizontal/landscape format with cinematic framing.
+
+CONTENT RULES:
+1. Art style: ${styleMap[style]}
+2. Extract the KEY DRAMATIC MOMENT - transform into CINEMATIC WONDER, not conflict
+3. Show the scene as if photographed on a real movie set with actors and practical effects
+4. Cinematic composition: wide establishing shots, dramatic angles, rule of thirds
+5. Real lighting: golden hour, torchlight, moonlight - all practical and natural
+6. Keep under 100 words
+7. Focus on: atmosphere, wonder, awe, majesty - the EMOTIONAL and VISUAL impact
+8. FORBIDDEN WORDS: "inventory", "icon", "UI", "card", "interface", "banner", "label", "frame", "border", "game asset", "illustration", "painting", "digital art", "attack", "violence", "blood", "gore", "weapon striking"
+
+EXAMPLES:
+Input: "A fox grows to 10 meters in an epic battle at night. Lightning strikes the heroes."
+Output: "Real photograph of a majestic giant fox spirit towering against a stormy night sky, silhouettes of four adventurers standing in awe below, dramatic lightning illuminating storm clouds in the distance, mystical fog swirling, cinematic wide shot, shot on Arri Alexa with anamorphic lens, natural film grain, like a movie still from a fantasy epic, NOT 3D rendered, NOT CGI"
+
+Input: "War of the Gods. A massive battle."
+Output: "Real photograph of an epic mythological tableau, divine figures silhouetted against a dramatic sunset sky, heroes witnessing the celestial event from a hilltop, golden light streaming through clouds, awe-inspiring scale, cinematic wide shot, shot on Arri Alexa, natural film grain, like a scene from Lord of the Rings, NOT 3D rendered, NOT CGI"
+
+Output ONLY the optimized prompt - make it SAFE for DALL-E while preserving the epic fantasy atmosphere.`
+  } else if (entityType === 'Item') {
     systemPrompt = `You are a DALL-E 3 prompt expert specializing in clean, isolated object renders.
 
 YOUR GOAL: Generate prompts that produce ONLY the object itself - no frames, no text, no UI elements, no decorations.
@@ -150,6 +347,19 @@ CRITICAL RULES:
 EXAMPLE:
 Bad: "A sword with no text or frame, game inventory icon style"
 Good: "An ornate longsword with silver crossguard and leather-wrapped grip, centered on neutral grey background, studio lighting, detailed metalwork visible"
+
+Output ONLY the optimized prompt.`
+  } else {
+    // Fallback for any other entity type
+    systemPrompt = `You are a DALL-E 3 prompt expert specializing in fantasy art.
+
+YOUR GOAL: Generate prompts that produce high-quality fantasy illustrations.
+
+CRITICAL RULES:
+1. Art style: ${styleMap[style]}
+2. Use ONLY positive descriptions - NEVER say "no text", "no frame", "no border"
+3. Keep under 100 words
+4. FORBIDDEN WORDS: "inventory", "icon", "UI", "card", "interface", "banner", "label", "frame", "border", "game asset"
 
 Output ONLY the optimized prompt.`
   }
@@ -190,6 +400,9 @@ Output ONLY the optimized prompt.`
   }
 
   // Call OpenAI DALL-E 3 API
+  // Use 16:9 format (1792x1024) for Session cover images, square for everything else
+  const imageSize = entityType === 'Session' ? '1792x1024' : '1024x1024'
+
   try {
     const response = await fetch('https://api.openai.com/v1/images/generations', {
       method: 'POST',
@@ -201,7 +414,7 @@ Output ONLY the optimized prompt.`
         model: 'dall-e-3',
         prompt: enhancedPrompt,
         n: 1,
-        size: '1024x1024',
+        size: imageSize,
         quality: 'standard',
         style: 'natural', // Use 'natural' to minimize creative rewriting
         response_format: 'url',


### PR DESCRIPTION
## Summary
- Add structured entity data support for richer DALL-E prompts (NPC, Location, Item, Faction, Player, Session)
- Change default style from fantasy-art to realistic with anti-3D/CGI instructions
- Add 16:9 format (1792x1024) for session cover images
- Add GPT-4 safety-filter-friendly rephrasing for session prompts (transforms "battle" → "epic confrontation", etc.)
- Add custom description field for session cover image generation
- Add meaningful error messages for safety filter rejections
- Add unsaved changes warning for image generation across all entity dialogs
- Disable dialog buttons during image generation

## Test plan
- [ ] Generate NPC image with race/class/alignment - verify realistic style, no 3D look
- [ ] Generate Location image - verify realistic style
- [ ] Generate Session cover with dramatic D&D content (e.g. "giant fox in battle") - verify safety filter bypass works
- [ ] Verify 16:9 aspect ratio for session covers
- [ ] Verify error message appears when safety filter still rejects
- [ ] Verify unsaved changes warning appears when generating image with unsaved form changes
- [ ] Verify Cancel/Save buttons are disabled during image generation

🤖 Generated with [Claude Code](https://claude.com/claude-code)