### PR TITLE
feat: sort all dropdown selections alphabetically

### DIFF
--- a/packages/app/app/components/factions/FactionEditDialog.vue
+++ b/packages/app/app/components/factions/FactionEditDialog.vue
@@ -601,7 +601,7 @@ const membershipTypeSuggestions = computed(() =>
   FACTION_MEMBERSHIP_TYPES.map((type) => ({
     value: type,
     title: t(`factions.membershipTypes.${type}`),
-  })),
+  })).sort((a, b) => a.title.localeCompare(b.title)),
 )
 
 // Faction type options from TypeScript types
@@ -610,7 +610,7 @@ const factionTypes = computed((): Array<{ value: string; title: string }> =>
   FACTION_TYPES.map((type) => ({
     value: type,
     title: t(`factions.types.${type}`),
-  })),
+  })).sort((a, b) => a.title.localeCompare(b.title)),
 )
 
 // Faction alignment options from TypeScript types
@@ -618,7 +618,7 @@ const factionAlignments = computed(() =>
   FACTION_ALIGNMENTS.map((alignment) => ({
     value: alignment,
     title: t(`factions.alignments.${alignment}`),
-  })),
+  })).sort((a, b) => a.title.localeCompare(b.title)),
 )
 
 // ============================================================================

--- a/packages/app/app/components/factions/FactionLocationsTab.vue
+++ b/packages/app/app/components/factions/FactionLocationsTab.vue
@@ -188,7 +188,7 @@ const relationTypeSuggestions = computed(() =>
   FACTION_LOCATION_TYPES.map((type) => ({
     value: type,
     title: t(`factions.locationTypes.${type}`),
-  })),
+  })).sort((a, b) => a.title.localeCompare(b.title)),
 )
 
 function handleAdd() {

--- a/packages/app/app/components/factions/FactionRelationsTab.vue
+++ b/packages/app/app/components/factions/FactionRelationsTab.vue
@@ -202,7 +202,7 @@ const factionRelationTypeSuggestions = computed(() =>
   FACTION_RELATION_TYPES.map((type) => ({
     value: type,
     title: t(`factions.factionRelationTypes.${type}`),
-  })),
+  })).sort((a, b) => a.title.localeCompare(b.title)),
 )
 
 function getNotesText(notes: string | Record<string, unknown> | null): string {

--- a/packages/app/app/components/items/ItemEditDialog.vue
+++ b/packages/app/app/components/items/ItemEditDialog.vue
@@ -121,7 +121,7 @@
               <v-col cols="12" md="6">
                 <v-select
                   v-model="form.metadata.type"
-                  :items="ITEM_TYPES"
+                  :items="sortedItemTypes"
                   :label="$t('items.type')"
                   variant="outlined"
                   clearable
@@ -137,7 +137,7 @@
               <v-col cols="12" md="6">
                 <v-select
                   v-model="form.metadata.rarity"
-                  :items="ITEM_RARITIES"
+                  :items="sortedItemRarities"
                   :label="$t('items.rarity')"
                   variant="outlined"
                   clearable
@@ -523,7 +523,7 @@
             <v-col cols="12" md="6">
               <v-select
                 v-model="form.metadata.type"
-                :items="ITEM_TYPES"
+                :items="sortedItemTypes"
                 :label="$t('items.type')"
                 variant="outlined"
                 clearable
@@ -539,7 +539,7 @@
             <v-col cols="12" md="6">
               <v-select
                 v-model="form.metadata.rarity"
-                :items="ITEM_RARITIES"
+                :items="sortedItemRarities"
                 :label="$t('items.rarity')"
                 variant="outlined"
                 clearable
@@ -792,7 +792,15 @@ const npcRelationTypeOptions = computed(() =>
   NPC_ITEM_RELATION_TYPES.map((type) => ({
     value: type,
     title: t(`items.ownerRelationTypes.${type}`, type),
-  })),
+  })).sort((a, b) => a.title.localeCompare(b.title)),
+)
+
+// Sorted item types and rarities
+const sortedItemTypes = computed(() =>
+  [...ITEM_TYPES].sort((a, b) => t(`items.types.${a}`).localeCompare(t(`items.types.${b}`))),
+)
+const sortedItemRarities = computed(() =>
+  [...ITEM_RARITIES].sort((a, b) => t(`items.rarities.${a}`).localeCompare(t(`items.rarities.${b}`))),
 )
 const newLocation = ref({ locationId: null as number | null, quantity: 1 })
 const newFaction = ref({ factionId: null as number | null })

