### PR TITLE
fix: add complete NPC type and status icon mappings

### DIFF
--- a/packages/app/app/components/npcs/NpcCard.vue
+++ b/packages/app/app/components/npcs/NpcCard.vue
@@ -375,6 +375,7 @@
 <script setup lang="ts">
 import type { NPC } from '~~/types/npc'
 import ImagePreviewDialog from '~/components/shared/ImagePreviewDialog.vue'
+import { getNpcTypeIcon, getNpcStatusIcon, getNpcStatusColor } from '~/utils/npc-icons'
 
 interface Props {
   npc: NPC
@@ -470,48 +471,7 @@ function getClassDisplayName(className: string): string {
   return classData.name
 }
 
-// Icon helpers
-function getNpcTypeIcon(type: string): string {
-  const icons: Record<string, string> = {
-    ally: 'mdi-handshake',
-    enemy: 'mdi-sword-cross',
-    neutral: 'mdi-minus-circle',
-    questgiver: 'mdi-exclamation',
-    merchant: 'mdi-cart',
-    guard: 'mdi-shield',
-    noble: 'mdi-crown',
-    commoner: 'mdi-account',
-    villain: 'mdi-skull',
-    mentor: 'mdi-school',
-    companion: 'mdi-account-multiple',
-    informant: 'mdi-eye',
-  }
-  return icons[type] || 'mdi-account'
-}
-
-function getNpcStatusIcon(status: string): string {
-  const icons: Record<string, string> = {
-    alive: 'mdi-heart-pulse',
-    dead: 'mdi-skull',
-    missing: 'mdi-help-circle',
-    imprisoned: 'mdi-lock',
-    unknown: 'mdi-help',
-    undead: 'mdi-zombie',
-  }
-  return icons[status] || 'mdi-help'
-}
-
-function getNpcStatusColor(status: string): string {
-  const colors: Record<string, string> = {
-    alive: 'success',
-    dead: 'error',
-    missing: 'warning',
-    imprisoned: 'grey-darken-2',
-    unknown: 'grey',
-    undead: 'purple',
-  }
-  return colors[status] || 'grey'
-}
+// Icon helpers imported from ~/utils/npc-icons
 </script>
 
 <style scoped>

--- a/packages/app/app/components/npcs/NpcEditDialog.vue
+++ b/packages/app/app/components/npcs/NpcEditDialog.vue
@@ -518,6 +518,7 @@ import { useImageDownload } from '~/composables/useImageDownload'
 import { useEntitiesStore } from '~/stores/entities'
 import { useCampaignStore } from '~/stores/campaign'
 import { useSnackbarStore } from '~/stores/snackbar'
+import { getNpcTypeIcon, getNpcStatusIcon, getNpcStatusColor } from '~/utils/npc-icons'
 
 // ============================================================================
 // Props & Emits - SIMPLIFIED: only show and npcId needed!
@@ -1408,42 +1409,7 @@ async function generateName() {
   }
 }
 
-// ============================================================================
-// Helper Functions
-// ============================================================================
-function getNpcTypeIcon(type: string): string {
-  const icons: Record<string, string> = {
-    friendly: 'mdi-account-heart',
-    neutral: 'mdi-account',
-    hostile: 'mdi-account-alert',
-    ally: 'mdi-account-check',
-    merchant: 'mdi-storefront',
-    quest_giver: 'mdi-script-text',
-    boss: 'mdi-crown',
-    companion: 'mdi-account-multiple',
-  }
-  return icons[type] || 'mdi-account'
-}
-
-function getNpcStatusIcon(status: string): string {
-  const icons: Record<string, string> = {
-    alive: 'mdi-heart-pulse',
-    dead: 'mdi-skull',
-    unknown: 'mdi-help-circle',
-    missing: 'mdi-magnify',
-  }
-  return icons[status] || 'mdi-help-circle'
-}
-
-function getNpcStatusColor(status: string): string {
-  const colors: Record<string, string> = {
-    alive: 'success',
-    dead: 'error',
-    unknown: 'grey',
-    missing: 'warning',
-  }
-  return colors[status] || 'grey'
-}
+// Icon helpers imported from ~/utils/npc-icons
 </script>
 
 <style scoped>

