### PR TITLE
feat: add error logging to file (#172)

### DIFF
--- a/packages/app/app/composables/useElectron.ts
+++ b/packages/app/app/composables/useElectron.ts
@@ -37,9 +37,10 @@ export interface UpdateDownloadProgress {
 
 export interface ElectronAPI {
   isElectron: boolean
-  exportDatabase: () => Promise<{ success: boolean; filePath?: string; error?: string }>
+  exportDatabase: () => Promise<{ success: boolean; canceled?: boolean; filePath?: string; error?: string }>
   openUploadsFolder: () => Promise<{ success: boolean; error?: string }>
-  getDataPaths: () => Promise<{ databasePath: string; uploadPath: string }>
+  openLogsFolder: () => Promise<{ success: boolean; error?: string }>
+  getDataPaths: () => Promise<{ databasePath: string; uploadPath: string; logsPath: string }>
   saveFileDialog: (options: SaveFileOptions) => Promise<SaveFileResult>
   openExternalUrl: (url: string) => Promise<{ success: boolean; error?: string }>
 
@@ -130,7 +131,7 @@ export function useElectron() {
     /**
      * Export the database (Electron only)
      */
-    async exportDatabase(): Promise<{ success: boolean; filePath?: string; error?: string }> {
+    async exportDatabase(): Promise<{ success: boolean; canceled?: boolean; filePath?: string; error?: string }> {
       if (!electronAPI) {
         return { success: false, error: 'Not running in Electron' }
       }
@@ -148,9 +149,19 @@ export function useElectron() {
     },
 
     /**
-     * Get data paths (database and uploads)
+     * Open the logs folder in file explorer (Electron only)
      */
-    async getDataPaths(): Promise<{ databasePath: string; uploadPath: string } | null> {
+    async openLogsFolder(): Promise<{ success: boolean; error?: string }> {
+      if (!electronAPI) {
+        return { success: false, error: 'Not running in Electron' }
+      }
+      return electronAPI.openLogsFolder()
+    },
+
+    /**
+     * Get data paths (database, uploads, and logs)
+     */
+    async getDataPaths(): Promise<{ databasePath: string; uploadPath: string; logsPath: string } | null> {
       if (!electronAPI) return null
       return electronAPI.getDataPaths()
     },

--- a/packages/app/app/pages/settings.vue
+++ b/packages/app/app/pages/settings.vue
@@ -167,6 +167,43 @@
       </v-card-text>
     </v-card>
 
+    <!-- Logs Section -->
+    <v-card class="mt-6">
+      <v-card-text>
+        <div class="mb-4">
+          <h2 class="text-h6 mb-2">
+            {{ $t('settings.sections.logs') }}
+          </h2>
+          <p class="text-medium-emphasis text-body-2">
+            {{ $t('settings.logs.subtitle') }}
+          </p>
+        </div>
+
+        <!-- Log Path Info -->
+        <v-alert v-if="logPath" type="info" variant="tonal" density="compact" class="mb-4">
+          <div class="text-caption">
+            <strong>{{ $t('settings.logs.logPath') }}:</strong><br />
+            {{ logPath }}
+          </div>
+        </v-alert>
+
+        <!-- Open Logs Folder Button (Electron only) -->
+        <v-btn
+          v-if="isElectron"
+          color="secondary"
+          variant="outlined"
+          @click="openLogsFolder"
+        >
+          <v-icon start>mdi-folder-text</v-icon>
+          {{ $t('settings.logs.openFolder') }}
+        </v-btn>
+
+        <div class="mt-2 text-caption text-medium-emphasis">
+          {{ $t('settings.logs.hint') }}
+        </div>
+      </v-card-text>
+    </v-card>
+
     <!-- Announcements Section -->
     <v-card class="mt-6">
       <v-card-text>
@@ -201,20 +238,7 @@
 
 <script setup lang="ts">
 import { useAnnouncements } from '~/composables/useAnnouncements'
-
-// Type declaration for Electron API exposed via preload
-interface ElectronAPI {
-  isElectron: boolean
-  exportDatabase: () => Promise<{ success: boolean; canceled?: boolean; filePath?: string; error?: string }>
-  openUploadsFolder: () => Promise<{ success: boolean; error?: string }>
-  getDataPaths: () => Promise<{ databasePath: string; uploadPath: string }>
-}
-
-declare global {
-  interface Window {
-    electronAPI?: ElectronAPI
-  }
-}
+import { useElectron } from '~/composables/useElectron'
 
 const { t } = useI18n()
 
@@ -237,9 +261,11 @@ function checkAnnouncementState() {
 }
 
 // Electron API detection
-const isElectron = ref(false)
-const dataPaths = ref<{ databasePath: string; uploadPath: string } | null>(null)
+const electron = useElectron()
+const dataPaths = ref<{ databasePath: string; uploadPath: string; logsPath: string } | null>(null)
 const exporting = ref(false)
+const logPath = ref<string | null>(null)
+const isElectron = computed(() => electron.isElectron)
 
 // Settings state
 const apiKey = ref('')
@@ -267,14 +293,14 @@ onMounted(() => {
   loadSettings()
   checkElectron()
   checkAnnouncementState()
+  loadLogPath()
 })
 
-// Check if running in Electron and load data paths
+// Load data paths (Electron only)
 async function checkElectron() {
-  if (typeof window !== 'undefined' && window.electronAPI) {
-    isElectron.value = true
+  if (electron.isElectron) {
     try {
-      dataPaths.value = await window.electronAPI.getDataPaths()
+      dataPaths.value = await electron.getDataPaths()
     } catch (error) {
       console.error('[Settings] Failed to get data paths:', error)
     }
@@ -283,11 +309,11 @@ async function checkElectron() {
 
 // Export database (Electron only)
 async function exportDatabase() {
-  if (!isElectron.value || !window.electronAPI) return
+  if (!electron.isElectron) return
 
   exporting.value = true
   try {
-    const result = await window.electronAPI.exportDatabase()
+    const result = await electron.exportDatabase()
 
     if (result.success) {
       snackbar.value = {
@@ -322,10 +348,10 @@ async function exportDatabase() {
 
 // Open uploads folder (Electron only)
 async function openUploadsFolder() {
-  if (!isElectron.value || !window.electronAPI) return
+  if (!electron.isElectron) return
 
   try {
-    const result = await window.electronAPI.openUploadsFolder()
+    const result = await electron.openUploadsFolder()
 
     if (!result.success) {
       snackbar.value = {
@@ -339,6 +365,40 @@ async function openUploadsFolder() {
     snackbar.value = {
       show: true,
       message: t('settings.dataManagement.openFolderFailed'),
+      color: 'error',
+    }
+  }
+}
+
+// Load log path from backend
+async function loadLogPath() {
+  try {
+    const result = await $fetch<{ logPath: string; logDir: string }>('/api/log-info/path')
+    logPath.value = result.logPath
+  } catch (error) {
+    console.error('[Settings] Failed to load log path:', error)
+  }
+}
+
+// Open logs folder (Electron only)
+async function openLogsFolder() {
+  if (!electron.isElectron) return
+
+  try {
+    const result = await electron.openLogsFolder()
+
+    if (!result.success) {
+      snackbar.value = {
+        show: true,
+        message: `${t('settings.logs.openFolderFailed')}: ${result.error}`,
+        color: 'error',
+      }
+    }
+  } catch (error) {
+    console.error('[Settings] Open logs folder failed:', error)
+    snackbar.value = {
+      show: true,
+      message: t('settings.logs.openFolderFailed'),
       color: 'error',
     }
   }

--- a/packages/app/electron/main.js
+++ b/packages/app/electron/main.js
@@ -1,9 +1,9 @@
 import { app, BrowserWindow, utilityProcess, ipcMain, dialog, shell } from 'electron'
 import pkg from 'electron-updater'
-const { autoUpdater } = pkg
 import path from 'path'
-import { existsSync, mkdirSync, copyFileSync, writeFileSync } from 'fs'
+import { existsSync, mkdirSync, copyFileSync, writeFileSync, appendFileSync } from 'fs'
 import { fileURLToPath } from 'url'
+const { autoUpdater } = pkg
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
@@ -46,7 +46,7 @@ let mainWindow = null
 let serverProcess = null
 
 /**
- * Get user data paths for database and uploads
+ * Get user data paths for database, uploads, and logs
  * In production, these are in app.getPath('userData')
  * In dev mode, these are not used (Nuxt dev server uses default paths)
  */
@@ -58,6 +58,7 @@ function getDataPaths() {
   const userDataPath = app.getPath('userData')
   const dataDir = path.join(userDataPath, 'data')
   const uploadsDir = path.join(userDataPath, 'uploads')
+  const logsDir = path.join(userDataPath, 'logs')
 
   const audioDir = path.join(uploadsDir, 'audio')
 
@@ -71,10 +72,14 @@ function getDataPaths() {
   if (!existsSync(audioDir)) {
     mkdirSync(audioDir, { recursive: true })
   }
+  if (!existsSync(logsDir)) {
+    mkdirSync(logsDir, { recursive: true })
+  }
 
   return {
     databasePath: path.join(dataDir, 'dm-hero.db'),
     uploadPath: uploadsDir,
+    logsPath: logsDir,
   }
 }
 
@@ -125,6 +130,7 @@ async function startServer() {
   console.log('[Electron]   Output dir:', outputDir)
   console.log('[Electron]   DATABASE_PATH:', paths.databasePath)
   console.log('[Electron]   UPLOAD_PATH:', paths.uploadPath)
+  console.log('[Electron]   LOG_PATH:', paths.logsPath)
 
   // Start server as utility process with environment variables
   serverProcess = utilityProcess.fork(serverPath, [], {
@@ -135,6 +141,7 @@ async function startServer() {
       PORT: String(PROD_SERVER_PORT),
       DATABASE_PATH: paths.databasePath,
       UPLOAD_PATH: paths.uploadPath,
+      LOG_PATH: paths.logsPath,
       NITRO_OUTPUT_DIR: outputDir,
     },
     cwd: outputDir,
@@ -255,6 +262,7 @@ ipcMain.handle('get-data-paths', () => {
     return {
       databasePath: path.join(process.cwd(), 'data', 'dm-hero.db'),
       uploadPath: path.join(process.cwd(), 'uploads'),
+      logsPath: path.join(process.cwd(), 'data', 'logs'),
     }
   }
   return getDataPaths()
@@ -302,6 +310,23 @@ ipcMain.handle('open-uploads-folder', async () => {
 
   try {
     await shell.openPath(paths.uploadPath)
+    return { success: true }
+  } catch (error) {
+    return { success: false, error: error.message }
+  }
+})
+
+ipcMain.handle('open-logs-folder', async () => {
+  const paths = isDev
+    ? { logsPath: path.join(process.cwd(), 'data', 'logs') }
+    : getDataPaths()
+
+  if (!existsSync(paths.logsPath)) {
+    mkdirSync(paths.logsPath, { recursive: true })
+  }
+
+  try {
+    await shell.openPath(paths.logsPath)
     return { success: true }
   } catch (error) {
     return { success: false, error: error.message }
@@ -486,6 +511,42 @@ ipcMain.handle('save-file-dialog', async (event, options) => {
   } catch (error) {
     return { success: false, error: error.message }
   }
+})
+
+// ============================================================================
+// UNCAUGHT EXCEPTION HANDLER
+// ============================================================================
+
+function logToFile(message) {
+  try {
+    const paths = getDataPaths()
+    const logsDir = paths?.logsPath || path.join(process.cwd(), 'data', 'logs')
+
+    if (!existsSync(logsDir)) {
+      mkdirSync(logsDir, { recursive: true })
+    }
+
+    const logFile = path.join(logsDir, 'dm-hero.log')
+    const now = new Date()
+    const timestamp = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')} ${String(now.getHours()).padStart(2, '0')}:${String(now.getMinutes()).padStart(2, '0')}:${String(now.getSeconds()).padStart(2, '0')}`
+    const logLine = `[${timestamp}] [FATAL] [Electron Main] ${message}\n`
+
+    appendFileSync(logFile, logLine, 'utf-8')
+  } catch (err) {
+    console.error('[Electron] Failed to write to log file:', err)
+  }
+}
+
+process.on('uncaughtException', (error) => {
+  const message = `Uncaught Exception: ${error.message}\n${error.stack || ''}`
+  console.error('[Electron]', message)
+  logToFile(message)
+})
+
+process.on('unhandledRejection', (reason) => {
+  const message = `Unhandled Rejection: ${reason instanceof Error ? reason.message + '\n' + reason.stack : String(reason)}`
+  console.error('[Electron]', message)
+  logToFile(message)
 })
 
 // App lifecycle

--- a/packages/app/electron/preload.js
+++ b/packages/app/electron/preload.js
@@ -11,6 +11,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
   // Open uploads folder in file explorer
   openUploadsFolder: () => ipcRenderer.invoke('open-uploads-folder'),
 
+  // Open logs folder in file explorer
+  openLogsFolder: () => ipcRenderer.invoke('open-logs-folder'),
+
   // Get data paths info
   getDataPaths: () => ipcRenderer.invoke('get-data-paths'),
 

--- a/packages/app/i18n/locales/de.json
+++ b/packages/app/i18n/locales/de.json
@@ -1451,7 +1451,8 @@
       "openai": "OpenAI Integration",
       "preferences": "Präferenzen",
       "campaign": "Kampagne",
-      "announcements": "Neuigkeiten"
+      "announcements": "Neuigkeiten",
+      "logs": "Protokolle"
     },
     "announcements": {
       "alreadySeen": "Du hast die neuesten Ankündigungen bereits gesehen",
@@ -1490,6 +1491,13 @@
       "exportCanceled": "Export abgebrochen",
       "exportFailed": "Export fehlgeschlagen",
       "openFolderFailed": "Ordner konnte nicht geöffnet werden"
+    },
+    "logs": {
+      "subtitle": "Fehler und Warnungen werden in eine Log-Datei geschrieben",
+      "logPath": "Log-Datei",
+      "openFolder": "Log-Ordner öffnen",
+      "hint": "Log-Dateien helfen bei der Fehlersuche. Max. 5 MB pro Datei, 3 Dateien werden aufbewahrt.",
+      "openFolderFailed": "Log-Ordner konnte nicht geöffnet werden"
     }
   },
   "players": {

--- a/packages/app/i18n/locales/en.json
+++ b/packages/app/i18n/locales/en.json
@@ -1458,7 +1458,8 @@
       "openai": "OpenAI Integration",
       "preferences": "Preferences",
       "campaign": "Campaign",
-      "announcements": "Announcements"
+      "announcements": "Announcements",
+      "logs": "Logs"
     },
     "announcements": {
       "alreadySeen": "You have already seen the latest announcements",
@@ -1497,6 +1498,13 @@
       "exportCanceled": "Export canceled",
       "exportFailed": "Export failed",
       "openFolderFailed": "Could not open folder"
+    },
+    "logs": {
+      "subtitle": "Errors and warnings are written to a log file",
+      "logPath": "Log File",
+      "openFolder": "Open Logs Folder",
+      "hint": "Log files help with troubleshooting. Max 5 MB per file, 3 files are retained.",
+      "openFolderFailed": "Could not open logs folder"
     }
   },
   "players": {

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -158,6 +158,7 @@
     "@types/archiver": "^7.0.0",
     "@types/better-sqlite3": "^7.6.13",
     "@types/leaflet": "^1.9.21",
+    "@types/node": "^25.0.3",
     "@types/unzipper": "^0.10.11",
     "@typescript-eslint/eslint-plugin": "^8.46.3",
     "@typescript-eslint/parser": "^8.46.3",

--- a/packages/app/server/api/log-info/path.get.ts
+++ b/packages/app/server/api/log-info/path.get.ts
@@ -1,0 +1,8 @@
+import { getLogPath, getLogDir } from '~~/server/utils/logger'
+
+export default defineEventHandler(() => {
+  return {
+    logPath: getLogPath(),
+    logDir: getLogDir(),
+  }
+})

--- a/packages/app/server/plugins/error-logger.ts
+++ b/packages/app/server/plugins/error-logger.ts
@@ -1,0 +1,41 @@
+import { logger } from '../utils/logger'
+
+// Store original console methods
+const originalConsoleError = console.error
+const originalConsoleWarn = console.warn
+
+export default defineNitroPlugin((nitroApp) => {
+  // Skip during build/prerender
+  if (process.env.NUXT_BUILD || process.env.NITRO_PRERENDER || import.meta.prerender) {
+    return
+  }
+
+  console.log('📝 Initializing error logger...')
+
+  // Intercept console.error
+  console.error = (...args: unknown[]) => {
+    // Write to log file
+    logger.error(...args)
+    // Still output to console
+    originalConsoleError(...args)
+  }
+
+  // Intercept console.warn
+  console.warn = (...args: unknown[]) => {
+    // Write to log file
+    logger.warn(...args)
+    // Still output to console
+    originalConsoleWarn(...args)
+  }
+
+  // Hook into Nitro errors (unhandled API errors)
+  nitroApp.hooks.hook('error', (error) => {
+    logger.error('[Unhandled API Error]', error)
+  })
+
+  // Log startup info
+  logger.info('DM Hero started')
+  logger.info(`Log file: ${logger.getPath()}`)
+
+  console.log(`✅ Error logger ready (${logger.getPath()})`)
+})

--- a/packages/app/server/utils/logger.ts
+++ b/packages/app/server/utils/logger.ts
@@ -1,0 +1,180 @@
+import { existsSync, mkdirSync, appendFileSync, statSync, renameSync, unlinkSync } from 'fs'
+import { join, dirname } from 'path'
+
+export type LogLevel = 'DEBUG' | 'INFO' | 'WARN' | 'ERROR' | 'FATAL'
+
+interface LoggerConfig {
+  maxFileSize: number // Max size in bytes before rotation
+  maxFiles: number // Number of rotated files to keep
+}
+
+const DEFAULT_CONFIG: LoggerConfig = {
+  maxFileSize: 5 * 1024 * 1024, // 5MB
+  maxFiles: 3,
+}
+
+let logPath: string | null = null
+let config: LoggerConfig = DEFAULT_CONFIG
+
+/**
+ * Get the path to the log file
+ */
+export function getLogPath(): string {
+  if (logPath) return logPath
+
+  // Use LOG_PATH env var (set by Electron) or default to data/logs
+  const logDir = process.env.LOG_PATH || join(process.cwd(), 'data', 'logs')
+
+  // Ensure log directory exists
+  if (!existsSync(logDir)) {
+    mkdirSync(logDir, { recursive: true })
+  }
+
+  logPath = join(logDir, 'dm-hero.log')
+  return logPath
+}
+
+/**
+ * Get the log directory path (for opening in file explorer)
+ */
+export function getLogDir(): string {
+  return dirname(getLogPath())
+}
+
+/**
+ * Format a timestamp for log entries
+ */
+function formatTimestamp(): string {
+  const now = new Date()
+  const year = now.getFullYear()
+  const month = String(now.getMonth() + 1).padStart(2, '0')
+  const day = String(now.getDate()).padStart(2, '0')
+  const hours = String(now.getHours()).padStart(2, '0')
+  const minutes = String(now.getMinutes()).padStart(2, '0')
+  const seconds = String(now.getSeconds()).padStart(2, '0')
+  return `${year}-${month}-${day} ${hours}:${minutes}:${seconds}`
+}
+
+/**
+ * Format log arguments into a string
+ */
+function formatArgs(args: unknown[]): string {
+  return args
+    .map((arg) => {
+      if (arg instanceof Error) {
+        return `${arg.message}\n${arg.stack || ''}`
+      }
+      if (typeof arg === 'object') {
+        try {
+          return JSON.stringify(arg, null, 2)
+        } catch {
+          return String(arg)
+        }
+      }
+      return String(arg)
+    })
+    .join(' ')
+}
+
+/**
+ * Rotate log files if current file exceeds max size
+ *
+ * Rotation chain (for maxFiles=3):
+ * 1. Delete .log.3 if exists (oldest)
+ * 2. Rename .log.2 -> .log.3
+ * 3. Rename .log.1 -> .log.2
+ * 4. Rename .log -> .log.1 (current becomes .1)
+ */
+function rotateIfNeeded(): void {
+  const path = getLogPath()
+
+  if (!existsSync(path)) return
+
+  try {
+    const stats = statSync(path)
+    if (stats.size < config.maxFileSize) return
+
+    // Delete oldest file if it exists
+    const oldestPath = `${path}.${config.maxFiles}`
+    if (existsSync(oldestPath)) {
+      try {
+        unlinkSync(oldestPath)
+      } catch {
+        // Ignore deletion errors
+      }
+    }
+
+    // Rotate existing numbered files: .log.2 -> .log.3, .log.1 -> .log.2
+    for (let i = config.maxFiles - 1; i >= 1; i--) {
+      const oldPath = `${path}.${i}`
+      const newPath = `${path}.${i + 1}`
+
+      if (existsSync(oldPath)) {
+        renameSync(oldPath, newPath)
+      }
+    }
+
+    // Rename current log to .1
+    renameSync(path, `${path}.1`)
+  } catch (err) {
+    // Ignore rotation errors - logging should not break the app
+    console.warn('[Logger] Rotation failed:', err)
+  }
+}
+
+/**
+ * Write a log entry to the file
+ */
+export function writeLog(level: LogLevel, ...args: unknown[]): void {
+  try {
+    rotateIfNeeded()
+
+    const timestamp = formatTimestamp()
+    const message = formatArgs(args)
+    const logLine = `[${timestamp}] [${level}] ${message}\n`
+
+    const path = getLogPath()
+    appendFileSync(path, logLine, 'utf-8')
+  } catch (err) {
+    // Fallback to console if file logging fails
+    console.warn('[Logger] Failed to write log:', err)
+  }
+}
+
+/**
+ * Log helper functions
+ */
+export const logger = {
+  debug: (...args: unknown[]) => writeLog('DEBUG', ...args),
+  info: (...args: unknown[]) => writeLog('INFO', ...args),
+  warn: (...args: unknown[]) => writeLog('WARN', ...args),
+  error: (...args: unknown[]) => writeLog('ERROR', ...args),
+  fatal: (...args: unknown[]) => writeLog('FATAL', ...args),
+
+  /**
+   * Get the current log file path
+   */
+  getPath: getLogPath,
+
+  /**
+   * Get the log directory path
+   */
+  getDir: getLogDir,
+
+  /**
+   * Configure the logger
+   */
+  configure: (newConfig: Partial<LoggerConfig>) => {
+    config = { ...config, ...newConfig }
+  },
+
+  /**
+   * Reset logger state (for testing only)
+   */
+  _reset: () => {
+    logPath = null
+    config = { ...DEFAULT_CONFIG }
+  },
+}
+
+export default logger

--- a/packages/app/test/unit/logger.test.ts
+++ b/packages/app/test/unit/logger.test.ts
@@ -1,0 +1,517 @@
+/// <reference types="node" />
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { existsSync, mkdirSync, rmSync, readFileSync } from 'fs'
+import { join } from 'path'
+
+// Test directory for isolated testing
+const TEST_LOG_DIR = join(process.cwd(), 'test', 'unit', '.test-logs')
+const TEST_LOG_FILE = join(TEST_LOG_DIR, 'dm-hero.log')
+
+// We need to mock the logger module to use our test directory
+// Import fresh module for each test
+async function getLogger() {
+  // Clear module cache to get fresh instance
+  vi.resetModules()
+
+  // Set environment variable before importing
+  process.env.LOG_PATH = TEST_LOG_DIR
+
+  const loggerModule = await import('../../server/utils/logger')
+
+  // Reset logger state to pick up new LOG_PATH
+  loggerModule.logger._reset()
+
+  return loggerModule
+}
+
+describe('Logger Utility', () => {
+  beforeEach(() => {
+    // Clean up test directory before each test
+    if (existsSync(TEST_LOG_DIR)) {
+      rmSync(TEST_LOG_DIR, { recursive: true })
+    }
+    mkdirSync(TEST_LOG_DIR, { recursive: true })
+  })
+
+  afterEach(() => {
+    // Clean up after each test
+    if (existsSync(TEST_LOG_DIR)) {
+      rmSync(TEST_LOG_DIR, { recursive: true })
+    }
+    delete process.env.LOG_PATH
+  })
+
+  describe('Basic Logging', () => {
+    it('should create log file on first write', async () => {
+      const { writeLog } = await getLogger()
+
+      writeLog('INFO', 'Test message')
+
+      expect(existsSync(TEST_LOG_FILE)).toBe(true)
+    })
+
+    it('should write log with correct timestamp format', async () => {
+      const { writeLog } = await getLogger()
+
+      writeLog('INFO', 'Test message')
+
+      const content = readFileSync(TEST_LOG_FILE, 'utf-8')
+      // Format: [YYYY-MM-DD HH:MM:SS] [LEVEL] message
+      expect(content).toMatch(/^\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\] \[INFO\] Test message\n$/)
+    })
+
+    it('should write all log levels correctly', async () => {
+      const { writeLog } = await getLogger()
+
+      writeLog('DEBUG', 'Debug message')
+      writeLog('INFO', 'Info message')
+      writeLog('WARN', 'Warn message')
+      writeLog('ERROR', 'Error message')
+      writeLog('FATAL', 'Fatal message')
+
+      const content = readFileSync(TEST_LOG_FILE, 'utf-8')
+      expect(content).toContain('[DEBUG] Debug message')
+      expect(content).toContain('[INFO] Info message')
+      expect(content).toContain('[WARN] Warn message')
+      expect(content).toContain('[ERROR] Error message')
+      expect(content).toContain('[FATAL] Fatal message')
+    })
+
+    it('should append multiple log entries', async () => {
+      const { writeLog } = await getLogger()
+
+      writeLog('INFO', 'First message')
+      writeLog('INFO', 'Second message')
+      writeLog('INFO', 'Third message')
+
+      const content = readFileSync(TEST_LOG_FILE, 'utf-8')
+      const lines = content.trim().split('\n')
+      expect(lines).toHaveLength(3)
+    })
+  })
+
+  describe('Message Formatting', () => {
+    it('should format Error objects with stack trace', async () => {
+      const { writeLog } = await getLogger()
+
+      const error = new Error('Test error')
+      writeLog('ERROR', error)
+
+      const content = readFileSync(TEST_LOG_FILE, 'utf-8')
+      expect(content).toContain('Test error')
+      expect(content).toContain('Error:')
+    })
+
+    it('should format objects as JSON', async () => {
+      const { writeLog } = await getLogger()
+
+      writeLog('INFO', { key: 'value', nested: { a: 1 } })
+
+      const content = readFileSync(TEST_LOG_FILE, 'utf-8')
+      expect(content).toContain('"key": "value"')
+      expect(content).toContain('"nested"')
+    })
+
+    it('should handle multiple arguments', async () => {
+      const { writeLog } = await getLogger()
+
+      writeLog('INFO', 'Message:', 123, { data: true })
+
+      const content = readFileSync(TEST_LOG_FILE, 'utf-8')
+      expect(content).toContain('Message:')
+      expect(content).toContain('123')
+      expect(content).toContain('"data": true')
+    })
+
+    it('should handle empty messages gracefully', async () => {
+      const { writeLog } = await getLogger()
+
+      // Should not throw
+      expect(() => writeLog('INFO')).not.toThrow()
+      expect(existsSync(TEST_LOG_FILE)).toBe(true)
+    })
+
+    it('should handle null and undefined values', async () => {
+      const { writeLog } = await getLogger()
+
+      expect(() => writeLog('INFO', null, undefined, 'text')).not.toThrow()
+
+      const content = readFileSync(TEST_LOG_FILE, 'utf-8')
+      expect(content).toContain('null')
+      expect(content).toContain('undefined')
+      expect(content).toContain('text')
+    })
+
+    it('should handle special characters', async () => {
+      const { writeLog } = await getLogger()
+
+      writeLog('INFO', 'Special: äöü ß € 日本語 🎲')
+
+      const content = readFileSync(TEST_LOG_FILE, 'utf-8')
+      expect(content).toContain('äöü ß € 日本語 🎲')
+    })
+
+    it('should handle very long messages', async () => {
+      const { writeLog } = await getLogger()
+
+      const longMessage = 'A'.repeat(10000)
+      expect(() => writeLog('INFO', longMessage)).not.toThrow()
+
+      const content = readFileSync(TEST_LOG_FILE, 'utf-8')
+      expect(content).toContain(longMessage)
+    })
+
+    it('should handle circular references in objects', async () => {
+      const { writeLog } = await getLogger()
+
+      const circular: Record<string, unknown> = { a: 1 }
+      circular.self = circular
+
+      // Should not throw, should fallback to String(obj)
+      expect(() => writeLog('INFO', circular)).not.toThrow()
+    })
+  })
+
+  describe('File Rotation', () => {
+    it('should rotate log file when size limit exceeded', async () => {
+      const { writeLog, logger } = await getLogger()
+
+      // Configure small file size for testing (1KB)
+      logger.configure({ maxFileSize: 1024, maxFiles: 3 })
+
+      // Write enough data to trigger rotation (each line ~50 bytes, need >20 lines)
+      for (let i = 0; i < 30; i++) {
+        writeLog('INFO', `Log entry number ${i} with some padding text here`)
+      }
+
+      // Check that rotation happened
+      expect(existsSync(TEST_LOG_FILE)).toBe(true)
+      expect(existsSync(`${TEST_LOG_FILE}.1`)).toBe(true)
+    })
+
+    it('should keep only configured number of rotated files', async () => {
+      const { writeLog, logger } = await getLogger()
+
+      // Configure very small file size and 2 max files
+      logger.configure({ maxFileSize: 512, maxFiles: 2 })
+
+      // Write lots of data to trigger multiple rotations
+      for (let i = 0; i < 100; i++) {
+        writeLog('INFO', `Log entry ${i} with padding to fill up space quickly`)
+      }
+
+      // Should have: dm-hero.log, dm-hero.log.1, dm-hero.log.2
+      // But NOT dm-hero.log.3 (since maxFiles = 2, we keep current + 2 rotated)
+      expect(existsSync(TEST_LOG_FILE)).toBe(true)
+      // Oldest files should be deleted
+      expect(existsSync(`${TEST_LOG_FILE}.3`)).toBe(false)
+      expect(existsSync(`${TEST_LOG_FILE}.4`)).toBe(false)
+    })
+
+    it('should preserve log content during rotation', async () => {
+      const { writeLog, logger } = await getLogger()
+
+      logger.configure({ maxFileSize: 512, maxFiles: 3 })
+
+      // Write identifiable entries
+      writeLog('INFO', 'MARKER_FIRST_ENTRY')
+
+      // Trigger rotation
+      for (let i = 0; i < 50; i++) {
+        writeLog('INFO', `Padding entry ${i} to trigger rotation mechanism`)
+      }
+
+      writeLog('INFO', 'MARKER_LAST_ENTRY')
+
+      // Check that entries are preserved (either in main or rotated file)
+      const mainContent = readFileSync(TEST_LOG_FILE, 'utf-8')
+      const rotatedContent = existsSync(`${TEST_LOG_FILE}.1`)
+        ? readFileSync(`${TEST_LOG_FILE}.1`, 'utf-8')
+        : ''
+
+      const allContent = mainContent + rotatedContent
+      expect(allContent).toContain('MARKER_LAST_ENTRY')
+    })
+
+    it('should complete full rotation cycle (delete oldest, rotate all)', async () => {
+      const { writeLog, logger } = await getLogger()
+      const { readdirSync, statSync } = await import('fs')
+
+      // Helper to show current state
+      const showFiles = (phase: string) => {
+        const files = readdirSync(TEST_LOG_DIR).sort()
+        console.log(`[${phase}] Dateien:`, files.map((f) => {
+          const size = statSync(join(TEST_LOG_DIR, f)).size
+          return `${f}(${size}b)`
+        }))
+      }
+
+      // Configure: max 2 rotated files (.log.1, .log.2) + current .log
+      // Use 300 bytes - each log line is ~80-100 bytes with timestamp
+      logger.configure({ maxFileSize: 300, maxFiles: 2 })
+
+      // Phase 1: Fill up to trigger first rotation (.log -> .log.1)
+      for (let i = 0; i < 5; i++) {
+        writeLog('INFO', `PHASE1_ENTRY_${i} - Filling up the first log file to trigger rotation`)
+      }
+      showFiles('Nach PHASE1')
+
+      // Verify .log.1 exists after first rotation
+      expect(existsSync(`${TEST_LOG_FILE}.1`)).toBe(true)
+
+      // Phase 2: Continue writing to trigger second rotation (.log.1 -> .log.2)
+      for (let i = 0; i < 5; i++) {
+        writeLog('INFO', `PHASE2_ENTRY_${i} - Second phase to push older entries to .log.2`)
+      }
+      showFiles('Nach PHASE2')
+
+      // Verify .log.2 exists after second rotation
+      expect(existsSync(`${TEST_LOG_FILE}.2`)).toBe(true)
+
+      // Phase 3: Continue - should delete .log.2 (oldest) and rotate others
+      // First capture what's in .log.2 before it gets deleted
+      const oldestContent = readFileSync(`${TEST_LOG_FILE}.2`, 'utf-8')
+      expect(oldestContent).toContain('PHASE1') // Oldest content is in .2
+
+      for (let i = 0; i < 5; i++) {
+        writeLog('INFO', `PHASE3_ENTRY_${i} - Third phase should trigger oldest file deletion`)
+      }
+      showFiles('Nach PHASE3')
+
+      // After full cycle:
+      // - .log.3 should NOT exist (maxFiles=2 means we keep .1 and .2 only)
+      expect(existsSync(`${TEST_LOG_FILE}.3`)).toBe(false)
+
+      // Current .log should have newest entries
+      const currentContent = readFileSync(TEST_LOG_FILE, 'utf-8')
+      expect(currentContent).toContain('PHASE3')
+
+      // Verify the rotation chain worked - check what's now in .log.2
+      const newLog2Content = readFileSync(`${TEST_LOG_FILE}.2`, 'utf-8')
+      // .log.2 should now contain PHASE2 content (was previously in .log.1)
+      expect(newLog2Content).toContain('PHASE2')
+
+      console.log('[Rotation] .log.2 enthält jetzt PHASE2 ✓ (war vorher PHASE1, wurde rotiert)')
+    })
+
+    it('should continue correctly after app restart (persist rotation state)', async () => {
+      // Simulate first app session
+      const session1 = await getLogger()
+      session1.logger.configure({ maxFileSize: 300, maxFiles: 2 })
+
+      // Write some logs in first session
+      for (let i = 0; i < 5; i++) {
+        session1.writeLog('INFO', `SESSION1_ENTRY_${i} - First app session logs here`)
+      }
+
+      // Verify files exist after first session
+      expect(existsSync(TEST_LOG_FILE)).toBe(true)
+      expect(existsSync(`${TEST_LOG_FILE}.1`)).toBe(true)
+
+      // Simulate app restart - get fresh logger instance
+      const session2 = await getLogger()
+      session2.logger.configure({ maxFileSize: 300, maxFiles: 2 })
+
+      // Write logs in second session
+      for (let i = 0; i < 5; i++) {
+        session2.writeLog('INFO', `SESSION2_ENTRY_${i} - Second app session continues`)
+      }
+
+      // Verify rotation continued correctly across sessions
+      // - Old .log.1 should now be in .log.2 (rotated)
+      // - New .log.1 should contain mix of session1 and session2
+      expect(existsSync(`${TEST_LOG_FILE}.2`)).toBe(true)
+
+      // Current log should have SESSION2 entries
+      const currentContent = readFileSync(TEST_LOG_FILE, 'utf-8')
+      expect(currentContent).toContain('SESSION2')
+
+      console.log('[App Restart] Rotation funktioniert über Neustarts hinweg ✓')
+    })
+  })
+
+  describe('Error Handling', () => {
+    it('should continue logging when file is temporarily inaccessible', async () => {
+      const { writeLog } = await getLogger()
+      const { chmodSync } = await import('fs')
+
+      // Write initial entry
+      writeLog('INFO', 'Entry before lock')
+      expect(existsSync(TEST_LOG_FILE)).toBe(true)
+
+      // Make file read-only (simulates locked file on some systems)
+      chmodSync(TEST_LOG_FILE, 0o444)
+
+      // This should NOT throw - logger catches errors internally
+      expect(() => writeLog('ERROR', 'Entry during lock attempt')).not.toThrow()
+
+      // Restore write permissions
+      chmodSync(TEST_LOG_FILE, 0o644)
+
+      // Should be able to write again after unlock
+      writeLog('INFO', 'Entry after unlock')
+
+      const content = readFileSync(TEST_LOG_FILE, 'utf-8')
+      expect(content).toContain('Entry before lock')
+      expect(content).toContain('Entry after unlock')
+    })
+
+    it('should not crash app when rotation fails due to locked file', async () => {
+      const { writeLog, logger } = await getLogger()
+      const { chmodSync } = await import('fs')
+
+      logger.configure({ maxFileSize: 100, maxFiles: 2 })
+
+      // Fill up log to trigger rotation
+      writeLog('INFO', 'Fill entry 1 with lots of padding text here')
+
+      // Make directory read-only (prevents creating .log.1)
+      chmodSync(TEST_LOG_DIR, 0o555)
+
+      // This triggers rotation attempt which will fail - should NOT crash
+      expect(() => {
+        writeLog('INFO', 'Entry that triggers failed rotation attempt here')
+      }).not.toThrow()
+
+      // Restore permissions
+      chmodSync(TEST_LOG_DIR, 0o755)
+
+      // Logger should still work after failed rotation
+      writeLog('INFO', 'Entry after rotation failure recovered')
+
+      // Verify app didn't crash and can still read log
+      expect(existsSync(TEST_LOG_FILE)).toBe(true)
+    })
+
+    it('should not throw when log directory does not exist (creates it)', async () => {
+      // Remove test dir
+      rmSync(TEST_LOG_DIR, { recursive: true })
+
+      const { writeLog } = await getLogger()
+
+      // Should create directory and write
+      expect(() => writeLog('INFO', 'Test')).not.toThrow()
+      expect(existsSync(TEST_LOG_FILE)).toBe(true)
+    })
+
+    it('should handle rapid successive writes', async () => {
+      const { writeLog } = await getLogger()
+
+      // Simulate rapid logging (like during an error cascade)
+      for (let i = 0; i < 100; i++) {
+        // writeLog is sync, but let's ensure it doesn't break
+        expect(() => writeLog('INFO', `Rapid write ${i}`)).not.toThrow()
+      }
+
+      const content = readFileSync(TEST_LOG_FILE, 'utf-8')
+      const lines = content.trim().split('\n')
+      expect(lines).toHaveLength(100)
+    })
+
+    it('should not crash on write failure (logs warning instead)', async () => {
+      const { writeLog } = await getLogger()
+
+      // Make log file read-only to simulate write failure
+      writeLog('INFO', 'Initial entry')
+
+      // This is tricky to test without actually breaking permissions
+      // The logger catches errors and logs to console.warn
+      // For now, verify the try-catch exists by checking no throw on normal write
+      expect(() => writeLog('INFO', 'Another entry')).not.toThrow()
+    })
+  })
+
+  describe('Logger Helper Methods', () => {
+    it('should expose all log level methods', async () => {
+      const { logger } = await getLogger()
+
+      expect(typeof logger.debug).toBe('function')
+      expect(typeof logger.info).toBe('function')
+      expect(typeof logger.warn).toBe('function')
+      expect(typeof logger.error).toBe('function')
+      expect(typeof logger.fatal).toBe('function')
+    })
+
+    it('should write via helper methods', async () => {
+      const { logger } = await getLogger()
+
+      logger.info('Info via helper')
+      logger.error('Error via helper')
+
+      const content = readFileSync(TEST_LOG_FILE, 'utf-8')
+      expect(content).toContain('[INFO] Info via helper')
+      expect(content).toContain('[ERROR] Error via helper')
+    })
+
+    it('should return correct log path', async () => {
+      const { logger } = await getLogger()
+
+      const path = logger.getPath()
+      expect(path).toBe(TEST_LOG_FILE)
+    })
+
+    it('should return correct log directory', async () => {
+      const { logger } = await getLogger()
+
+      const dir = logger.getDir()
+      expect(dir).toBe(TEST_LOG_DIR)
+    })
+  })
+
+  describe('Configuration', () => {
+    it('should allow reconfiguring max file size', async () => {
+      const { logger, writeLog } = await getLogger()
+
+      logger.configure({ maxFileSize: 100 })
+
+      // Write enough to trigger rotation with small size
+      for (let i = 0; i < 10; i++) {
+        writeLog('INFO', 'Short message for rotation test')
+      }
+
+      // Should have rotated due to small file size
+      expect(existsSync(`${TEST_LOG_FILE}.1`)).toBe(true)
+    })
+
+    it('should allow reconfiguring max files', async () => {
+      const { logger, writeLog } = await getLogger()
+
+      logger.configure({ maxFileSize: 100, maxFiles: 1 })
+
+      // Write enough to trigger multiple rotations
+      for (let i = 0; i < 50; i++) {
+        writeLog('INFO', 'Message for rotation limiting test')
+      }
+
+      // With maxFiles: 1, should only keep .log and .log.1
+      expect(existsSync(TEST_LOG_FILE)).toBe(true)
+      // .log.2 should be deleted
+      expect(existsSync(`${TEST_LOG_FILE}.2`)).toBe(false)
+    })
+  })
+
+  describe('Timestamp Accuracy', () => {
+    it('should use current timestamp for each entry', async () => {
+      const { writeLog } = await getLogger()
+
+      writeLog('INFO', 'First')
+
+      // Small delay
+      await new Promise((resolve) => setTimeout(resolve, 1100))
+
+      writeLog('INFO', 'Second')
+
+      const content = readFileSync(TEST_LOG_FILE, 'utf-8')
+      const lines = content.trim().split('\n')
+
+      // Extract timestamps
+      const timestamp1 = lines[0].match(/\[(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})\]/)?.[1]
+      const timestamp2 = lines[1].match(/\[(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})\]/)?.[1]
+
+      expect(timestamp1).toBeDefined()
+      expect(timestamp2).toBeDefined()
+      // Timestamps should be different (at least 1 second apart)
+      expect(timestamp1).not.toBe(timestamp2)
+    })
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,7 +17,7 @@ importers:
         version: 0.5.2(encoding@0.1.13)
       '@changesets/cli':
         specifier: ^2.29.8
-        version: 2.29.8(@types/node@24.10.1)
+        version: 2.29.8(@types/node@25.0.3)
 
   packages/app:
     dependencies:
@@ -32,7 +32,7 @@ importers:
         version: 7.4.47
       '@nuxt/test-utils':
         specifier: 3.20.1
-        version: 3.20.1(@vue/test-utils@2.4.6)(happy-dom@20.0.11)(magicast@0.5.1)(typescript@5.9.3)(vitest@4.0.14(@types/node@24.10.1)(happy-dom@20.0.11)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))
+        version: 3.20.1(@vue/test-utils@2.4.6)(happy-dom@20.0.11)(magicast@0.5.1)(typescript@5.9.3)(vitest@4.0.14(@types/node@25.0.3)(happy-dom@20.0.11)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))
       '@nuxtjs/i18n':
         specifier: ^10.2.0
         version: 10.2.1(@vue/compiler-dom@3.5.25)(db0@0.3.4(better-sqlite3@12.5.0)(mysql2@3.15.3))(eslint@9.39.1(jiti@2.6.1))(ioredis@5.8.2)(magicast@0.5.1)(rollup@4.53.3)(vue@3.5.25(typescript@5.9.3))
@@ -71,7 +71,7 @@ importers:
         version: 6.2.0(vue@3.5.25(typescript@5.9.3))
       nuxt:
         specifier: ^4.2.1
-        version: 4.2.1(@parcel/watcher@2.5.1)(@types/node@24.10.1)(@vue/compiler-sfc@3.5.25)(better-sqlite3@12.5.0)(db0@0.3.4(better-sqlite3@12.5.0)(mysql2@3.15.3))(encoding@0.1.13)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.8.2)(magicast@0.5.1)(mysql2@3.15.3)(optionator@0.9.4)(rollup@4.53.3)(terser@5.44.1)(typescript@5.9.3)(vite@7.2.4(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))(yaml@2.8.2)
+        version: 4.2.1(@parcel/watcher@2.5.1)(@types/node@25.0.3)(@vue/compiler-sfc@3.5.25)(better-sqlite3@12.5.0)(db0@0.3.4(better-sqlite3@12.5.0)(mysql2@3.15.3))(encoding@0.1.13)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.8.2)(magicast@0.5.1)(mysql2@3.15.3)(optionator@0.9.4)(rollup@4.53.3)(terser@5.44.1)(typescript@5.9.3)(vite@7.2.4(@types/node@25.0.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))(yaml@2.8.2)
       pinia:
         specifier: ^3.0.4
         version: 3.0.4(typescript@5.9.3)(vue@3.5.25(typescript@5.9.3))
@@ -83,7 +83,7 @@ importers:
         version: 0.12.3
       vite-plugin-vuetify:
         specifier: ^2.1.2
-        version: 2.1.2(vite@7.2.4(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))(vue@3.5.25(typescript@5.9.3))(vuetify@3.11.0)
+        version: 2.1.2(vite@7.2.4(@types/node@25.0.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))(vue@3.5.25(typescript@5.9.3))(vuetify@3.11.0)
       vue:
         specifier: ^3.5.24
         version: 3.5.25(typescript@5.9.3)
@@ -105,7 +105,7 @@ importers:
         version: 4.0.1
       '@nuxt/eslint':
         specifier: 1.10.0
-        version: 1.10.0(@typescript-eslint/utils@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(@vue/compiler-sfc@3.5.25)(eslint@9.39.1(jiti@2.6.1))(magicast@0.5.1)(typescript@5.9.3)(vite@7.2.4(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))
+        version: 1.10.0(@typescript-eslint/utils@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(@vue/compiler-sfc@3.5.25)(eslint@9.39.1(jiti@2.6.1))(magicast@0.5.1)(typescript@5.9.3)(vite@7.2.4(@types/node@25.0.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))
       '@oxc-minify/binding-linux-x64-gnu':
         specifier: ^0.97.0
         version: 0.97.0
@@ -127,6 +127,9 @@ importers:
       '@types/leaflet':
         specifier: ^1.9.21
         version: 1.9.21
+      '@types/node':
+        specifier: ^25.0.3
+        version: 25.0.3
       '@types/unzipper':
         specifier: ^0.10.11
         version: 0.10.11
@@ -138,10 +141,10 @@ importers:
         version: 8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
       '@vitejs/plugin-vue':
         specifier: ^6.0.1
-        version: 6.0.2(vite@7.2.4(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))(vue@3.5.25(typescript@5.9.3))
+        version: 6.0.2(vite@7.2.4(@types/node@25.0.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))(vue@3.5.25(typescript@5.9.3))
       '@vitest/coverage-v8':
         specifier: ^4.0.16
-        version: 4.0.16(vitest@4.0.14(@types/node@24.10.1)(happy-dom@20.0.11)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))
+        version: 4.0.16(vitest@4.0.14(@types/node@25.0.3)(happy-dom@20.0.11)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))
       '@vue/test-utils':
         specifier: ^2.4.6
         version: 2.4.6
@@ -177,10 +180,10 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^7.2.4
-        version: 7.2.4(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2)
+        version: 7.2.4(@types/node@25.0.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2)
       vitest:
         specifier: ^4.0.8
-        version: 4.0.14(@types/node@24.10.1)(happy-dom@20.0.11)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2)
+        version: 4.0.14(@types/node@25.0.3)(happy-dom@20.0.11)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2)
       wait-on:
         specifier: ^9.0.3
         version: 9.0.3
@@ -195,10 +198,10 @@ importers:
         version: 3.9.0(better-sqlite3@12.5.0)(magicast@0.5.1)(mysql2@3.15.3)
       '@nuxt/eslint':
         specifier: 1.11.0
-        version: 1.11.0(@typescript-eslint/utils@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(@vue/compiler-sfc@3.5.25)(eslint@9.39.1(jiti@2.6.1))(magicast@0.5.1)(typescript@5.9.3)(vite@7.2.4(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))
+        version: 1.11.0(@typescript-eslint/utils@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(@vue/compiler-sfc@3.5.25)(eslint@9.39.1(jiti@2.6.1))(magicast@0.5.1)(typescript@5.9.3)(vite@7.2.4(@types/node@25.0.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))
       '@nuxt/test-utils':
         specifier: 3.20.1
-        version: 3.20.1(@vue/test-utils@2.4.6)(happy-dom@20.0.11)(magicast@0.5.1)(typescript@5.9.3)(vitest@4.0.14(@types/node@24.10.1)(happy-dom@20.0.11)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))
+        version: 3.20.1(@vue/test-utils@2.4.6)(happy-dom@20.0.11)(magicast@0.5.1)(typescript@5.9.3)(vitest@4.0.14(@types/node@25.0.3)(happy-dom@20.0.11)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))
       '@nuxtjs/i18n':
         specifier: ^10.2.1
         version: 10.2.1(@vue/compiler-dom@3.5.25)(db0@0.3.4(better-sqlite3@12.5.0)(mysql2@3.15.3))(eslint@9.39.1(jiti@2.6.1))(ioredis@5.8.2)(magicast@0.5.1)(rollup@4.53.3)(vue@3.5.25(typescript@5.9.3))
@@ -252,13 +255,13 @@ importers:
         version: 7.0.11
       nuxt:
         specifier: ^4.2.1
-        version: 4.2.1(@parcel/watcher@2.5.1)(@types/node@24.10.1)(@vue/compiler-sfc@3.5.25)(better-sqlite3@12.5.0)(db0@0.3.4(better-sqlite3@12.5.0)(mysql2@3.15.3))(encoding@0.1.13)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.8.2)(magicast@0.5.1)(mysql2@3.15.3)(optionator@0.9.4)(rollup@4.53.3)(terser@5.44.1)(typescript@5.9.3)(vite@7.2.4(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))(yaml@2.8.2)
+        version: 4.2.1(@parcel/watcher@2.5.1)(@types/node@25.0.3)(@vue/compiler-sfc@3.5.25)(better-sqlite3@12.5.0)(db0@0.3.4(better-sqlite3@12.5.0)(mysql2@3.15.3))(encoding@0.1.13)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.8.2)(magicast@0.5.1)(mysql2@3.15.3)(optionator@0.9.4)(rollup@4.53.3)(terser@5.44.1)(typescript@5.9.3)(vite@7.2.4(@types/node@25.0.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))(yaml@2.8.2)
       pinia:
         specifier: ^3.0.4
         version: 3.0.4(typescript@5.9.3)(vue@3.5.25(typescript@5.9.3))
       vite-plugin-vuetify:
         specifier: ^2.1.2
-        version: 2.1.2(vite@7.2.4(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))(vue@3.5.25(typescript@5.9.3))(vuetify@3.11.0)
+        version: 2.1.2(vite@7.2.4(@types/node@25.0.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))(vue@3.5.25(typescript@5.9.3))(vuetify@3.11.0)
       vue:
         specifier: ^3.5.25
         version: 3.5.25(typescript@5.9.3)
@@ -289,7 +292,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.14
-        version: 4.0.14(@types/node@24.10.1)(happy-dom@20.0.11)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2)
+        version: 4.0.14(@types/node@25.0.3)(happy-dom@20.0.11)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2)
 
 packages:
 
@@ -3133,6 +3136,9 @@ packages:
 
   '@types/node@24.10.1':
     resolution: {integrity: sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==}
+
+  '@types/node@25.0.3':
+    resolution: {integrity: sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA==}
 
   '@types/nodemailer@7.0.4':
     resolution: {integrity: sha512-ee8fxWqOchH+Hv6MDDNNy028kwvVnLplrStm4Zf/3uHWw5zzo8FoYYeffpJtGs2wWysEumMH0ZIdMGMY1eMAow==}
@@ -8790,7 +8796,7 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@changesets/cli@2.29.8(@types/node@24.10.1)':
+  '@changesets/cli@2.29.8(@types/node@25.0.3)':
     dependencies:
       '@changesets/apply-release-plan': 7.0.14
       '@changesets/assemble-release-plan': 6.0.9
@@ -8806,7 +8812,7 @@ snapshots:
       '@changesets/should-skip-package': 0.1.2
       '@changesets/types': 6.1.0
       '@changesets/write': 0.4.0
-      '@inquirer/external-editor': 1.0.3(@types/node@24.10.1)
+      '@inquirer/external-editor': 1.0.3(@types/node@25.0.3)
       '@manypkg/get-packages': 1.1.3
       ansi-colors: 4.1.3
       ci-info: 3.9.0
@@ -9715,12 +9721,12 @@ snapshots:
   '@img/sharp-win32-x64@0.34.5':
     optional: true
 
-  '@inquirer/external-editor@1.0.3(@types/node@24.10.1)':
+  '@inquirer/external-editor@1.0.3(@types/node@25.0.3)':
     dependencies:
       chardet: 2.1.1
       iconv-lite: 0.7.1
     optionalDependencies:
-      '@types/node': 24.10.1
+      '@types/node': 25.0.3
 
   '@intlify/bundle-utils@11.0.1(vue-i18n@11.2.2(vue@3.5.25(typescript@5.9.3)))':
     dependencies:
@@ -10178,11 +10184,11 @@ snapshots:
 
   '@nuxt/devalue@2.0.2': {}
 
-  '@nuxt/devtools-kit@3.1.1(magicast@0.5.1)(vite@7.2.4(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))':
+  '@nuxt/devtools-kit@3.1.1(magicast@0.5.1)(vite@7.2.4(@types/node@25.0.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))':
     dependencies:
       '@nuxt/kit': 4.2.1(magicast@0.5.1)
       execa: 8.0.1
-      vite: 7.2.4(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2)
+      vite: 7.2.4(@types/node@25.0.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2)
     transitivePeerDependencies:
       - magicast
 
@@ -10197,12 +10203,12 @@ snapshots:
       prompts: 2.4.2
       semver: 7.7.3
 
-  '@nuxt/devtools@3.1.1(vite@7.2.4(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))(vue@3.5.25(typescript@5.9.3))':
+  '@nuxt/devtools@3.1.1(vite@7.2.4(@types/node@25.0.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))(vue@3.5.25(typescript@5.9.3))':
     dependencies:
-      '@nuxt/devtools-kit': 3.1.1(magicast@0.5.1)(vite@7.2.4(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))
+      '@nuxt/devtools-kit': 3.1.1(magicast@0.5.1)(vite@7.2.4(@types/node@25.0.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))
       '@nuxt/devtools-wizard': 3.1.1
       '@nuxt/kit': 4.2.1(magicast@0.5.1)
-      '@vue/devtools-core': 8.0.5(vite@7.2.4(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))(vue@3.5.25(typescript@5.9.3))
+      '@vue/devtools-core': 8.0.5(vite@7.2.4(@types/node@25.0.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))(vue@3.5.25(typescript@5.9.3))
       '@vue/devtools-kit': 8.0.5
       birpc: 2.8.0
       consola: 3.4.2
@@ -10227,9 +10233,9 @@ snapshots:
       sirv: 3.0.2
       structured-clone-es: 1.0.0
       tinyglobby: 0.2.15
-      vite: 7.2.4(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2)
-      vite-plugin-inspect: 11.3.3(@nuxt/kit@4.2.1(magicast@0.5.1))(vite@7.2.4(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))
-      vite-plugin-vue-tracer: 1.1.3(vite@7.2.4(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))(vue@3.5.25(typescript@5.9.3))
+      vite: 7.2.4(@types/node@25.0.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2)
+      vite-plugin-inspect: 11.3.3(@nuxt/kit@4.2.1(magicast@0.5.1))(vite@7.2.4(@types/node@25.0.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))
+      vite-plugin-vue-tracer: 1.1.3(vite@7.2.4(@types/node@25.0.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))(vue@3.5.25(typescript@5.9.3))
       which: 5.0.0
       ws: 8.18.3
     transitivePeerDependencies:
@@ -10318,10 +10324,10 @@ snapshots:
       - supports-color
       - typescript
 
-  '@nuxt/eslint@1.10.0(@typescript-eslint/utils@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(@vue/compiler-sfc@3.5.25)(eslint@9.39.1(jiti@2.6.1))(magicast@0.5.1)(typescript@5.9.3)(vite@7.2.4(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))':
+  '@nuxt/eslint@1.10.0(@typescript-eslint/utils@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(@vue/compiler-sfc@3.5.25)(eslint@9.39.1(jiti@2.6.1))(magicast@0.5.1)(typescript@5.9.3)(vite@7.2.4(@types/node@25.0.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))':
     dependencies:
       '@eslint/config-inspector': 1.4.2(eslint@9.39.1(jiti@2.6.1))
-      '@nuxt/devtools-kit': 3.1.1(magicast@0.5.1)(vite@7.2.4(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))
+      '@nuxt/devtools-kit': 3.1.1(magicast@0.5.1)(vite@7.2.4(@types/node@25.0.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))
       '@nuxt/eslint-config': 1.10.0(@typescript-eslint/utils@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(@vue/compiler-sfc@3.5.25)(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
       '@nuxt/eslint-plugin': 1.10.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
       '@nuxt/kit': 4.2.1(magicast@0.5.1)
@@ -10346,10 +10352,10 @@ snapshots:
       - utf-8-validate
       - vite
 
-  '@nuxt/eslint@1.11.0(@typescript-eslint/utils@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(@vue/compiler-sfc@3.5.25)(eslint@9.39.1(jiti@2.6.1))(magicast@0.5.1)(typescript@5.9.3)(vite@7.2.4(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))':
+  '@nuxt/eslint@1.11.0(@typescript-eslint/utils@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(@vue/compiler-sfc@3.5.25)(eslint@9.39.1(jiti@2.6.1))(magicast@0.5.1)(typescript@5.9.3)(vite@7.2.4(@types/node@25.0.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))':
     dependencies:
       '@eslint/config-inspector': 1.4.2(eslint@9.39.1(jiti@2.6.1))
-      '@nuxt/devtools-kit': 3.1.1(magicast@0.5.1)(vite@7.2.4(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))
+      '@nuxt/devtools-kit': 3.1.1(magicast@0.5.1)(vite@7.2.4(@types/node@25.0.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))
       '@nuxt/eslint-config': 1.11.0(@typescript-eslint/utils@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(@vue/compiler-sfc@3.5.25)(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
       '@nuxt/eslint-plugin': 1.11.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
       '@nuxt/kit': 4.2.1(magicast@0.5.1)
@@ -10425,7 +10431,7 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@nuxt/nitro-server@4.2.1(better-sqlite3@12.5.0)(db0@0.3.4(better-sqlite3@12.5.0)(mysql2@3.15.3))(encoding@0.1.13)(ioredis@5.8.2)(magicast@0.5.1)(mysql2@3.15.3)(nuxt@4.2.1(@parcel/watcher@2.5.1)(@types/node@24.10.1)(@vue/compiler-sfc@3.5.25)(better-sqlite3@12.5.0)(db0@0.3.4(better-sqlite3@12.5.0)(mysql2@3.15.3))(encoding@0.1.13)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.8.2)(magicast@0.5.1)(mysql2@3.15.3)(optionator@0.9.4)(rollup@4.53.3)(terser@5.44.1)(typescript@5.9.3)(vite@7.2.4(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))(yaml@2.8.2))(typescript@5.9.3)':
+  '@nuxt/nitro-server@4.2.1(better-sqlite3@12.5.0)(db0@0.3.4(better-sqlite3@12.5.0)(mysql2@3.15.3))(encoding@0.1.13)(ioredis@5.8.2)(magicast@0.5.1)(mysql2@3.15.3)(nuxt@4.2.1(@parcel/watcher@2.5.1)(@types/node@25.0.3)(@vue/compiler-sfc@3.5.25)(better-sqlite3@12.5.0)(db0@0.3.4(better-sqlite3@12.5.0)(mysql2@3.15.3))(encoding@0.1.13)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.8.2)(magicast@0.5.1)(mysql2@3.15.3)(optionator@0.9.4)(rollup@4.53.3)(terser@5.44.1)(typescript@5.9.3)(vite@7.2.4(@types/node@25.0.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))(yaml@2.8.2))(typescript@5.9.3)':
     dependencies:
       '@nuxt/devalue': 2.0.2
       '@nuxt/kit': 4.2.1(magicast@0.5.1)
@@ -10443,7 +10449,7 @@ snapshots:
       klona: 2.0.6
       mocked-exports: 0.1.1
       nitropack: 2.12.9(better-sqlite3@12.5.0)(encoding@0.1.13)(mysql2@3.15.3)
-      nuxt: 4.2.1(@parcel/watcher@2.5.1)(@types/node@24.10.1)(@vue/compiler-sfc@3.5.25)(better-sqlite3@12.5.0)(db0@0.3.4(better-sqlite3@12.5.0)(mysql2@3.15.3))(encoding@0.1.13)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.8.2)(magicast@0.5.1)(mysql2@3.15.3)(optionator@0.9.4)(rollup@4.53.3)(terser@5.44.1)(typescript@5.9.3)(vite@7.2.4(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))(yaml@2.8.2)
+      nuxt: 4.2.1(@parcel/watcher@2.5.1)(@types/node@25.0.3)(@vue/compiler-sfc@3.5.25)(better-sqlite3@12.5.0)(db0@0.3.4(better-sqlite3@12.5.0)(mysql2@3.15.3))(encoding@0.1.13)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.8.2)(magicast@0.5.1)(mysql2@3.15.3)(optionator@0.9.4)(rollup@4.53.3)(terser@5.44.1)(typescript@5.9.3)(vite@7.2.4(@types/node@25.0.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))(yaml@2.8.2)
       pathe: 2.0.3
       pkg-types: 2.3.0
       radix3: 1.1.2
@@ -10514,7 +10520,7 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@nuxt/test-utils@3.20.1(@vue/test-utils@2.4.6)(happy-dom@20.0.11)(magicast@0.5.1)(typescript@5.9.3)(vitest@4.0.14(@types/node@24.10.1)(happy-dom@20.0.11)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))':
+  '@nuxt/test-utils@3.20.1(@vue/test-utils@2.4.6)(happy-dom@20.0.11)(magicast@0.5.1)(typescript@5.9.3)(vitest@4.0.14(@types/node@25.0.3)(happy-dom@20.0.11)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))':
     dependencies:
       '@nuxt/kit': 4.2.1(magicast@0.5.1)
       c12: 3.3.2(magicast@0.5.1)
@@ -10538,22 +10544,22 @@ snapshots:
       tinyexec: 1.0.2
       ufo: 1.6.1
       unplugin: 2.3.11
-      vitest-environment-nuxt: 1.0.1(@vue/test-utils@2.4.6)(happy-dom@20.0.11)(magicast@0.5.1)(typescript@5.9.3)(vitest@4.0.14(@types/node@24.10.1)(happy-dom@20.0.11)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))
+      vitest-environment-nuxt: 1.0.1(@vue/test-utils@2.4.6)(happy-dom@20.0.11)(magicast@0.5.1)(typescript@5.9.3)(vitest@4.0.14(@types/node@25.0.3)(happy-dom@20.0.11)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))
       vue: 3.5.25(typescript@5.9.3)
     optionalDependencies:
       '@vue/test-utils': 2.4.6
       happy-dom: 20.0.11
-      vitest: 4.0.14(@types/node@24.10.1)(happy-dom@20.0.11)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2)
+      vitest: 4.0.14(@types/node@25.0.3)(happy-dom@20.0.11)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2)
     transitivePeerDependencies:
       - magicast
       - typescript
 
-  '@nuxt/vite-builder@4.2.1(@types/node@24.10.1)(eslint@9.39.1(jiti@2.6.1))(magicast@0.5.1)(nuxt@4.2.1(@parcel/watcher@2.5.1)(@types/node@24.10.1)(@vue/compiler-sfc@3.5.25)(better-sqlite3@12.5.0)(db0@0.3.4(better-sqlite3@12.5.0)(mysql2@3.15.3))(encoding@0.1.13)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.8.2)(magicast@0.5.1)(mysql2@3.15.3)(optionator@0.9.4)(rollup@4.53.3)(terser@5.44.1)(typescript@5.9.3)(vite@7.2.4(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))(yaml@2.8.2))(optionator@0.9.4)(rollup@4.53.3)(terser@5.44.1)(typescript@5.9.3)(vue@3.5.25(typescript@5.9.3))(yaml@2.8.2)':
+  '@nuxt/vite-builder@4.2.1(@types/node@25.0.3)(eslint@9.39.1(jiti@2.6.1))(magicast@0.5.1)(nuxt@4.2.1(@parcel/watcher@2.5.1)(@types/node@25.0.3)(@vue/compiler-sfc@3.5.25)(better-sqlite3@12.5.0)(db0@0.3.4(better-sqlite3@12.5.0)(mysql2@3.15.3))(encoding@0.1.13)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.8.2)(magicast@0.5.1)(mysql2@3.15.3)(optionator@0.9.4)(rollup@4.53.3)(terser@5.44.1)(typescript@5.9.3)(vite@7.2.4(@types/node@25.0.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))(yaml@2.8.2))(optionator@0.9.4)(rollup@4.53.3)(terser@5.44.1)(typescript@5.9.3)(vue@3.5.25(typescript@5.9.3))(yaml@2.8.2)':
     dependencies:
       '@nuxt/kit': 4.2.1(magicast@0.5.1)
       '@rollup/plugin-replace': 6.0.3(rollup@4.53.3)
-      '@vitejs/plugin-vue': 6.0.2(vite@7.2.4(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))(vue@3.5.25(typescript@5.9.3))
-      '@vitejs/plugin-vue-jsx': 5.1.2(vite@7.2.4(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))(vue@3.5.25(typescript@5.9.3))
+      '@vitejs/plugin-vue': 6.0.2(vite@7.2.4(@types/node@25.0.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))(vue@3.5.25(typescript@5.9.3))
+      '@vitejs/plugin-vue-jsx': 5.1.2(vite@7.2.4(@types/node@25.0.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))(vue@3.5.25(typescript@5.9.3))
       autoprefixer: 10.4.22(postcss@8.5.6)
       consola: 3.4.2
       cssnano: 7.1.2(postcss@8.5.6)
@@ -10568,7 +10574,7 @@ snapshots:
       magic-string: 0.30.21
       mlly: 1.8.0
       mocked-exports: 0.1.1
-      nuxt: 4.2.1(@parcel/watcher@2.5.1)(@types/node@24.10.1)(@vue/compiler-sfc@3.5.25)(better-sqlite3@12.5.0)(db0@0.3.4(better-sqlite3@12.5.0)(mysql2@3.15.3))(encoding@0.1.13)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.8.2)(magicast@0.5.1)(mysql2@3.15.3)(optionator@0.9.4)(rollup@4.53.3)(terser@5.44.1)(typescript@5.9.3)(vite@7.2.4(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))(yaml@2.8.2)
+      nuxt: 4.2.1(@parcel/watcher@2.5.1)(@types/node@25.0.3)(@vue/compiler-sfc@3.5.25)(better-sqlite3@12.5.0)(db0@0.3.4(better-sqlite3@12.5.0)(mysql2@3.15.3))(encoding@0.1.13)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.8.2)(magicast@0.5.1)(mysql2@3.15.3)(optionator@0.9.4)(rollup@4.53.3)(terser@5.44.1)(typescript@5.9.3)(vite@7.2.4(@types/node@25.0.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))(yaml@2.8.2)
       pathe: 2.0.3
       pkg-types: 2.3.0
       postcss: 8.5.6
@@ -10577,9 +10583,9 @@ snapshots:
       std-env: 3.10.0
       ufo: 1.6.1
       unenv: 2.0.0-rc.24
-      vite: 7.2.4(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2)
-      vite-node: 5.2.0(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2)
-      vite-plugin-checker: 0.11.0(eslint@9.39.1(jiti@2.6.1))(optionator@0.9.4)(typescript@5.9.3)(vite@7.2.4(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))
+      vite: 7.2.4(@types/node@25.0.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2)
+      vite-node: 5.2.0(@types/node@25.0.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2)
+      vite-plugin-checker: 0.11.0(eslint@9.39.1(jiti@2.6.1))(optionator@0.9.4)(typescript@5.9.3)(vite@7.2.4(@types/node@25.0.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))
       vue: 3.5.25(typescript@5.9.3)
       vue-bundle-renderer: 2.2.0
     transitivePeerDependencies:
@@ -11736,13 +11742,13 @@ snapshots:
 
   '@types/better-sqlite3@7.6.13':
     dependencies:
-      '@types/node': 24.10.1
+      '@types/node': 25.0.3
 
   '@types/cacheable-request@6.0.3':
     dependencies:
       '@types/http-cache-semantics': 4.0.4
       '@types/keyv': 3.1.4
-      '@types/node': 24.10.1
+      '@types/node': 25.0.3
       '@types/responselike': 1.0.3
 
   '@types/canvas-confetti@1.9.0': {}
@@ -11762,7 +11768,7 @@ snapshots:
 
   '@types/fs-extra@9.0.13':
     dependencies:
-      '@types/node': 24.10.1
+      '@types/node': 25.0.3
 
   '@types/geojson@7946.0.16': {}
 
@@ -11781,7 +11787,7 @@ snapshots:
 
   '@types/keyv@3.1.4':
     dependencies:
-      '@types/node': 24.10.1
+      '@types/node': 25.0.3
 
   '@types/leaflet@1.9.21':
     dependencies:
@@ -11818,6 +11824,10 @@ snapshots:
     dependencies:
       undici-types: 7.16.0
 
+  '@types/node@25.0.3':
+    dependencies:
+      undici-types: 7.16.0
+
   '@types/nodemailer@7.0.4':
     dependencies:
       '@aws-sdk/client-sesv2': 3.950.0
@@ -11831,19 +11841,19 @@ snapshots:
 
   '@types/plist@3.0.5':
     dependencies:
-      '@types/node': 24.10.1
+      '@types/node': 25.0.3
       xmlbuilder: 15.1.1
     optional: true
 
   '@types/readdir-glob@1.1.5':
     dependencies:
-      '@types/node': 24.10.1
+      '@types/node': 25.0.3
 
   '@types/resolve@1.20.2': {}
 
   '@types/responselike@1.0.3':
     dependencies:
-      '@types/node': 24.10.1
+      '@types/node': 25.0.3
 
   '@types/unist@2.0.11': {}
 
@@ -11851,7 +11861,7 @@ snapshots:
 
   '@types/unzipper@0.10.11':
     dependencies:
-      '@types/node': 24.10.1
+      '@types/node': 25.0.3
 
   '@types/verror@1.10.11':
     optional: true
@@ -11862,7 +11872,7 @@ snapshots:
 
   '@types/yauzl@2.10.3':
     dependencies:
-      '@types/node': 24.10.1
+      '@types/node': 25.0.3
     optional: true
 
   '@typescript-eslint/eslint-plugin@8.48.0(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)':
@@ -12047,25 +12057,25 @@ snapshots:
       - rollup
       - supports-color
 
-  '@vitejs/plugin-vue-jsx@5.1.2(vite@7.2.4(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))(vue@3.5.25(typescript@5.9.3))':
+  '@vitejs/plugin-vue-jsx@5.1.2(vite@7.2.4(@types/node@25.0.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))(vue@3.5.25(typescript@5.9.3))':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/plugin-syntax-typescript': 7.27.1(@babel/core@7.28.5)
       '@babel/plugin-transform-typescript': 7.28.5(@babel/core@7.28.5)
       '@rolldown/pluginutils': 1.0.0-beta.52
       '@vue/babel-plugin-jsx': 2.0.1(@babel/core@7.28.5)
-      vite: 7.2.4(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2)
+      vite: 7.2.4(@types/node@25.0.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2)
       vue: 3.5.25(typescript@5.9.3)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-vue@6.0.2(vite@7.2.4(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))(vue@3.5.25(typescript@5.9.3))':
+  '@vitejs/plugin-vue@6.0.2(vite@7.2.4(@types/node@25.0.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))(vue@3.5.25(typescript@5.9.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-beta.50
-      vite: 7.2.4(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2)
+      vite: 7.2.4(@types/node@25.0.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2)
       vue: 3.5.25(typescript@5.9.3)
 
-  '@vitest/coverage-v8@4.0.16(vitest@4.0.14(@types/node@24.10.1)(happy-dom@20.0.11)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))':
+  '@vitest/coverage-v8@4.0.16(vitest@4.0.14(@types/node@25.0.3)(happy-dom@20.0.11)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.0.16
@@ -12078,7 +12088,7 @@ snapshots:
       obug: 2.1.1
       std-env: 3.10.0
       tinyrainbow: 3.0.3
-      vitest: 4.0.14(@types/node@24.10.1)(happy-dom@20.0.11)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2)
+      vitest: 4.0.14(@types/node@25.0.3)(happy-dom@20.0.11)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -12091,13 +12101,13 @@ snapshots:
       chai: 6.2.1
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@4.0.14(vite@7.2.4(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))':
+  '@vitest/mocker@4.0.14(vite@7.2.4(@types/node@25.0.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))':
     dependencies:
       '@vitest/spy': 4.0.14
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.2.4(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2)
+      vite: 7.2.4(@types/node@25.0.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2)
 
   '@vitest/pretty-format@4.0.14':
     dependencies:
@@ -12217,14 +12227,14 @@ snapshots:
     dependencies:
       '@vue/devtools-kit': 7.7.9
 
-  '@vue/devtools-core@8.0.5(vite@7.2.4(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))(vue@3.5.25(typescript@5.9.3))':
+  '@vue/devtools-core@8.0.5(vite@7.2.4(@types/node@25.0.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))(vue@3.5.25(typescript@5.9.3))':
     dependencies:
       '@vue/devtools-kit': 8.0.5
       '@vue/devtools-shared': 8.0.5
       mitt: 3.0.1
       nanoid: 5.1.6
       pathe: 2.0.3
-      vite-hot-client: 2.1.0(vite@7.2.4(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))
+      vite-hot-client: 2.1.0(vite@7.2.4(@types/node@25.0.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))
       vue: 3.5.25(typescript@5.9.3)
     transitivePeerDependencies:
       - vite
@@ -15585,16 +15595,16 @@ snapshots:
 
   nuxt-define@1.0.0: {}
 
-  nuxt@4.2.1(@parcel/watcher@2.5.1)(@types/node@24.10.1)(@vue/compiler-sfc@3.5.25)(better-sqlite3@12.5.0)(db0@0.3.4(better-sqlite3@12.5.0)(mysql2@3.15.3))(encoding@0.1.13)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.8.2)(magicast@0.5.1)(mysql2@3.15.3)(optionator@0.9.4)(rollup@4.53.3)(terser@5.44.1)(typescript@5.9.3)(vite@7.2.4(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))(yaml@2.8.2):
+  nuxt@4.2.1(@parcel/watcher@2.5.1)(@types/node@25.0.3)(@vue/compiler-sfc@3.5.25)(better-sqlite3@12.5.0)(db0@0.3.4(better-sqlite3@12.5.0)(mysql2@3.15.3))(encoding@0.1.13)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.8.2)(magicast@0.5.1)(mysql2@3.15.3)(optionator@0.9.4)(rollup@4.53.3)(terser@5.44.1)(typescript@5.9.3)(vite@7.2.4(@types/node@25.0.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))(yaml@2.8.2):
     dependencies:
       '@dxup/nuxt': 0.2.2(magicast@0.5.1)
       '@nuxt/cli': 3.30.0(magicast@0.5.1)
-      '@nuxt/devtools': 3.1.1(vite@7.2.4(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))(vue@3.5.25(typescript@5.9.3))
+      '@nuxt/devtools': 3.1.1(vite@7.2.4(@types/node@25.0.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))(vue@3.5.25(typescript@5.9.3))
       '@nuxt/kit': 4.2.1(magicast@0.5.1)
-      '@nuxt/nitro-server': 4.2.1(better-sqlite3@12.5.0)(db0@0.3.4(better-sqlite3@12.5.0)(mysql2@3.15.3))(encoding@0.1.13)(ioredis@5.8.2)(magicast@0.5.1)(mysql2@3.15.3)(nuxt@4.2.1(@parcel/watcher@2.5.1)(@types/node@24.10.1)(@vue/compiler-sfc@3.5.25)(better-sqlite3@12.5.0)(db0@0.3.4(better-sqlite3@12.5.0)(mysql2@3.15.3))(encoding@0.1.13)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.8.2)(magicast@0.5.1)(mysql2@3.15.3)(optionator@0.9.4)(rollup@4.53.3)(terser@5.44.1)(typescript@5.9.3)(vite@7.2.4(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))(yaml@2.8.2))(typescript@5.9.3)
+      '@nuxt/nitro-server': 4.2.1(better-sqlite3@12.5.0)(db0@0.3.4(better-sqlite3@12.5.0)(mysql2@3.15.3))(encoding@0.1.13)(ioredis@5.8.2)(magicast@0.5.1)(mysql2@3.15.3)(nuxt@4.2.1(@parcel/watcher@2.5.1)(@types/node@25.0.3)(@vue/compiler-sfc@3.5.25)(better-sqlite3@12.5.0)(db0@0.3.4(better-sqlite3@12.5.0)(mysql2@3.15.3))(encoding@0.1.13)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.8.2)(magicast@0.5.1)(mysql2@3.15.3)(optionator@0.9.4)(rollup@4.53.3)(terser@5.44.1)(typescript@5.9.3)(vite@7.2.4(@types/node@25.0.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))(yaml@2.8.2))(typescript@5.9.3)
       '@nuxt/schema': 4.2.1
       '@nuxt/telemetry': 2.6.6(magicast@0.5.1)
-      '@nuxt/vite-builder': 4.2.1(@types/node@24.10.1)(eslint@9.39.1(jiti@2.6.1))(magicast@0.5.1)(nuxt@4.2.1(@parcel/watcher@2.5.1)(@types/node@24.10.1)(@vue/compiler-sfc@3.5.25)(better-sqlite3@12.5.0)(db0@0.3.4(better-sqlite3@12.5.0)(mysql2@3.15.3))(encoding@0.1.13)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.8.2)(magicast@0.5.1)(mysql2@3.15.3)(optionator@0.9.4)(rollup@4.53.3)(terser@5.44.1)(typescript@5.9.3)(vite@7.2.4(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))(yaml@2.8.2))(optionator@0.9.4)(rollup@4.53.3)(terser@5.44.1)(typescript@5.9.3)(vue@3.5.25(typescript@5.9.3))(yaml@2.8.2)
+      '@nuxt/vite-builder': 4.2.1(@types/node@25.0.3)(eslint@9.39.1(jiti@2.6.1))(magicast@0.5.1)(nuxt@4.2.1(@parcel/watcher@2.5.1)(@types/node@25.0.3)(@vue/compiler-sfc@3.5.25)(better-sqlite3@12.5.0)(db0@0.3.4(better-sqlite3@12.5.0)(mysql2@3.15.3))(encoding@0.1.13)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.8.2)(magicast@0.5.1)(mysql2@3.15.3)(optionator@0.9.4)(rollup@4.53.3)(terser@5.44.1)(typescript@5.9.3)(vite@7.2.4(@types/node@25.0.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))(yaml@2.8.2))(optionator@0.9.4)(rollup@4.53.3)(terser@5.44.1)(typescript@5.9.3)(vue@3.5.25(typescript@5.9.3))(yaml@2.8.2)
       '@unhead/vue': 2.0.19(vue@3.5.25(typescript@5.9.3))
       '@vue/shared': 3.5.25
       c12: 3.3.2(magicast@0.5.1)
@@ -15646,7 +15656,7 @@ snapshots:
       vue-router: 4.6.3(vue@3.5.25(typescript@5.9.3))
     optionalDependencies:
       '@parcel/watcher': 2.5.1
-      '@types/node': 24.10.1
+      '@types/node': 25.0.3
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -17523,23 +17533,23 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite-dev-rpc@1.1.0(vite@7.2.4(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2)):
+  vite-dev-rpc@1.1.0(vite@7.2.4(@types/node@25.0.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2)):
     dependencies:
       birpc: 2.8.0
-      vite: 7.2.4(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2)
-      vite-hot-client: 2.1.0(vite@7.2.4(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))
+      vite: 7.2.4(@types/node@25.0.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2)
+      vite-hot-client: 2.1.0(vite@7.2.4(@types/node@25.0.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))
 
-  vite-hot-client@2.1.0(vite@7.2.4(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2)):
+  vite-hot-client@2.1.0(vite@7.2.4(@types/node@25.0.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2)):
     dependencies:
-      vite: 7.2.4(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2)
+      vite: 7.2.4(@types/node@25.0.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2)
 
-  vite-node@5.2.0(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2):
+  vite-node@5.2.0(@types/node@25.0.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2):
     dependencies:
       cac: 6.7.14
       es-module-lexer: 1.7.0
       obug: 2.1.1
       pathe: 2.0.3
-      vite: 7.2.4(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2)
+      vite: 7.2.4(@types/node@25.0.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -17553,7 +17563,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite-plugin-checker@0.11.0(eslint@9.39.1(jiti@2.6.1))(optionator@0.9.4)(typescript@5.9.3)(vite@7.2.4(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2)):
+  vite-plugin-checker@0.11.0(eslint@9.39.1(jiti@2.6.1))(optionator@0.9.4)(typescript@5.9.3)(vite@7.2.4(@types/node@25.0.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2)):
     dependencies:
       '@babel/code-frame': 7.27.1
       chokidar: 4.0.3
@@ -17562,14 +17572,14 @@ snapshots:
       picomatch: 4.0.3
       tiny-invariant: 1.3.3
       tinyglobby: 0.2.15
-      vite: 7.2.4(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2)
+      vite: 7.2.4(@types/node@25.0.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2)
       vscode-uri: 3.1.0
     optionalDependencies:
       eslint: 9.39.1(jiti@2.6.1)
       optionator: 0.9.4
       typescript: 5.9.3
 
-  vite-plugin-inspect@11.3.3(@nuxt/kit@4.2.1(magicast@0.5.1))(vite@7.2.4(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2)):
+  vite-plugin-inspect@11.3.3(@nuxt/kit@4.2.1(magicast@0.5.1))(vite@7.2.4(@types/node@25.0.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2)):
     dependencies:
       ansis: 4.2.0
       debug: 4.4.3
@@ -17579,35 +17589,35 @@ snapshots:
       perfect-debounce: 2.0.0
       sirv: 3.0.2
       unplugin-utils: 0.3.1
-      vite: 7.2.4(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2)
-      vite-dev-rpc: 1.1.0(vite@7.2.4(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))
+      vite: 7.2.4(@types/node@25.0.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2)
+      vite-dev-rpc: 1.1.0(vite@7.2.4(@types/node@25.0.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))
     optionalDependencies:
       '@nuxt/kit': 4.2.1(magicast@0.5.1)
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-vue-tracer@1.1.3(vite@7.2.4(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))(vue@3.5.25(typescript@5.9.3)):
+  vite-plugin-vue-tracer@1.1.3(vite@7.2.4(@types/node@25.0.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))(vue@3.5.25(typescript@5.9.3)):
     dependencies:
       estree-walker: 3.0.3
       exsolve: 1.0.8
       magic-string: 0.30.21
       pathe: 2.0.3
       source-map-js: 1.2.1
-      vite: 7.2.4(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2)
+      vite: 7.2.4(@types/node@25.0.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2)
       vue: 3.5.25(typescript@5.9.3)
 
-  vite-plugin-vuetify@2.1.2(vite@7.2.4(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))(vue@3.5.25(typescript@5.9.3))(vuetify@3.11.0):
+  vite-plugin-vuetify@2.1.2(vite@7.2.4(@types/node@25.0.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))(vue@3.5.25(typescript@5.9.3))(vuetify@3.11.0):
     dependencies:
       '@vuetify/loader-shared': 2.1.1(vue@3.5.25(typescript@5.9.3))(vuetify@3.11.0)
       debug: 4.4.3
       upath: 2.0.1
-      vite: 7.2.4(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2)
+      vite: 7.2.4(@types/node@25.0.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2)
       vue: 3.5.25(typescript@5.9.3)
       vuetify: 3.11.0(typescript@5.9.3)(vite-plugin-vuetify@2.1.2)(vue@3.5.25(typescript@5.9.3))
     transitivePeerDependencies:
       - supports-color
 
-  vite@7.2.4(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2):
+  vite@7.2.4(@types/node@25.0.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.3)
@@ -17616,15 +17626,15 @@ snapshots:
       rollup: 4.53.3
       tinyglobby: 0.2.15
     optionalDependencies:
-      '@types/node': 24.10.1
+      '@types/node': 25.0.3
       fsevents: 2.3.3
       jiti: 2.6.1
       terser: 5.44.1
       yaml: 2.8.2
 
-  vitest-environment-nuxt@1.0.1(@vue/test-utils@2.4.6)(happy-dom@20.0.11)(magicast@0.5.1)(typescript@5.9.3)(vitest@4.0.14(@types/node@24.10.1)(happy-dom@20.0.11)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2)):
+  vitest-environment-nuxt@1.0.1(@vue/test-utils@2.4.6)(happy-dom@20.0.11)(magicast@0.5.1)(typescript@5.9.3)(vitest@4.0.14(@types/node@25.0.3)(happy-dom@20.0.11)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2)):
     dependencies:
-      '@nuxt/test-utils': 3.20.1(@vue/test-utils@2.4.6)(happy-dom@20.0.11)(magicast@0.5.1)(typescript@5.9.3)(vitest@4.0.14(@types/node@24.10.1)(happy-dom@20.0.11)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))
+      '@nuxt/test-utils': 3.20.1(@vue/test-utils@2.4.6)(happy-dom@20.0.11)(magicast@0.5.1)(typescript@5.9.3)(vitest@4.0.14(@types/node@25.0.3)(happy-dom@20.0.11)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))
     transitivePeerDependencies:
       - '@cucumber/cucumber'
       - '@jest/globals'
