### PR TITLE
fix: Dockerfile SSR + skip migrations during prerender

### DIFF
--- a/.changeset/fix-dockerfile-ssr.md
+++ b/.changeset/fix-dockerfile-ssr.md
@@ -1,0 +1,5 @@
+---
+"@dm-hero/landing": patch
+---
+
+fix: Dockerfile now uses Node.js server instead of nginx for SSR support, skip plugins during prerender

--- a/packages/landing/Dockerfile
+++ b/packages/landing/Dockerfile
@@ -15,19 +15,28 @@ COPY packages/landing ./packages/landing
 # Install dependencies
 RUN pnpm install --frozen-lockfile
 
-# Build the static site
+# Build the SSR app
 WORKDIR /app/packages/landing
 RUN pnpm build
 
-# Stage 2: Serve with Nginx
-FROM nginx:stable-alpine
+# Stage 2: Production runtime
+FROM node:22-bookworm-slim
 
-# Copy built static files
-COPY --from=builder /app/packages/landing/.output/public /usr/share/nginx/html
+WORKDIR /app
 
-# Copy custom nginx config for SPA routing
-COPY packages/landing/nginx.conf /etc/nginx/conf.d/default.conf
+# Copy built output from builder
+COPY --from=builder /app/packages/landing/.output ./.output
 
-EXPOSE 80
+# Create uploads directory
+RUN mkdir -p ./uploads
 
-CMD ["nginx", "-g", "daemon off;"]
+# Expose port
+EXPOSE 3000
+
+# Set environment
+ENV NODE_ENV=production
+ENV HOST=0.0.0.0
+ENV PORT=3000
+
+# Run the Nitro server
+CMD ["node", ".output/server/index.mjs"]

--- a/packages/landing/server/plugins/migrations.ts
+++ b/packages/landing/server/plugins/migrations.ts
@@ -1,6 +1,12 @@
 import { runMigrations } from '../utils/migrations'
 
 export default defineNitroPlugin(async () => {
+  // Don't run during build or prerender
+  if (process.env.NUXT_BUILD || process.env.NITRO_PRERENDER || import.meta.prerender) {
+    console.log('[Plugin] Skipping migrations during build/prerender')
+    return
+  }
+
   console.log('[Plugin] Running database migrations...')
   try {
     await runMigrations()


### PR DESCRIPTION
## Problem
1. Dockerfile used nginx for static files, but Landing is now SSR with API routes
2. Migrations plugin tried to connect to DB during prerender

## Fix
- Dockerfile now runs Node.js Nitro server instead of nginx
- Migrations plugin skips during build/prerender (like ValidationCron)

## Tested
- Local Docker build completes in ~44s without DB errors