### PR TITLE
fix: add Docker ARM64 support for Apple Silicon (#168)

### DIFF
--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -7,13 +7,47 @@ on:
     paths:
       - 'packages/app/package.json'
   workflow_dispatch:
+    inputs:
+      test_docker_only:
+        description: 'Test Docker build without pushing (for CI testing)'
+        required: false
+        type: boolean
+        default: false
 
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
+  # Test-only Docker build (no push, no release)
+  test-docker:
+    if: ${{ github.event.inputs.test_docker_only == 'true' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Docker image (test only, no push)
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: false
+          platforms: linux/amd64,linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build successful
+        run: echo "✅ Multi-arch Docker build successful for linux/amd64 and linux/arm64"
+
   check:
+    if: ${{ github.event.inputs.test_docker_only != 'true' }}
     runs-on: ubuntu-latest
     outputs:
       should_release: ${{ steps.check.outputs.should_release }}
@@ -55,6 +89,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -83,7 +120,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
 
       - name: Image digest
         run: echo "Image pushed with digest ${{ steps.meta.outputs.digest }}"


### PR DESCRIPTION
## Summary
- Adds ARM64 (Apple Silicon) support to Docker image
- Uses QEMU emulation for cross-platform builds
- Adds `test_docker_only` workflow input for CI testing without release

## Changes
- Added QEMU setup step before Docker Buildx
- Changed platforms from `linux/amd64` to `linux/amd64,linux/arm64`
- Added `test-docker` job for testing builds without pushing

## Test Plan
1. Go to Actions → Release App
2. Click "Run workflow"
3. Check "Test Docker build without pushing"
4. Run and verify build succeeds for both architectures

After merge, users on Apple Silicon can use:
```bash
docker pull ghcr.io/flo0806/dm-hero
```

Closes #168