--- a/packages/app/app/components/locations/LocationEditDialog.vue
+++ b/packages/app/app/components/locations/LocationEditDialog.vue
@@ -423,14 +423,14 @@ const itemRelationTypeSuggestions = computed(() =>
   LOCATION_ITEM_RELATION_TYPES.map((type) => ({
     value: type,
     title: t(`locations.itemRelationTypes.${type}`),
-  })),
+  })).sort((a, b) => a.title.localeCompare(b.title)),
 )
 
 const locationTypes = computed(() =>
   LOCATION_TYPES.map((type) => ({
     value: type,
     title: t(`locations.types.${type}`),
-  })),
+  })).sort((a, b) => a.title.localeCompare(b.title)),
 )
 
 // Snapshot of original values for image-critical fields

--- a/packages/app/app/components/lore/LoreEditDialog.vue
+++ b/packages/app/app/components/lore/LoreEditDialog.vue
@@ -577,7 +577,7 @@ const loreTypeItems = computed(() =>
   LORE_TYPES.map((type) => ({
     title: t(`lore.types.${type}`),
     value: type,
-  })),
+  })).sort((a, b) => a.title.localeCompare(b.title)),
 )
 
 // ============================================================================

--- a/packages/app/app/components/npcs/NpcEditDialog.vue
+++ b/packages/app/app/components/npcs/NpcEditDialog.vue
@@ -667,17 +667,21 @@ const previewImageTitle = ref('')
 // Computed: Reference data for selects
 // ============================================================================
 const raceItems = computed(() =>
-  races.value.map((race) => ({
-    title: locale.value === 'de' ? (race.name_de || race.name) : (race.name_en || race.name),
-    value: race.name,
-  })),
+  races.value
+    .map((race) => ({
+      title: locale.value === 'de' ? (race.name_de || race.name) : (race.name_en || race.name),
+      value: race.name,
+    }))
+    .sort((a, b) => a.title.localeCompare(b.title)),
 )
 
 const classItems = computed(() =>
-  classes.value.map((cls) => ({
-    title: locale.value === 'de' ? (cls.name_de || cls.name) : (cls.name_en || cls.name),
-    value: cls.name,
-  })),
+  classes.value
+    .map((cls) => ({
+      title: locale.value === 'de' ? (cls.name_de || cls.name) : (cls.name_en || cls.name),
+      value: cls.name,
+    }))
+    .sort((a, b) => a.title.localeCompare(b.title)),
 )
 
 const genderItems = computed(() => [
@@ -692,14 +696,14 @@ const npcTypes = computed(() =>
   NPC_TYPES.map((type) => ({
     value: type,
     title: t(`npcs.types.${type}`),
-  })),
+  })).sort((a, b) => a.title.localeCompare(b.title)),
 )
 
 const npcStatuses = computed(() =>
   NPC_STATUSES.map((status) => ({
     value: status,
     title: t(`npcs.statuses.${status}`),
-  })),
+  })).sort((a, b) => a.title.localeCompare(b.title)),
 )
 
 // Available entities from store (sorted alphabetically)
@@ -733,7 +737,7 @@ const npcItemRelationTypeSuggestions = computed(() =>
   NPC_ITEM_RELATION_TYPES.map((type) => ({
     value: type,
     title: t(`npcs.itemRelationTypes.${type}`),
-  })),
+  })).sort((a, b) => a.title.localeCompare(b.title)),
 )
 
 // ============================================================================

--- a/packages/app/app/components/npcs/NpcMembershipsTab.vue
+++ b/packages/app/app/components/npcs/NpcMembershipsTab.vue
@@ -206,7 +206,7 @@ const membershipTypeSuggestions = computed(() =>
   FACTION_MEMBERSHIP_TYPES.map((type) => ({
     value: type,
     title: t(`factions.membershipTypes.${type}`),
-  })),
+  })).sort((a, b) => a.title.localeCompare(b.title)),
 )
 
 function handleAdd() {

--- a/packages/app/app/components/npcs/NpcRelationsTab.vue
+++ b/packages/app/app/components/npcs/NpcRelationsTab.vue
@@ -213,7 +213,7 @@ const npcRelationTypeSuggestions = computed(() =>
   NPC_RELATION_TYPES.map((type) => ({
     value: type,
     title: t(`npcs.npcRelationTypes.${type}`),
-  })),
+  })).sort((a, b) => a.title.localeCompare(b.title)),
 )
 
 // Extract text from notes (can be string, JSON string, object with text property, or null)

