### PR TITLE
Fix typo in en.json

### DIFF
--- a/packages/landing/i18n/locales/en.json
+++ b/packages/landing/i18n/locales/en.json
@@ -23,7 +23,7 @@
     "title": {
       "line1": "Your Campaign.",
       "line2": "Your Story.",
-      "line3": "Your Heros."
+      "line3": "Your Heroes."
     },
     "subtitle": "The ultimate campaign management tool for Dungeon Masters. Organize NPCs, locations, items, factions, and sessions with powerful fuzzy search and AI integration.",
     "cta": {


### PR DESCRIPTION
Plural of hero should be heroes.

https://dictionary.cambridge.org/dictionary/english/heroes