### PR TITLE
feat: add Linux Electron build to GitHub Actions

### DIFF
--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -131,8 +131,51 @@ jobs:
           path: packages/app/dist-electron/*.zip
           if-no-files-found: warn
 
+  build-electron-linux:
+    needs: check
+    if: needs.check.outputs.should_release == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build Nuxt
+        run: pnpm --filter @dm-hero/app build
+
+      - name: Rebuild better-sqlite3 for Electron
+        run: pnpm --filter @dm-hero/app electron:rebuild
+
+      - name: Build Electron app
+        working-directory: packages/app
+        run: pnpm exec electron-builder --linux
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dm-hero-linux
+          path: packages/app/dist-electron/*.AppImage
+          if-no-files-found: warn
+
   create-release:
-    needs: [check, build-docker, build-electron-windows]
+    needs: [check, build-docker, build-electron-windows, build-electron-linux]
     if: needs.check.outputs.should_release == 'true'
     runs-on: ubuntu-latest
     permissions:
@@ -147,6 +190,15 @@ jobs:
         with:
           name: dm-hero-windows
           path: ./artifacts
+
+      - name: Download Linux artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dm-hero-linux
+          path: ./artifacts
+
+      - name: List artifacts
+        run: ls -la ./artifacts/
 
       - name: Read changelog
         id: changelog

--- a/.gitignore
+++ b/.gitignore
@@ -36,5 +36,10 @@ uploads/
 /uploads/
 packages/*/uploads/
 
+# Electron build outputs
+dist-electron/
+packages/*/dist-electron/
+squashfs-root/
+
 # Private project documentation (keep local only)
 CLAUDE.md

--- a/packages/app/electron/main.js
+++ b/packages/app/electron/main.js
@@ -180,23 +180,39 @@ function stopServer() {
 function createWindow() {
   console.log('[Electron] Creating window...')
   console.log('[Electron] isDev:', isDev)
+  console.log('[Electron] Platform:', process.platform)
 
   // Start with dark theme (default)
   const currentTheme = THEME.dark
 
-  mainWindow = new BrowserWindow({
+  // Platform-specific window options
+  // Windows: Custom titlebar with overlay controls
+  // Linux/macOS: Native titlebar (titleBarOverlay not supported on Linux)
+  const isWindows = process.platform === 'win32'
+
+  const windowOptions = {
     width: 1400,
     height: 900,
     backgroundColor: currentTheme.background,
     show: false,
-    titleBarStyle: 'hidden',
-    titleBarOverlay: currentTheme.titleBarOverlay,
     webPreferences: {
       contextIsolation: true,
       nodeIntegration: false,
       preload: path.join(__dirname, 'preload.js'),
     },
-  })
+  }
+
+  if (isWindows) {
+    windowOptions.titleBarStyle = 'hidden'
+    windowOptions.titleBarOverlay = currentTheme.titleBarOverlay
+  } else {
+    // Linux/macOS: Hide menu bar for cleaner look
+    windowOptions.autoHideMenuBar = true
+    // Set window icon (Linux needs this explicitly, Windows/macOS use app bundle icon)
+    windowOptions.icon = path.join(__dirname, 'icons', 'icon.png')
+  }
+
+  mainWindow = new BrowserWindow(windowOptions)
 
   mainWindow.once('ready-to-show', () => {
     console.log('[Electron] Window ready to show')


### PR DESCRIPTION
## Summary
- Add Linux build job to release workflow (builds AppImage on ubuntu-latest)
- Fix platform-specific Electron window config (titleBarOverlay only on Windows)
- Add autoHideMenuBar and explicit icon for Linux
- Update .gitignore to exclude dist-electron/ and squashfs-root/

## Changes
- `.github/workflows/release-app.yml`: New `build-electron-linux` job running parallel to Windows
- `packages/app/electron/main.js`: Platform detection for window options
- `.gitignore`: Ignore Electron build outputs

## Test plan
- [x] Tested Linux build locally in WSL (AppImage extracted and ran successfully)
- [x] Verify GitHub Actions builds both Windows and Linux artifacts
- [x] Verify Linux AppImage works on native Linux