### PR TITLE
fix: skip validation cron during prerender (v1.1.1)

### DIFF
--- a/packages/landing/package.json
+++ b/packages/landing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dm-hero/landing",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "type": "module",
   "private": true,
   "scripts": {

--- a/packages/landing/server/plugins/validationCron.ts
+++ b/packages/landing/server/plugins/validationCron.ts
@@ -33,9 +33,9 @@ interface VersionFile {
 const VALIDATION_INTERVAL = 10 * 60 * 1000 // 10 minutes
 
 export default defineNitroPlugin((_nitroApp) => {
-  // Don't run during build
-  if (process.env.NUXT_BUILD) {
-    console.log('[ValidationCron] Skipping during build')
+  // Don't run during build or prerender
+  if (process.env.NUXT_BUILD || process.env.NITRO_PRERENDER || import.meta.prerender) {
+    console.log('[ValidationCron] Skipping during build/prerender')
     return
   }
 


### PR DESCRIPTION
## Problem
ValidationCron plugin was running during build/prerender phase, causing:
1. DB connection errors (no MySQL during build)
2. Build never finishing because `setInterval` keeps Node.js event loop alive

## Fix
Added checks for `NITRO_PRERENDER` and `import.meta.prerender` to skip CRON initialization during build.

## Release
Landing: 1.1.0 → 1.1.1