@@ -17639,10 +17649,10 @@ snapshots:
       - typescript
       - vitest
 
-  vitest@4.0.14(@types/node@24.10.1)(happy-dom@20.0.11)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2):
+  vitest@4.0.14(@types/node@25.0.3)(happy-dom@20.0.11)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2):
     dependencies:
       '@vitest/expect': 4.0.14
-      '@vitest/mocker': 4.0.14(vite@7.2.4(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))
+      '@vitest/mocker': 4.0.14(vite@7.2.4(@types/node@25.0.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))
       '@vitest/pretty-format': 4.0.14
       '@vitest/runner': 4.0.14
       '@vitest/snapshot': 4.0.14
@@ -17659,10 +17669,10 @@ snapshots:
       tinyexec: 0.3.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 7.2.4(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2)
+      vite: 7.2.4(@types/node@25.0.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 24.10.1
+      '@types/node': 25.0.3
       happy-dom: 20.0.11
     transitivePeerDependencies:
       - jiti
@@ -17746,7 +17756,7 @@ snapshots:
       vue: 3.5.25(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
-      vite-plugin-vuetify: 2.1.2(vite@7.2.4(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))(vue@3.5.25(typescript@5.9.3))(vuetify@3.11.0)
+      vite-plugin-vuetify: 2.1.2(vite@7.2.4(@types/node@25.0.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))(vue@3.5.25(typescript@5.9.3))(vuetify@3.11.0)
 
   w3c-keyname@2.2.8: {}
 


### PR DESCRIPTION
## Summary
- Adds comprehensive file-based error logging for debugging support issues
- Implements log file rotation (5 MB max, 3 files kept)
- Intercepts console.error/warn globally to capture all errors
- Adds Settings UI section to view log path and open logs folder
- Full Electron integration with native folder opening

## Implementation Details

### Logger (`server/utils/logger.ts`)
- Writes logs to `data/logs/dm-hero.log` (dev) or `~/.config/dm-hero/logs/dm-hero.log` (Electron)
- Automatic rotation when file exceeds 5 MB
- Keeps 3 rotated files (dm-hero.log.1, .2, .3)
- Timestamps in format `[YYYY-MM-DD HH:MM:SS]`
- Log levels: DEBUG, INFO, WARN, ERROR, FATAL

### Console Interception (`server/plugins/error-logger.ts`)
- Monkey-patches console.error and console.warn
- All errors logged to file even when caught by try-catch
- Nitro error hook for unhandled API errors

### Electron Integration
- LOG_PATH environment variable for production paths
- IPC handler for opening logs folder
- Process exception handlers (uncaughtException, unhandledRejection)

### Settings UI
- New "Logs" section showing log file path
- "Open Logs Folder" button (Electron only)
- Full i18n support (DE + EN)

## Test Plan
- [x] 29 unit tests covering all scenarios
- [x] Basic logging (all levels)
- [x] Message formatting (strings, objects, errors)
- [x] Full rotation cycle (delete oldest, shift all, rename current)
- [x] App restart persistence
- [x] File locking scenarios (no crash when user opens file)
- [x] Error handling (graceful fallback)

Closes #172