--- a/packages/app/app/components/players/PlayerCharactersTab.vue
+++ b/packages/app/app/components/players/PlayerCharactersTab.vue
@@ -194,7 +194,7 @@ const relationTypeSuggestions = computed(() =>
   NPC_RELATION_TYPES.map((type) => ({
     value: type,
     title: t(`npcs.npcRelationTypes.${type}`),
-  })),
+  })).sort((a, b) => a.title.localeCompare(b.title)),
 )
 
 watch(

--- a/packages/app/app/components/players/PlayerItemsTab.vue
+++ b/packages/app/app/components/players/PlayerItemsTab.vue
@@ -196,7 +196,7 @@ const relationTypeSuggestions = computed(() =>
   NPC_ITEM_RELATION_TYPES.map((type) => ({
     value: type,
     title: t(`players.itemRelationTypes.${type}`),
-  })),
+  })).sort((a, b) => a.title.localeCompare(b.title)),
 )
 
 watch(

--- a/packages/app/app/components/players/PlayerLoreTab.vue
+++ b/packages/app/app/components/players/PlayerLoreTab.vue
@@ -194,7 +194,7 @@ const relationTypeSuggestions = computed(() =>
   PLAYER_RELATION_TYPES.map((type) => ({
     value: type,
     title: t(`players.loreRelationTypes.${type}`),
-  })),
+  })).sort((a, b) => a.title.localeCompare(b.title)),
 )
 
 watch(

--- a/packages/app/app/components/shared/EntityFactionsTab.vue
+++ b/packages/app/app/components/shared/EntityFactionsTab.vue
@@ -197,7 +197,7 @@ const relationTypeSuggestions = computed(() =>
   FACTION_MEMBERSHIP_TYPES.map((type) => ({
     value: type,
     title: t(`factions.membershipTypes.${type}`),
-  })),
+  })).sort((a, b) => a.title.localeCompare(b.title)),
 )
 
 // Load factions on mount and when entityId changes

--- a/packages/app/app/components/shared/EntityLocationsTab.vue
+++ b/packages/app/app/components/shared/EntityLocationsTab.vue
@@ -199,7 +199,7 @@ const relationTypeSuggestions = computed(() =>
   NPC_LOCATION_RELATION_TYPES.map((type) => ({
     value: type,
     title: t(`npcs.relationTypes.${type}`),
-  })),
+  })).sort((a, b) => a.title.localeCompare(b.title)),
 )
 
 // Track dirty state: form has data or edit dialog is open

--- a/packages/app/app/components/shared/EntityPlayersTab.vue
+++ b/packages/app/app/components/shared/EntityPlayersTab.vue
@@ -193,7 +193,7 @@ const relationTypeSuggestions = computed(() =>
   PLAYER_RELATION_TYPES.map((type) => ({
     value: type,
     title: t(`players.relationTypes.${type}`),
-  })),
+  })).sort((a, b) => a.title.localeCompare(b.title)),
 )
 
 // Track dirty state: form has data or edit dialog is open


### PR DESCRIPTION
## Summary
- All dropdown/select components now sort their options alphabetically using `localeCompare()`
- Sorting is reactive - when data changes, dropdowns re-sort automatically

## Affected Components
- NpcEditDialog (race, class, type, status, item relations)
- LocationEditDialog (type, item relations)
- ItemEditDialog (type, rarity, owner relations)
- FactionEditDialog (type, alignment, membership types)
- LoreEditDialog (type)
- NpcRelationsTab, NpcMembershipsTab
- FactionRelationsTab, FactionLocationsTab
- EntityLocationsTab, EntityFactionsTab, EntityPlayersTab
- PlayerCharactersTab, PlayerItemsTab, PlayerLoreTab

Closes #185