### PR TITLE
fix: large map uploads via streaming (#179)

### DIFF
--- a/packages/app/app/pages/maps/index.vue
+++ b/packages/app/app/pages/maps/index.vue
@@ -478,7 +478,10 @@
 import type { CampaignMap, MapMarker, MapArea } from '~~/types/map'
 import { ENTITY_TYPE_ICONS, ENTITY_TYPE_COLORS } from '~~/types/map'
 import type { EntityPreviewType } from '~/components/shared/EntityPreviewDialog.vue'
+import { useSnackbarStore } from '~/stores/snackbar'
 
+const { t } = useI18n()
+const snackbarStore = useSnackbarStore()
 const campaignStore = useCampaignStore()
 const activeCampaignId = computed(() => campaignStore.activeCampaignId)
 
@@ -734,8 +737,17 @@ async function uploadMap() {
 
     // Open the newly created map directly
     await selectMap(map)
-  } catch (error) {
+  } catch (error: unknown) {
     console.error('Failed to upload map:', error)
+    // Show translated error message
+    const errorMessage = (error as { statusMessage?: string })?.statusMessage
+    if (errorMessage === 'INVALID_FILE_TYPE') {
+      snackbarStore.error(t('maps.errors.invalidFileType'))
+    } else if (errorMessage === 'FILE_TOO_LARGE') {
+      snackbarStore.error(t('maps.errors.fileTooLarge'))
+    } else {
+      snackbarStore.error(t('maps.errors.uploadFailed'))
+    }
   } finally {
     uploading.value = false
   }
@@ -1138,8 +1150,17 @@ async function saveMapEdit() {
 
     showEditDialog.value = false
     editingMap.value = null
-  } catch (error) {
+  } catch (error: unknown) {
     console.error('Failed to update map:', error)
+    // Show translated error message
+    const errorMessage = (error as { statusMessage?: string })?.statusMessage
+    if (errorMessage === 'INVALID_FILE_TYPE') {
+      snackbarStore.error(t('maps.errors.invalidFileType'))
+    } else if (errorMessage === 'FILE_TOO_LARGE') {
+      snackbarStore.error(t('maps.errors.fileTooLarge'))
+    } else {
+      snackbarStore.error(t('maps.errors.updateFailed'))
+    }
   } finally {
     saving.value = false
   }

--- a/packages/app/i18n/locales/de.json
+++ b/packages/app/i18n/locales/de.json
@@ -1930,7 +1930,13 @@
     "areaConflictMessage": "{count} Markierung(en) würden nach dieser Änderung außerhalb von '{location}' liegen:",
     "areaConflictMove": "Markierungen mit dem Bereich verschieben",
     "areaConflictKeep": "Markierungen an aktueller Position belassen",
-    "areaConflictRemove": "Standort-Zuweisung der Markierungen entfernen"
+    "areaConflictRemove": "Standort-Zuweisung der Markierungen entfernen",
+    "errors": {
+      "invalidFileType": "Ungültiger Dateityp. Erlaubt: JPG, PNG, GIF, WebP, BMP",
+      "fileTooLarge": "Datei zu groß. Maximale Größe: 50MB",
+      "uploadFailed": "Karte konnte nicht hochgeladen werden",
+      "updateFailed": "Karte konnte nicht aktualisiert werden"
+    }
   },
   "update": {
     "newVersionAvailable": "Neue Version verfügbar",

--- a/packages/app/i18n/locales/en.json
+++ b/packages/app/i18n/locales/en.json
@@ -1954,7 +1954,13 @@
     "areaConflictMessage": "{count} marker(s) would be outside '{location}' after this change:",
     "areaConflictMove": "Move markers with the area",
     "areaConflictKeep": "Keep markers at current position",
-    "areaConflictRemove": "Remove location assignment from markers"
+    "areaConflictRemove": "Remove location assignment from markers",
+    "errors": {
+      "invalidFileType": "Invalid file type. Allowed: JPG, PNG, GIF, WebP, BMP",
+      "fileTooLarge": "File too large. Maximum size: 50MB",
+      "uploadFailed": "Failed to upload map",
+      "updateFailed": "Failed to update map"
+    }
   },
   "update": {
     "newVersionAvailable": "New version available",

--- a/packages/app/server/api/maps/[id]/upload-image.post.ts
+++ b/packages/app/server/api/maps/[id]/upload-image.post.ts
@@ -1,8 +1,107 @@
-import { mkdir, writeFile } from 'fs/promises'
+import { mkdir, writeFile, rm } from 'fs/promises'
+import { createWriteStream } from 'fs'
 import { join } from 'path'
+import { tmpdir } from 'os'
+import { randomUUID } from 'crypto'
 import { getDb } from '~~/server/utils/db'
 import { getUploadPath } from '~~/server/utils/paths'
 import type { CampaignMap } from '~~/types/map'
+
+// =============================================================================
+// STREAMING MULTIPART PARSER FOR LARGE MAP IMAGES
+// =============================================================================
+// Large battlemaps can be 16-50MB. The default h3 readMultipartFormData()
+// has array size limits that fail with large files ("Invalid array length").
+//
+// This streaming implementation:
+// 1. Streams the raw HTTP body directly to a temp file
+// 2. Parses the multipart boundaries to extract the image
+// 3. Validates and saves the image file
+// =============================================================================
+
+// Stream request body to temp file
+async function streamBodyToFile(event: Parameters<typeof defineEventHandler>[0] extends (e: infer E) => unknown ? E : never, filePath: string): Promise<void> {
+  const stream = getRequestWebStream(event)
+  if (!stream) {
+    throw new Error('No request stream available')
+  }
+
+  const reader = stream.getReader()
+  const writeStream = createWriteStream(filePath)
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+      writeStream.write(value)
+    }
+  } finally {
+    writeStream.end()
+    await new Promise<void>((resolve, reject) => {
+      writeStream.on('finish', resolve)
+      writeStream.on('error', reject)
+    })
+  }
+}
+
+// Parse multipart boundary from content-type header
+function getMultipartBoundary(contentType: string): string | null {
+  const match = contentType.match(/boundary=(?:"([^"]+)"|([^;]+))/)
+  return match ? (match[1] || match[2]) : null
+}
+
+// Extract image from multipart data
+async function extractImageFromMultipart(rawFilePath: string, boundary: string): Promise<{ data: Buffer; contentType: string; filename: string } | null> {
+  const { readFile } = await import('fs/promises')
+
+  const raw = await readFile(rawFilePath)
+  const boundaryMarker = Buffer.from(`--${boundary}`)
+
+  // Find parts by splitting on boundary
+  let start = 0
+  while (start < raw.length) {
+    const boundaryIndex = raw.indexOf(boundaryMarker, start)
+    if (boundaryIndex === -1) break
+
+    const nextBoundary = raw.indexOf(boundaryMarker, boundaryIndex + boundaryMarker.length)
+    if (nextBoundary === -1) break
+
+    const partData = raw.subarray(boundaryIndex + boundaryMarker.length, nextBoundary)
+
+    // Find headers end (double CRLF)
+    const headersEnd = partData.indexOf(Buffer.from('\r\n\r\n'))
+    if (headersEnd === -1) {
+      start = boundaryIndex + boundaryMarker.length
+      continue
+    }
+
+    const headersStr = partData.subarray(0, headersEnd).toString('utf-8')
+
+    // Check if this is the image field
+    if (headersStr.includes('name="image"')) {
+      // Extract content type
+      const contentTypeMatch = headersStr.match(/Content-Type:\s*([^\r\n]+)/i)
+      const contentType = contentTypeMatch ? contentTypeMatch[1].trim() : 'application/octet-stream'
+
+      // Extract filename
+      const filenameMatch = headersStr.match(/filename="([^"]+)"/)
+      const filename = filenameMatch ? filenameMatch[1] : 'image.jpg'
+
+      // Extract body (skip headers + CRLF, trim trailing CRLF before boundary)
+      let body = partData.subarray(headersEnd + 4)
+      // Trim trailing \r\n before boundary
+      if (body.length >= 2 && body[body.length - 2] === 0x0d && body[body.length - 1] === 0x0a) {
+        body = body.subarray(0, -2)
+      }
+
+      return { data: body, contentType, filename }
+    }
+
+    start = nextBoundary
+  }
+
+  return null
+}
 
 export default defineEventHandler(async (event) => {
   const db = getDb()
@@ -27,62 +126,79 @@ export default defineEventHandler(async (event) => {
     })
   }
 
-  const formData = await readMultipartFormData(event)
-  if (!formData) {
+  // Get content type and boundary
+  const contentType = getHeader(event, 'content-type') || ''
+  const boundary = getMultipartBoundary(contentType)
+
+  if (!boundary) {
     throw createError({
       statusCode: 400,
-      statusMessage: 'No file uploaded',
+      statusMessage: 'Invalid multipart request',
     })
   }
 
-  const file = formData.find((f) => f.name === 'image')
-  if (!file || !file.data) {
-    throw createError({
-      statusCode: 400,
-      statusMessage: 'No image file found',
-    })
+  // Stream body to temp file
+  const tempDir = join(tmpdir(), `dm-hero-map-${randomUUID()}`)
+  const tempFile = join(tempDir, 'upload.raw')
+  await mkdir(tempDir, { recursive: true })
+
+  try {
+    await streamBodyToFile(event, tempFile)
+
+    // Extract image from multipart
+    const image = await extractImageFromMultipart(tempFile, boundary)
+
+    if (!image) {
+      throw createError({
+        statusCode: 400,
+        statusMessage: 'No image file found',
+      })
+    }
+
+    // Validate file type
+    const allowedTypes = ['image/jpeg', 'image/png', 'image/gif', 'image/webp', 'image/bmp']
+    if (!allowedTypes.includes(image.contentType)) {
+      throw createError({
+        statusCode: 400,
+        statusMessage: 'INVALID_FILE_TYPE',
+      })
+    }
+
+    // Validate file size (max 50MB for maps - battlemaps can be very large)
+    const maxSize = 50 * 1024 * 1024
+    if (image.data.length > maxSize) {
+      throw createError({
+        statusCode: 400,
+        statusMessage: 'FILE_TOO_LARGE',
+      })
+    }
+
+    // Generate filename
+    const ext = image.contentType.split('/')[1] || 'jpg'
+    const filename = `map_${id}_${Date.now()}.${ext}`
+
+    // Ensure maps directory exists
+    const uploadBase = getUploadPath()
+    const mapsDir = join(uploadBase, 'maps')
+    await mkdir(mapsDir, { recursive: true })
+
+    // Save file
+    const filePath = join(mapsDir, filename)
+    await writeFile(filePath, image.data)
+
+    // Update map with image URL
+    const imageUrl = `maps/${filename}`
+    db.prepare(
+      'UPDATE campaign_maps SET image_url = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?',
+    ).run(imageUrl, Number(id))
+
+    const map = db
+      .prepare('SELECT * FROM campaign_maps WHERE id = ?')
+      .get(Number(id)) as CampaignMap
+
+    return map
+  } finally {
+    // Cleanup temp files
+    await rm(tempDir, { recursive: true, force: true }).catch(() => {})
   }
-
-  // Validate file type
-  const allowedTypes = ['image/jpeg', 'image/png', 'image/gif', 'image/webp']
-  if (!file.type || !allowedTypes.includes(file.type)) {
-    throw createError({
-      statusCode: 400,
-      statusMessage: 'Invalid file type. Allowed: JPG, PNG, GIF, WebP',
-    })
-  }
-
-  // Validate file size (max 20MB for maps - larger than normal images)
-  const maxSize = 20 * 1024 * 1024
-  if (file.data.length > maxSize) {
-    throw createError({
-      statusCode: 400,
-      statusMessage: 'File too large. Maximum size: 20MB',
-    })
-  }
-
-  // Generate filename
-  const ext = file.type.split('/')[1] || 'jpg'
-  const filename = `map_${id}_${Date.now()}.${ext}`
-
-  // Ensure maps directory exists
-  const uploadBase = getUploadPath()
-  const mapsDir = join(uploadBase, 'maps')
-  await mkdir(mapsDir, { recursive: true })
-
-  // Save file
-  const filePath = join(mapsDir, filename)
-  await writeFile(filePath, new Uint8Array(file.data))
-
-  // Update map with image URL
-  const imageUrl = `maps/${filename}`
-  db.prepare(
-    'UPDATE campaign_maps SET image_url = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?',
-  ).run(imageUrl, Number(id))
-
-  const map = db
-    .prepare('SELECT * FROM campaign_maps WHERE id = ?')
-    .get(Number(id)) as CampaignMap
-
-  return map
 })

--- a/packages/app/server/middleware/uploads.ts
+++ b/packages/app/server/middleware/uploads.ts
@@ -1,5 +1,6 @@
 import { join } from 'node:path'
-import { readFile, stat } from 'node:fs/promises'
+import { stat } from 'node:fs/promises'
+import { createReadStream } from 'node:fs'
 import { getUploadPath } from '../utils/paths'
 
 /**
@@ -49,9 +50,6 @@ export default defineEventHandler(async (event) => {
       return // Let it fall through to 404
     }
 
-    // Read and serve the file
-    const fileBuffer = await readFile(fullPath)
-
     // Set content type based on extension
     const ext = filename.split('.').pop()?.toLowerCase()
     const contentTypes: Record<string, string> = {
@@ -60,16 +58,21 @@ export default defineEventHandler(async (event) => {
       png: 'image/png',
       gif: 'image/gif',
       webp: 'image/webp',
+      bmp: 'image/bmp',
       pdf: 'application/pdf',
+      mp3: 'audio/mpeg',
+      wav: 'audio/wav',
+      ogg: 'audio/ogg',
     }
 
     const contentType = contentTypes[ext || ''] || 'application/octet-stream'
 
     setHeader(event, 'Content-Type', contentType)
-    setHeader(event, 'Content-Length', fileBuffer.length)
+    setHeader(event, 'Content-Length', stats.size)
     setHeader(event, 'Cache-Control', 'public, max-age=31536000') // 1 year cache
 
-    return fileBuffer
+    // Stream file instead of loading into memory (crucial for large maps 25MB+)
+    return sendStream(event, createReadStream(fullPath))
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
       return // Let it fall through to 404


### PR DESCRIPTION
Stream large map uploads to disk, increase limit to 50MB, add BMP support, add translated error messages. Fixes #179