### PR TITLE
fix: remove compile-time prerender check from migrations

### DIFF
--- a/.changeset/fix-migrations-runtime.md
+++ b/.changeset/fix-migrations-runtime.md
@@ -1,0 +1,5 @@
+---
+"@dm-hero/landing": patch
+---
+
+fix: remove import.meta.prerender from migrations check (compile-time constant breaks runtime)

--- a/packages/landing/server/plugins/migrations.ts
+++ b/packages/landing/server/plugins/migrations.ts
@@ -1,8 +1,8 @@
 import { runMigrations } from '../utils/migrations'
 
 export default defineNitroPlugin(async () => {
-  // Don't run during build or prerender
-  if (process.env.NUXT_BUILD || process.env.NITRO_PRERENDER || import.meta.prerender) {
+  // Don't run during build (process.env checks are runtime, import.meta.prerender is compile-time and breaks runtime)
+  if (process.env.NUXT_BUILD || process.env.NITRO_PRERENDER) {
     console.log('[Plugin] Skipping migrations during build/prerender')
     return
   }


### PR DESCRIPTION
## Summary
- Remove `import.meta.prerender` from migrations plugin check
- Keep only `process.env.NUXT_BUILD || process.env.NITRO_PRERENDER` (runtime checks)

## Problem
`import.meta.prerender` is a compile-time constant that gets baked into the bundle as `true` during build. This caused migrations to NEVER run at runtime.

## Solution
Only use `process.env` checks which are evaluated at runtime:
- During build: env vars set → skip migrations
- At runtime: env vars not set → run migrations

## Test
Docker build completed in ~50s (no hanging), migrations error during build is expected and caught by try/catch.