### PR TITLE
feat: replace alerts with translated snackbars

### DIFF
--- a/packages/app/app/app.vue
+++ b/packages/app/app/app.vue
@@ -42,6 +42,11 @@
       location="top"
     >
       {{ snackbarStore.message }}
+      <template v-if="snackbarStore.persistent" #actions>
+        <v-btn variant="text" @click="snackbarStore.hide()">
+          {{ $t('common.close') }}
+        </v-btn>
+      </template>
     </v-snackbar>
 
     <!-- Announcements Dialog -->

--- a/packages/app/app/components/audio/Player.vue
+++ b/packages/app/app/components/audio/Player.vue
@@ -285,6 +285,7 @@ const emit = defineEmits<{
 }>()
 
 const { t } = useI18n()
+const { showError } = useErrorHandler()
 
 // Audio element ref
 const audioElement = ref<HTMLAudioElement | null>(null)
@@ -577,7 +578,7 @@ async function saveMarker() {
     emit('markers-updated')
   } catch (error) {
     console.error('Failed to save marker:', error)
-    alert(t('audio.saveMarkerError'))
+    showError(error, 'audio.saveMarkerError')
   } finally {
     savingMarker.value = false
   }

--- a/packages/app/app/components/npcs/NpcEditDialog.vue
+++ b/packages/app/app/components/npcs/NpcEditDialog.vue
@@ -528,6 +528,7 @@ import { useImageDownload } from '~/composables/useImageDownload'
 import { useEntitiesStore } from '~/stores/entities'
 import { useCampaignStore } from '~/stores/campaign'
 import { useSnackbarStore } from '~/stores/snackbar'
+import { useErrorHandler } from '~/composables/useErrorHandler'
 import { getNpcTypeIcon, getNpcStatusIcon, getNpcStatusColor } from '~/utils/npc-icons'
 
 // ============================================================================
@@ -551,6 +552,7 @@ const { locale, t } = useI18n()
 const entitiesStore = useEntitiesStore()
 const campaignStore = useCampaignStore()
 const snackbarStore = useSnackbarStore()
+const { showError, showUploadError, showImageError } = useErrorHandler()
 const { downloadImage: downloadImageFile } = useImageDownload()
 
 // Dirty state management for tabs
@@ -1371,7 +1373,7 @@ async function handleImageUpload(event: Event) {
     await refreshNpc()
   } catch (error) {
     console.error('Failed to upload image:', error)
-    alert(t('npcs.uploadImageError'))
+    showUploadError('image')
   } finally {
     uploadingImage.value = false
     if (target) target.value = ''
@@ -1413,20 +1415,19 @@ async function generateImage() {
     }
   } catch (error: unknown) {
     console.error('[NPC] Failed to generate image:', error)
-    // Extract detailed error info from Nuxt FetchError
-    let errorMessage = 'Failed to generate image'
+    // Extract error message from Nuxt FetchError for logging
     if (error && typeof error === 'object') {
       const fetchError = error as { data?: { message?: string }; message?: string; statusCode?: number }
-      // Log full error details for debugging
       console.error('[NPC] Error details:', {
         statusCode: fetchError.statusCode,
         message: fetchError.message,
         data: fetchError.data,
       })
-      // Use server message if available
-      errorMessage = fetchError.data?.message || fetchError.message || errorMessage
+      // Show translated error via error handler
+      showError(fetchError.data?.message || fetchError.message, 'errors.image.generateFailed')
+    } else {
+      showImageError('generate')
     }
-    alert(errorMessage)
   } finally {
     generatingImage.value = false
   }
@@ -1441,7 +1442,7 @@ async function deleteImage() {
     await refreshNpc()
   } catch (error) {
     console.error('Failed to delete image:', error)
-    alert(t('npcs.deleteImageError'))
+    showImageError('delete')
   } finally {
     deletingImage.value = false
   }
@@ -1483,6 +1484,7 @@ async function generateName() {
     }
   } catch (error) {
     console.error('[NPC] Failed to generate name:', error)
+    showError(error)
   } finally {
     generatingName.value = false
   }

--- a/packages/app/app/components/players/PlayerEditDialog.vue
+++ b/packages/app/app/components/players/PlayerEditDialog.vue
@@ -381,6 +381,7 @@ import ImagePreviewDialog from '../shared/ImagePreviewDialog.vue'
 import LocationSelectWithMap from '../shared/LocationSelectWithMap.vue'
 import { useImageDownload } from '~/composables/useImageDownload'
 import { useSnackbarStore } from '~/stores/snackbar'
