### PR TITLE
fix: sync store counts with composable countsMap

### DIFF
--- a/packages/app/app/composables/useFactionCounts.ts
+++ b/packages/app/app/composables/useFactionCounts.ts
@@ -13,14 +13,15 @@ interface FactionCounts {
   locations: number
 }
 
+// SHARED STATE - outside the function so all components share the same cache
+const loadingCounts = ref<Set<number>>(new Set())
+const countsMap = reactive<Record<number, FactionCounts | undefined>>({})
+
 /**
  * Composable to load Faction counts asynchronously
  * Updates the Faction object reactively with _counts property
  */
 export function useFactionCounts() {
-  const loadingCounts = ref<Set<number>>(new Set())
-  // Store counts as reactive object (not Map - Vue can't track Map.get())
-  const countsMap = reactive<Record<number, FactionCounts | undefined>>({})
 
   async function loadFactionCounts(faction: Faction): Promise<void> {
     // Skip if already loading
@@ -67,6 +68,13 @@ export function useFactionCounts() {
   }
 
   /**
+   * Set counts for a specific Faction directly (used by store after API fetch)
+   */
+  function setCounts(factionId: number, counts: FactionCounts): void {
+    countsMap[factionId] = counts
+  }
+
+  /**
    * Force reload counts for a specific Faction (ignores cache)
    * Use this after operations that change counts (e.g., adding/deleting relations)
    */
@@ -94,6 +102,7 @@ export function useFactionCounts() {
     loadFactionCounts,
     loadFactionCountsBatch,
     getCounts,
+    setCounts,
     reloadFactionCounts,
     clearCountsCache,
     loadingCounts: computed(() => loadingCounts.value),

--- a/packages/app/app/composables/useItemCounts.ts
+++ b/packages/app/app/composables/useItemCounts.ts
@@ -55,6 +55,13 @@ export function useItemCounts() {
   }
 
   /**
+   * Set counts for a specific Item directly (used by store after API fetch)
+   */
+  function setCounts(itemId: number, counts: ItemCounts): void {
+    countsMap[itemId] = counts
+  }
+
+  /**
    * Force reload counts for a specific Item (ignores cache)
    * Use this after operations that change counts (e.g., adding/deleting relations)
    */
@@ -82,6 +89,7 @@ export function useItemCounts() {
     loadItemCounts,
     loadItemCountsBatch,
     getCounts,
+    setCounts,
     reloadItemCounts,
     clearCountsCache,
     loadingCounts: computed(() => loadingCounts.value),

--- a/packages/app/app/composables/useLoreCounts.ts
+++ b/packages/app/app/composables/useLoreCounts.ts
@@ -68,6 +68,13 @@ export function useLoreCounts() {
   }
 
   /**
+   * Set counts for a specific Lore entry directly (used by store after API fetch)
+   */
+  function setCounts(loreId: number, counts: LoreCounts): void {
+    countsMap[loreId] = counts
+  }
+
+  /**
    * Force reload counts for a specific Lore entry (ignores cache)
    * Use this after operations that change counts (e.g., adding/deleting relations)
    */
@@ -95,6 +102,7 @@ export function useLoreCounts() {
     loadLoreCounts,
     loadLoreCountsBatch,
     getCounts,
+    setCounts,
     reloadLoreCounts,
     clearCountsCache,
     loadingCounts: computed(() => loadingCounts.value),

--- a/packages/app/app/composables/useNpcCounts.ts
+++ b/packages/app/app/composables/useNpcCounts.ts
@@ -55,6 +55,13 @@ export function useNpcCounts() {
   }
 
   /**
+   * Set counts for a specific NPC directly (used by store after API fetch)
+   */
+  function setCounts(npcId: number, counts: NpcCounts): void {
+    countsMap[npcId] = counts
+  }
+
+  /**
    * Force reload counts for a specific NPC (ignores cache)
    * Use this after operations that change counts (e.g., adding/deleting relations)
    */
@@ -112,6 +119,7 @@ export function useNpcCounts() {
     loadNpcCounts,
     loadNpcCountsBatch,
     getCounts,
+    setCounts,
     reloadNpcCounts,
     clearCountsCache,
     invalidateCountsFor,

--- a/packages/app/app/composables/usePlayerCounts.ts
+++ b/packages/app/app/composables/usePlayerCounts.ts
@@ -55,6 +55,13 @@ export function usePlayerCounts() {
   }
 
   /**
+   * Set counts for a specific Player directly (used by store after API fetch)
+   */
+  function setCounts(playerId: number, counts: PlayerCounts): void {
+    countsMap[playerId] = counts
+  }
+
+  /**
    * Force reload counts for a specific Player (ignores cache)
    * Use this after operations that change counts (e.g., adding/deleting relations)
    */
@@ -82,6 +89,7 @@ export function usePlayerCounts() {
     loadPlayerCounts,
     loadPlayerCountsBatch,
     getCounts,
+    setCounts,
     reloadPlayerCounts,
     clearCountsCache,
     loadingCounts: computed(() => loadingCounts.value),

--- a/packages/app/app/stores/entities.ts
+++ b/packages/app/app/stores/entities.ts
@@ -4,6 +4,11 @@ import type { Item } from '../../types/item'
 import type { Lore } from '../../types/lore'
 import type { Player } from '../../types/player'
 import type { Faction } from '../../types/faction'
+import { useNpcCounts } from '../composables/useNpcCounts'
+import { useFactionCounts } from '../composables/useFactionCounts'
+import { useItemCounts } from '../composables/useItemCounts'
+import { useLoreCounts } from '../composables/useLoreCounts'
+import { usePlayerCounts } from '../composables/usePlayerCounts'
 
 interface Location {
   id: number
@@ -189,6 +194,10 @@ export const useEntitiesStore = defineStore('entities', {
             _counts: counts,
           }
         }
+
+        // Also update the composable's countsMap for reactive UI updates
+        const { setCounts } = useNpcCounts()
+        setCounts(id, counts)
       } catch (error) {
         console.error(`Failed to load counts for NPC ${id}:`, error)
       }
@@ -282,6 +291,10 @@ export const useEntitiesStore = defineStore('entities', {
             _counts: counts,
           }
         }
+
+        // Also update the composable's countsMap for reactive UI updates
+        const { setCounts } = useFactionCounts()
+        setCounts(id, counts)
       } catch (error) {
         console.error(`Failed to load counts for faction ${id}:`, error)
       }
@@ -432,6 +445,10 @@ export const useEntitiesStore = defineStore('entities', {
             _counts: counts,
           }
         }
+
+        // Also update the composable's countsMap for reactive UI updates
+        const { setCounts } = useItemCounts()
+        setCounts(id, counts)
       } catch (error) {
         console.error(`Failed to load counts for Item ${id}:`, error)
       }
@@ -547,6 +564,10 @@ export const useEntitiesStore = defineStore('entities', {
             _counts: counts,
           }
         }
+
+        // Also update the composable's countsMap for reactive UI updates
+        const { setCounts } = useLoreCounts()
+        setCounts(id, counts)
       } catch (error) {
         console.error(`Failed to load counts for Lore ${id}:`, error)
       }
@@ -679,6 +700,10 @@ export const useEntitiesStore = defineStore('entities', {
             _counts: counts,
           }
         }
+
+        // Also update the composable's countsMap for reactive UI updates
+        const { setCounts } = usePlayerCounts()
+        setCounts(id, counts)
       } catch (error) {
         console.error(`Failed to load counts for Player ${id}:`, error)
       }


### PR DESCRIPTION
Closes #158

## Problem
Badge counts showed 0 for newly created entities because the store and composables had separate caches that weren't synchronized.

## Solution
- Add `setCounts()` function to all count composables (NPC, Faction, Item, Lore, Player)
- Store calls `setCounts()` after fetching counts from API
- Both caches now stay in sync

## Bonus fix
- `useFactionCounts` had `countsMap` defined inside the function (not shared) - moved to module level