--- a/packages/app/app/utils/npc-icons.ts
+++ b/packages/app/app/utils/npc-icons.ts
@@ -1,0 +1,100 @@
+// Central NPC icon and color mappings
+// Used by NpcCard.vue, NpcEditDialog.vue, and other NPC-related components
+
+export function getNpcTypeIcon(type: string): string {
+  const icons: Record<string, string> = {
+    ally: 'mdi-account-check',
+    enemy: 'mdi-account-alert',
+    neutral: 'mdi-account',
+    questgiver: 'mdi-script-text',
+    merchant: 'mdi-storefront',
+    guard: 'mdi-shield-account',
+    noble: 'mdi-crown',
+    commoner: 'mdi-account',
+    villain: 'mdi-account-cancel',
+    mentor: 'mdi-school',
+    companion: 'mdi-account-multiple',
+    informant: 'mdi-ear-hearing',
+    innkeeper: 'mdi-glass-mug-variant',
+    rival: 'mdi-sword-cross',
+    servant: 'mdi-broom',
+    slave: 'mdi-handcuffs',
+    ruler: 'mdi-crown',
+    steward: 'mdi-key-variant',
+    spy: 'mdi-incognito',
+    healer: 'mdi-medical-bag',
+    scholar: 'mdi-book-open-variant',
+    craftsman: 'mdi-hammer-wrench',
+    priest: 'mdi-cross',
+    soldier: 'mdi-sword',
+    thief: 'mdi-domino-mask',
+    bard: 'mdi-music',
+    farmer: 'mdi-sprout',
+    hunter: 'mdi-bow-arrow',
+    mage: 'mdi-wizard-hat',
+    knight: 'mdi-shield-sword',
+    assassin: 'mdi-knife-military',
+    smuggler: 'mdi-sack',
+  }
+  return icons[type] || 'mdi-account'
+}
+
+export function getNpcStatusIcon(status: string): string {
+  const icons: Record<string, string> = {
+    alive: 'mdi-heart-pulse',
+    dead: 'mdi-skull',
+    missing: 'mdi-magnify',
+    imprisoned: 'mdi-handcuffs',
+    unknown: 'mdi-help-circle',
+    undead: 'mdi-skull-outline',
+    cursed: 'mdi-ghost',
+    petrified: 'mdi-diamond-stone',
+    polymorphed: 'mdi-swap-horizontal',
+    possessed: 'mdi-ghost',
+    banished: 'mdi-exit-run',
+    sleeping: 'mdi-sleep',
+    retired: 'mdi-home-account',
+    charmed: 'mdi-heart',
+    paralyzed: 'mdi-human-handsdown',
+    blinded: 'mdi-eye-off',
+    deafened: 'mdi-ear-hearing-off',
+    diseased: 'mdi-virus',
+    insane: 'mdi-head-alert',
+    exiled: 'mdi-account-arrow-right',
+    hiding: 'mdi-eye-off-outline',
+    traveling: 'mdi-walk',
+    unconscious: 'mdi-sleep',
+    resurrected: 'mdi-account-convert',
+  }
+  return icons[status] || 'mdi-account'
+}
+
+export function getNpcStatusColor(status: string): string {
+  const colors: Record<string, string> = {
+    alive: 'success',
+    dead: 'error',
+    missing: 'warning',
+    imprisoned: 'error',
+    unknown: 'grey',
+    undead: 'purple',
+    cursed: 'purple',
+    petrified: 'grey',
+    polymorphed: 'info',
+    possessed: 'purple',
+    banished: 'error',
+    sleeping: 'info',
+    retired: 'grey',
+    charmed: 'pink',
+    paralyzed: 'warning',
+    blinded: 'warning',
+    deafened: 'warning',
+    diseased: 'warning',
+    insane: 'purple',
+    exiled: 'error',
+    hiding: 'info',
+    traveling: 'info',
+    unconscious: 'warning',
+    resurrected: 'success',
+  }
+  return colors[status] || 'grey'
+}


### PR DESCRIPTION
## Summary
- Created central `utils/npc-icons.ts` with all 33 NPC types and 24 status icons
- Updated NpcCard.vue and NpcEditDialog.vue to use shared utils
- Default fallback is `mdi-account` instead of question mark

Closes #118