+import { useErrorHandler } from '~/composables/useErrorHandler'
 import { useDialogDirtyStateProvider } from '~/composables/useDialogDirtyState'
 
 const props = defineProps<{
@@ -399,6 +400,7 @@ const { downloadImage: downloadImageFile } = useImageDownload()
 const entitiesStore = useEntitiesStore()
 const campaignStore = useCampaignStore()
 const snackbarStore = useSnackbarStore()
+const { showError, showUploadError, showImageError } = useErrorHandler()
 
 // Dirty state management for tabs
 const { hasDirtyTabs, dirtyTabLabels } = useDialogDirtyStateProvider()
@@ -752,7 +754,7 @@ async function handleImageUpload(event: Event) {
     await loadCounts(player.value.id)
   } catch (error) {
     console.error('Failed to upload image:', error)
-    alert(t('players.uploadImageError'))
+    showUploadError('image')
   } finally {
     uploadingImage.value = false
     if (target) target.value = ''
@@ -803,8 +805,7 @@ async function generateImage() {
     }
   } catch (error: unknown) {
     console.error('[PlayerEditDialog] Failed to generate image:', error)
-    const errorMessage = error instanceof Error ? error.message : 'Failed to generate image'
-    alert(errorMessage)
+    showError(error, 'errors.image.generateFailed')
   } finally {
     generatingImage.value = false
   }
@@ -826,7 +827,7 @@ async function deleteImage() {
     await loadCounts(player.value.id)
   } catch (error) {
     console.error('Failed to delete image:', error)
-    alert(t('players.deleteImageError'))
+    showImageError('delete')
   } finally {
     deletingImage.value = false
   }

--- a/packages/app/app/components/sessions/SessionAudioGallery.vue
+++ b/packages/app/app/components/sessions/SessionAudioGallery.vue
@@ -136,7 +136,7 @@ const emit = defineEmits<{
   uploading: [isUploading: boolean]
 }>()
 
-const { t } = useI18n()
+const { showUploadError } = useErrorHandler()
 
 // State
 const audioFiles = ref<SessionAudio[]>([])
@@ -208,7 +208,7 @@ async function handleAudioUpload(event: Event) {
     emit('audio-updated')
   } catch (error) {
     console.error('Failed to upload audio:', error)
-    alert(t('audio.uploadError'))
+    showUploadError('audio')
   } finally {
     uploadingAudio.value = false
     emit('uploading', false)

--- a/packages/app/app/components/sessions/SessionImageGallery.vue
+++ b/packages/app/app/components/sessions/SessionImageGallery.vue
@@ -192,6 +192,7 @@ const emit = defineEmits<{
 
 const { t } = useI18n()
 const { downloadImage } = useImageDownload()
+const { showUploadError } = useErrorHandler()
 
 // Image state
 const images = ref<SessionImage[]>([])
@@ -278,7 +279,7 @@ async function handleImageUpload(event: Event) {
     emit('images-updated')
   } catch (error) {
     console.error('Failed to upload session images:', error)
-    alert(t('common.uploadImageError'))
+    showUploadError('image')
   } finally {
     uploadingImage.value = false
     if (target) target.value = ''

--- a/packages/app/app/components/shared/EntityDocuments.vue
+++ b/packages/app/app/components/shared/EntityDocuments.vue
@@ -296,6 +296,7 @@ const emit = defineEmits<{
 
 const { t } = useI18n()
 const { locale } = useI18n()
+const { showUploadError, showDownloadError } = useErrorHandler()
 const entitiesStore = useEntitiesStore()
 const campaignStore = useCampaignStore()
 
@@ -523,7 +524,7 @@ async function handlePdfUpload(event: Event) {
     emit('changed') // Notify parent that document count changed
   } catch (error) {
     console.error('PDF upload failed:', error)
-    alert('PDF Upload fehlgeschlagen. Bitte versuche es erneut.')
+    showUploadError('pdf')
   } finally {
     uploadingPdf.value = false
   }
@@ -559,7 +560,7 @@ function downloadPdf(doc: Document) {
     document.body.removeChild(link)
   } catch (error) {
     console.error('Failed to download PDF:', error)
-    alert('Download fehlgeschlagen. Bitte versuche es erneut.')
+    showDownloadError()
   }
 }
 

--- a/packages/app/app/components/shared/EntityImageGallery.vue
+++ b/packages/app/app/components/shared/EntityImageGallery.vue
@@ -177,8 +177,8 @@ const emit = defineEmits<{
   generating: [isGenerating: boolean]
 }>()
 
-const { t } = useI18n()
 const { downloadImage } = useImageDownload()
+const { showError, showUploadError } = useErrorHandler()
 
 // Image state
 const images = ref<EntityImage[]>([])
@@ -252,7 +252,7 @@ async function handleImageUpload(event: Event) {
     emit('images-updated') // Notify parent that images changed
   } catch (error) {
     console.error('Failed to upload images:', error)
-    alert(t('common.uploadImageError'))
+    showUploadError('image')
   } finally {
     uploadingImage.value = false
     if (target) target.value = ''
@@ -301,7 +301,7 @@ async function generateImage() {
     }
   } catch (error) {
     console.error('Failed to generate image:', error)
-    alert(t('common.generateImageError'))
+    showError(error, 'errors.image.generateFailed')
   } finally {
     generatingImage.value = false
     emit('generating', false)

--- a/packages/app/app/composables/useErrorHandler.ts
+++ b/packages/app/app/composables/useErrorHandler.ts
@@ -1,0 +1,178 @@
+/**
+ * Composable for handling and translating API errors
+ *
+ * Parses error messages and returns appropriate i18n keys
+ * for user-friendly error display.
+ */
+
+/**
+ * Parse OpenAI error message and return the appropriate i18n key
+ */
+export function getOpenAIErrorKey(error: string): string {
+  const errorLower = error.toLowerCase()
+
+  // Check for specific error patterns
+  if (errorLower.includes('quota') || errorLower.includes('exceeded your current quota')) {
+    return 'errors.openai.insufficientQuota'
+  }
+  if (errorLower.includes('invalid_api_key') || errorLower.includes('incorrect api key')) {
+    return 'errors.openai.invalidApiKey'
+  }
+  if (errorLower.includes('rate_limit') || errorLower.includes('rate limit')) {
+    return 'errors.openai.rateLimitExceeded'
+  }
+  if (errorLower.includes('content_policy') || errorLower.includes('safety system')) {
+    return 'errors.openai.contentPolicyViolation'
+  }
+  if (errorLower.includes('billing_hard_limit') || errorLower.includes('billing hard limit')) {
+    return 'errors.openai.billingHardLimitReached'
+  }
+  if (errorLower.includes('server_error') || errorLower.includes('internal server error')) {
+    return 'errors.openai.serverError'
+  }
+  if (errorLower.includes('model_not_found') || errorLower.includes('does not exist')) {
+    return 'errors.openai.modelNotFound'
+  }
+
+  // Default fallback
+  return 'errors.openai.unknown'
+}
+
+/**
+ * Check if an error is an OpenAI-related error
+ */
+export function isOpenAIError(error: string): boolean {
+  const errorLower = error.toLowerCase()
+  return (
+    errorLower.includes('openai') ||
+    errorLower.includes('quota') ||
+    errorLower.includes('api key') ||
+    errorLower.includes('api_key') ||
+    errorLower.includes('rate limit') ||
+    errorLower.includes('dall-e') ||
+    errorLower.includes('gpt')
+  )
+}
+
+/**
+ * Extract the actual error message from various error formats
+ */
+function extractErrorMessage(error: unknown): string {
+  // Handle $fetch errors which have nested data
+  if (error && typeof error === 'object') {
+    const fetchError = error as {
+      data?: { message?: string; statusMessage?: string }
+      statusMessage?: string
+      message?: string
+      statusCode?: number
+    }
+
+    // Check for nested error data (from $fetch)
+    if (fetchError.data?.message) {
+      return fetchError.data.message
+    }
+    if (fetchError.data?.statusMessage) {
+      return fetchError.data.statusMessage
+    }
+    if (fetchError.statusMessage) {
+      return fetchError.statusMessage
+    }
+
+    // Check for 401 status code (invalid API key)
+    if (fetchError.statusCode === 401) {
+      return 'invalid_api_key'
+    }
+
+    if (fetchError.message) {
+      // Check for 401 in the message
+      if (fetchError.message.includes('401')) {
+        return 'invalid_api_key'
+      }
+      return fetchError.message
+    }
+  }
+
+  if (error instanceof Error) {
+    // Check for 401 in the message
+    if (error.message.includes('401')) {
+      return 'invalid_api_key'
+    }
+    return error.message
+  }
+
+  if (typeof error === 'string') {
+    return error
+  }
+
+  return ''
+}
+
+/**
+ * Composable for error handling with snackbar integration
+ */
+export function useErrorHandler() {
+  const { t } = useI18n()
+  const snackbarStore = useSnackbarStore()
+
+  /**
+   * Show an error in the snackbar with automatic translation for known errors
+   */
+  function showError(error: unknown, fallbackKey?: string) {
+    const message = extractErrorMessage(error)
+
+    if (!message) {
+      snackbarStore.error(t(fallbackKey || 'errors.openai.unknown'), { persistent: true })
+      return
+    }
+
+    // Check if it's an OpenAI error and translate it
+    if (isOpenAIError(message)) {
+      const errorKey = getOpenAIErrorKey(message)
+      snackbarStore.error(t(errorKey), { persistent: true })
+    } else if (fallbackKey) {
+      snackbarStore.error(t(fallbackKey), { persistent: true })
+    } else {
+      // Show original message if no translation available
+      snackbarStore.error(message, { persistent: true })
+    }
+  }
+
+  /**
+   * Show an upload error
+   */
+  function showUploadError(type: 'image' | 'pdf' | 'audio') {
+    const keyMap = {
+      image: 'errors.upload.imageFailed',
+      pdf: 'errors.upload.pdfFailed',
+      audio: 'errors.upload.audioFailed',
+    }
+    snackbarStore.error(t(keyMap[type]), { persistent: true })
+  }
+
+  /**
+   * Show a download error
+   */
+  function showDownloadError() {
+    snackbarStore.error(t('errors.upload.downloadFailed'), { persistent: true })
+  }
+
+  /**
+   * Show an image operation error
+   */
+  function showImageError(type: 'generate' | 'delete') {
+    const keyMap = {
+      generate: 'errors.image.generateFailed',
+      delete: 'errors.image.deleteFailed',
+    }
+    snackbarStore.error(t(keyMap[type]), { persistent: true })
+  }
+
+  return {
+    showError,
+    showUploadError,
+    showDownloadError,
+    showImageError,
+    getOpenAIErrorKey,
+    isOpenAIError,
+  }
+}

--- a/packages/app/app/stores/snackbar.ts
+++ b/packages/app/app/stores/snackbar.ts
@@ -2,11 +2,17 @@ import { defineStore } from 'pinia'
 
 export type SnackbarColor = 'success' | 'error' | 'warning' | 'info'
 
+interface SnackbarOptions {
+  timeout?: number
+  persistent?: boolean
+}
+
 interface SnackbarState {
   show: boolean
   message: string
   color: SnackbarColor
   timeout: number
+  persistent: boolean
 }
 
 export const useSnackbarStore = defineStore('snackbar', {
@@ -15,34 +21,37 @@ export const useSnackbarStore = defineStore('snackbar', {
     message: '',
     color: 'info',
     timeout: 4000,
+    persistent: false,
   }),
 
   actions: {
-    showMessage(message: string, color: SnackbarColor = 'info', timeout = 4000) {
+    showMessage(message: string, color: SnackbarColor = 'info', options: SnackbarOptions = {}) {
       this.message = message
       this.color = color
-      this.timeout = timeout
+      this.timeout = options.persistent ? -1 : (options.timeout ?? 4000)
+      this.persistent = options.persistent ?? false
       this.show = true
     },
 
-    success(message: string, timeout = 4000) {
-      this.showMessage(message, 'success', timeout)
+    success(message: string, options: SnackbarOptions = {}) {
+      this.showMessage(message, 'success', { timeout: 4000, ...options })
     },
 
-    error(message: string, timeout = 5000) {
-      this.showMessage(message, 'error', timeout)
+    error(message: string, options: SnackbarOptions = {}) {
+      this.showMessage(message, 'error', { timeout: 5000, ...options })
     },
 
-    warning(message: string, timeout = 5000) {
-      this.showMessage(message, 'warning', timeout)
+    warning(message: string, options: SnackbarOptions = {}) {
+      this.showMessage(message, 'warning', { timeout: 5000, ...options })
     },
 
-    info(message: string, timeout = 4000) {
-      this.showMessage(message, 'info', timeout)
+    info(message: string, options: SnackbarOptions = {}) {
+      this.showMessage(message, 'info', { timeout: 4000, ...options })
     },
 
     hide() {
       this.show = false
+      this.persistent = false
     },
   },
 })

--- a/packages/app/i18n/locales/de.json
+++ b/packages/app/i18n/locales/de.json
@@ -1968,5 +1968,27 @@
     "dontShowAgain": "Nicht mehr anzeigen",
     "resetButton": "Neuigkeiten erneut anzeigen",
     "resetSuccess": "Neuigkeiten werden beim nächsten Start wieder angezeigt"
+  },
+  "errors": {
+    "openai": {
+      "insufficientQuota": "OpenAI-Guthaben aufgebraucht. Bitte Zahlungsmethode unter platform.openai.com prüfen.",
+      "invalidApiKey": "Ungültiger API-Schlüssel. Bitte in den Einstellungen prüfen.",
+      "rateLimitExceeded": "Zu viele Anfragen. Bitte kurz warten und erneut versuchen.",
+      "contentPolicyViolation": "Der Inhalt verstößt gegen die OpenAI-Richtlinien. Bitte Beschreibung anpassen.",
+      "billingHardLimitReached": "OpenAI-Kostenlimit erreicht. Bitte Limits unter platform.openai.com prüfen.",
+      "serverError": "OpenAI-Server nicht erreichbar. Bitte später erneut versuchen.",
+      "modelNotFound": "Das ausgewählte KI-Modell ist nicht verfügbar.",
+      "unknown": "Ein Fehler bei der KI-Anfrage ist aufgetreten."
+    },
+    "upload": {
+      "imageFailed": "Bild-Upload fehlgeschlagen. Bitte erneut versuchen.",
+      "pdfFailed": "PDF-Upload fehlgeschlagen. Bitte erneut versuchen.",
+      "audioFailed": "Audio-Upload fehlgeschlagen. Bitte erneut versuchen.",
+      "downloadFailed": "Download fehlgeschlagen. Bitte erneut versuchen."
+    },
+    "image": {
+      "generateFailed": "Bildgenerierung fehlgeschlagen.",
+      "deleteFailed": "Bild konnte nicht gelöscht werden."
+    }
   }
 }

--- a/packages/app/i18n/locales/en.json
+++ b/packages/app/i18n/locales/en.json
@@ -1992,5 +1992,27 @@
     "dontShowAgain": "Don't show again",
     "resetButton": "Show announcements again",
     "resetSuccess": "Announcements will be shown on next start"
+  },
+  "errors": {
+    "openai": {
+      "insufficientQuota": "OpenAI credits exhausted. Please check your billing at platform.openai.com.",
+      "invalidApiKey": "Invalid API key. Please check your settings.",
+      "rateLimitExceeded": "Too many requests. Please wait a moment and try again.",
+      "contentPolicyViolation": "Content violates OpenAI policies. Please adjust the description.",
+      "billingHardLimitReached": "OpenAI billing limit reached. Please check your limits at platform.openai.com.",
+      "serverError": "OpenAI server unavailable. Please try again later.",
+      "modelNotFound": "The selected AI model is not available.",
+      "unknown": "An error occurred during the AI request."
+    },
+    "upload": {
+      "imageFailed": "Image upload failed. Please try again.",
+      "pdfFailed": "PDF upload failed. Please try again.",
+      "audioFailed": "Audio upload failed. Please try again.",
+      "downloadFailed": "Download failed. Please try again."
+    },
+    "image": {
+      "generateFailed": "Image generation failed.",
+      "deleteFailed": "Could not delete image."
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Replace all browser `alert()` calls with user-friendly snackbars
- Add translated error messages for OpenAI API errors (DE/EN)
- Persistent snackbars for errors (require explicit close)

## Changes
- **New**: `useErrorHandler` composable for parsing and translating API errors
- **Enhanced**: Snackbar store with `persistent` option
- **Updated**: 6 components (NpcEditDialog, PlayerEditDialog, EntityImageGallery, EntityDocuments, SessionImageGallery, SessionAudioGallery, Player)
- **i18n**: Error translations for OpenAI quota, invalid key, rate limit, etc.

## Test Plan
- [ ] Trigger AI name/image generation with invalid API key → shows translated error
- [ ] Upload large file → shows upload error snackbar
- [ ] Persistent snackbars show close button and don't auto-dismiss

Closes #175