### PR TITLE
fix: sync entities.image_url with primary entity image

### DIFF
--- a/packages/app/app/utils/npc-icons.ts
+++ b/packages/app/app/utils/npc-icons.ts
@@ -35,6 +35,7 @@ export function getNpcTypeIcon(type: string): string {
     knight: 'mdi-shield-sword',
     assassin: 'mdi-knife-military',
     smuggler: 'mdi-sack',
+    deity: 'mdi-creation',
   }
   return icons[type] || 'mdi-account'
 }

--- a/packages/app/i18n/locales/de.json
+++ b/packages/app/i18n/locales/de.json
@@ -224,7 +224,8 @@
       "mage": "Magier",
       "knight": "Ritter",
       "assassin": "Assassine",
-      "smuggler": "Schmuggler"
+      "smuggler": "Schmuggler",
+      "deity": "Gottheit"
     },
     "status": "Status",
     "statuses": {
@@ -367,7 +368,9 @@
       "memberships": "Fraktionsmitgliedschaften",
       "players": "Verknüpfte Spieler"
     },
-    "noLore": "Kein verknüpftes Wissen vorhanden"
+    "noLore": "Kein verknüpftes Wissen vorhanden",
+    "noMemberships": "Keine Fraktionsmitgliedschaften",
+    "noMembershipsText": "Dieser NPC ist noch kein Mitglied einer Fraktion."
   },
   "factions": {
     "title": "Fraktionen",

--- a/packages/app/i18n/locales/en.json
+++ b/packages/app/i18n/locales/en.json
@@ -225,7 +225,8 @@
       "mage": "Mage",
       "knight": "Knight",
       "assassin": "Assassin",
-      "smuggler": "Smuggler"
+      "smuggler": "Smuggler",
+      "deity": "Deity"
     },
     "status": "Status",
     "statuses": {
@@ -366,7 +367,9 @@
       "lore": "Linked Lore",
       "memberships": "Faction Memberships",
       "players": "Linked Players"
-    }
+    },
+    "noMemberships": "No Faction Memberships",
+    "noMembershipsText": "This NPC is not a member of any faction yet."
   },
   "factions": {
     "title": "Factions",

--- a/packages/app/server/api/entity-images/[id].delete.ts
+++ b/packages/app/server/api/entity-images/[id].delete.ts
@@ -42,29 +42,41 @@ export default defineEventHandler(async (event) => {
   // Delete from database
   db.prepare('DELETE FROM entity_images WHERE id = ?').run(imageId)
 
-  // If this was the primary image, set another image as primary
+  // If this was the primary image, set another image as primary and update entities.image_url
   if (image.is_primary === 1) {
     const nextImage = db
       .prepare(
         `
-      SELECT id FROM entity_images
+      SELECT id, image_url FROM entity_images
       WHERE entity_id = ?
       ORDER BY display_order ASC, created_at ASC
       LIMIT 1
     `,
       )
-      .get(image.entity_id) as { id: number } | undefined
+      .get(image.entity_id) as { id: number; image_url: string } | undefined
 
     if (nextImage) {
       db.prepare('UPDATE entity_images SET is_primary = 1 WHERE id = ?').run(nextImage.id)
+      // Update entities.image_url to the new primary image
+      db.prepare('UPDATE entities SET image_url = ?, updated_at = ? WHERE id = ?').run(
+        nextImage.image_url,
+        new Date().toISOString(),
+        image.entity_id,
+      )
+    } else {
+      // No more images, clear entities.image_url
+      db.prepare('UPDATE entities SET image_url = NULL, updated_at = ? WHERE id = ?').run(
+        new Date().toISOString(),
+        image.entity_id,
+      )
     }
+  } else {
+    // Update entity's updated_at
+    db.prepare('UPDATE entities SET updated_at = ? WHERE id = ?').run(
+      new Date().toISOString(),
+      image.entity_id,
+    )
   }
-
-  // Update entity's updated_at
-  db.prepare('UPDATE entities SET updated_at = ? WHERE id = ?').run(
-    new Date().toISOString(),
-    image.entity_id,
-  )
 
   return {
     success: true,

--- a/packages/app/server/api/entity-images/[id]/set-primary.patch.ts
+++ b/packages/app/server/api/entity-images/[id]/set-primary.patch.ts
@@ -11,11 +11,12 @@ export default defineEventHandler(async (event) => {
     })
   }
 
-  // Get image info
-  const image = db.prepare('SELECT id, entity_id FROM entity_images WHERE id = ?').get(imageId) as
+  // Get image info including the image_url
+  const image = db.prepare('SELECT id, entity_id, image_url FROM entity_images WHERE id = ?').get(imageId) as
     | {
         id: number
         entity_id: number
+        image_url: string
       }
     | undefined
 
@@ -32,8 +33,9 @@ export default defineEventHandler(async (event) => {
   // Set this image as primary
   db.prepare('UPDATE entity_images SET is_primary = 1 WHERE id = ?').run(imageId)
 
-  // Update entity's updated_at
-  db.prepare('UPDATE entities SET updated_at = ? WHERE id = ?').run(
+  // Update entity's image_url and updated_at
+  db.prepare('UPDATE entities SET image_url = ?, updated_at = ? WHERE id = ?').run(
+    image.image_url,
     new Date().toISOString(),
     image.entity_id,
   )

--- a/packages/app/server/api/entity-images/add-generated.post.ts
+++ b/packages/app/server/api/entity-images/add-generated.post.ts
@@ -64,6 +64,15 @@ export default defineEventHandler(async (event) => {
     )
     .run(entityId, imageUrl, isPrimary, displayOrder, new Date().toISOString())
 
+  // If this is the first/primary image, also update entities.image_url
+  if (isPrimary === 1) {
+    db.prepare('UPDATE entities SET image_url = ?, updated_at = ? WHERE id = ?').run(
+      imageUrl,
+      new Date().toISOString(),
+      entityId,
+    )
+  }
+
   return {
     success: true,
     imageId: Number(result.lastInsertRowid),

--- a/packages/app/server/api/entity-images/upload.post.ts
+++ b/packages/app/server/api/entity-images/upload.post.ts
@@ -117,6 +117,15 @@ export default defineEventHandler(async (event) => {
       )
       .run(entityId, uniqueName, isPrimary, displayOrder, new Date().toISOString())
 
+    // If this is the first/primary image, also update entities.image_url
+    if (isPrimary === 1) {
+      db.prepare('UPDATE entities SET image_url = ?, updated_at = ? WHERE id = ?').run(
+        uniqueName,
+        new Date().toISOString(),
+        entityId,
+      )
+    }
+
     uploadedImages.push({
       id: Number(result.lastInsertRowid),
       imageUrl: uniqueName,

--- a/packages/app/server/api/lore/[id]/index.patch.ts
+++ b/packages/app/server/api/lore/[id]/index.patch.ts
@@ -62,6 +62,8 @@ export default defineEventHandler(async (event) => {
     campaign_id: number
     name: string
     description: string | null
+    image_url: string | null
+    location_id: number | null
     metadata: string | null
     created_at: string
     updated_at: string
@@ -71,7 +73,8 @@ export default defineEventHandler(async (event) => {
   const lore = db
     .prepare<unknown[], DbEntity>(
       `
-    SELECT * FROM entities WHERE id = ? AND deleted_at IS NULL
+    SELECT id, type_id, campaign_id, name, description, image_url, location_id, metadata, created_at, updated_at, deleted_at
+    FROM entities WHERE id = ? AND deleted_at IS NULL
   `,
     )
     .get(id)

--- a/packages/app/types/npc.ts
+++ b/packages/app/types/npc.ts
@@ -31,6 +31,7 @@ export const NPC_TYPES = [
   'knight',
   'assassin',
   'smuggler',
+  'deity',
 ] as const
 
 export type NpcType = (typeof NPC_TYPES)[number]


### PR DESCRIPTION
## Summary
- **Upload/generate** now sets `entities.image_url` for first image (all entity types)
- **Set primary** updates `entities.image_url` when primary changes
- **Delete** updates to next primary image or clears if no images left
- **Lore PATCH** now returns `image_url` in response
- **Migration 33**: syncs existing entities with their primary image
- Added missing i18n keys (`deity` type, `noMemberships`)

## Root Cause
The `entity_images` table tracked primary images via `is_primary`, but `entities.image_url` was never synchronized. Cards use `entities.image_url` for preview.

Closes #113