### PR TITLE
perf: replace N count requests with 1 batch endpoint

### DIFF
--- a/packages/app/app/composables/useFactionCounts.ts
+++ b/packages/app/app/composables/useFactionCounts.ts
@@ -17,6 +17,7 @@ interface FactionCounts {
 // SHARED STATE - outside the function so all components share the same cache
 const loadingCounts = ref<Set<number>>(new Set())
 const countsMap = reactive<Record<number, FactionCounts | undefined>>({})
+const batchLoading = ref(false)
 
 /**
  * Composable to load Faction counts asynchronously
@@ -54,11 +55,36 @@ export function useFactionCounts() {
   }
 
   /**
-   * Load counts for multiple Factions in parallel
+   * Load counts for multiple Factions in parallel (legacy - uses individual requests)
    */
   async function loadFactionCountsBatch(factions: Faction[]): Promise<void> {
     const promises = factions.map((faction) => loadFactionCounts(faction))
     await Promise.all(promises)
+  }
+
+  /**
+   * Load ALL counts for a campaign in ONE request (efficient!)
+   * Replaces N individual requests with 1 batch request
+   */
+  async function loadAllCountsForCampaign(campaignId: string | number): Promise<void> {
+    if (batchLoading.value) return
+
+    batchLoading.value = true
+    try {
+      const allCounts = await $fetch<Record<number, FactionCounts>>('/api/factions/batch-counts', {
+        query: { campaignId },
+      })
+
+      // Store all counts in the cache
+      for (const [factionIdStr, counts] of Object.entries(allCounts)) {
+        const factionId = Number(factionIdStr)
+        countsMap[factionId] = counts
+      }
+    } catch (error) {
+      console.error('Failed to load Faction counts batch:', error)
+    } finally {
+      batchLoading.value = false
+    }
   }
 
   /**
@@ -102,10 +128,12 @@ export function useFactionCounts() {
   return {
     loadFactionCounts,
     loadFactionCountsBatch,
+    loadAllCountsForCampaign,
     getCounts,
     setCounts,
     reloadFactionCounts,
     clearCountsCache,
     loadingCounts: computed(() => loadingCounts.value),
+    batchLoading: computed(() => batchLoading.value),
   }
 }

--- a/packages/app/app/composables/useItemCounts.ts
+++ b/packages/app/app/composables/useItemCounts.ts
@@ -3,6 +3,7 @@ import type { ItemCounts, Item } from '../../types/item.js'
 // SHARED STATE - outside the function so all components share the same cache
 const loadingCounts = ref<Set<number>>(new Set())
 const countsMap = reactive<Record<number, ItemCounts | undefined>>({})
+const batchLoading = ref(false)
 
 /**
  * Composable to load Item counts asynchronously
@@ -40,11 +41,36 @@ export function useItemCounts() {
   }
 
   /**
-   * Load counts for multiple Items in parallel
+   * Load counts for multiple Items in parallel (legacy - uses individual requests)
    */
   async function loadItemCountsBatch(items: Item[]): Promise<void> {
     const promises = items.map((item) => loadItemCounts(item))
     await Promise.all(promises)
+  }
+
+  /**
+   * Load ALL counts for a campaign in ONE request (efficient!)
+   * Replaces N individual requests with 1 batch request
+   */
+  async function loadAllCountsForCampaign(campaignId: string | number): Promise<void> {
+    if (batchLoading.value) return
+
+    batchLoading.value = true
+    try {
+      const allCounts = await $fetch<Record<number, ItemCounts>>('/api/items/batch-counts', {
+        query: { campaignId },
+      })
+
+      // Store all counts in the cache
+      for (const [itemIdStr, counts] of Object.entries(allCounts)) {
+        const itemId = Number(itemIdStr)
+        countsMap[itemId] = counts
+      }
+    } catch (error) {
+      console.error('Failed to load Item counts batch:', error)
+    } finally {
+      batchLoading.value = false
+    }
   }
 
   /**
@@ -88,10 +114,12 @@ export function useItemCounts() {
   return {
     loadItemCounts,
     loadItemCountsBatch,
+    loadAllCountsForCampaign,
     getCounts,
     setCounts,
     reloadItemCounts,
     clearCountsCache,
     loadingCounts: computed(() => loadingCounts.value),
+    batchLoading: computed(() => batchLoading.value),
   }
 }

--- a/packages/app/app/composables/useLoreCounts.ts
+++ b/packages/app/app/composables/useLoreCounts.ts
@@ -16,6 +16,7 @@ interface LoreCounts {
 // SHARED STATE - outside the function so all components share the same cache
 const loadingCounts = ref<Set<number>>(new Set())
 const countsMap = reactive<Record<number, LoreCounts | undefined>>({})
+const batchLoading = ref(false)
 
 /**
  * Composable to load Lore counts asynchronously
@@ -53,11 +54,36 @@ export function useLoreCounts() {
   }
 
   /**
-   * Load counts for multiple Lore entries in parallel
+   * Load counts for multiple Lore entries in parallel (legacy - uses individual requests)
    */
   async function loadLoreCountsBatch(loreEntries: Lore[]): Promise<void> {
     const promises = loreEntries.map((lore) => loadLoreCounts(lore))
     await Promise.all(promises)
+  }
+
+  /**
+   * Load ALL counts for a campaign in ONE request (efficient!)
+   * Replaces N individual requests with 1 batch request
+   */
+  async function loadAllCountsForCampaign(campaignId: string | number): Promise<void> {
+    if (batchLoading.value) return
+
+    batchLoading.value = true
+    try {
+      const allCounts = await $fetch<Record<number, LoreCounts>>('/api/lore/batch-counts', {
+        query: { campaignId },
+      })
+
+      // Store all counts in the cache
+      for (const [loreIdStr, counts] of Object.entries(allCounts)) {
+        const loreId = Number(loreIdStr)
+        countsMap[loreId] = counts
+      }
+    } catch (error) {
+      console.error('Failed to load Lore counts batch:', error)
+    } finally {
+      batchLoading.value = false
+    }
   }
 
   /**
@@ -101,10 +127,12 @@ export function useLoreCounts() {
   return {
     loadLoreCounts,
     loadLoreCountsBatch,
+    loadAllCountsForCampaign,
     getCounts,
     setCounts,
     reloadLoreCounts,
     clearCountsCache,
     loadingCounts: computed(() => loadingCounts.value),
+    batchLoading: computed(() => batchLoading.value),
   }
 }

--- a/packages/app/app/composables/useNpcCounts.ts
+++ b/packages/app/app/composables/useNpcCounts.ts
@@ -3,6 +3,7 @@ import type { NPC, NpcCounts } from '../../types/npc.js'
 // SHARED STATE - outside the function so all components share the same cache
 const loadingCounts = ref<Set<number>>(new Set())
 const countsMap = reactive<Record<number, NpcCounts | undefined>>({})
+const batchLoading = ref(false)
 
 /**
  * Composable to load NPC counts asynchronously
@@ -40,11 +41,36 @@ export function useNpcCounts() {
   }
 
   /**
-   * Load counts for multiple NPCs in parallel
+   * Load counts for multiple NPCs in parallel (legacy - uses individual requests)
    */
   async function loadNpcCountsBatch(npcs: NPC[]): Promise<void> {
     const promises = npcs.map((npc) => loadNpcCounts(npc))
     await Promise.all(promises)
+  }
+
+  /**
+   * Load ALL counts for a campaign in ONE request (efficient!)
+   * Replaces N individual requests with 1 batch request
+   */
+  async function loadAllCountsForCampaign(campaignId: string | number): Promise<void> {
+    if (batchLoading.value) return
+
+    batchLoading.value = true
+    try {
+      const allCounts = await $fetch<Record<number, NpcCounts>>('/api/npcs/batch-counts', {
+        query: { campaignId },
+      })
+
+      // Store all counts in the cache
+      for (const [npcIdStr, counts] of Object.entries(allCounts)) {
+        const npcId = Number(npcIdStr)
+        countsMap[npcId] = counts
+      }
+    } catch (error) {
+      console.error('Failed to load NPC counts batch:', error)
+    } finally {
+      batchLoading.value = false
+    }
   }
 
   /**
@@ -118,6 +144,7 @@ export function useNpcCounts() {
   return {
     loadNpcCounts,
     loadNpcCountsBatch,
+    loadAllCountsForCampaign,
     getCounts,
     setCounts,
     reloadNpcCounts,
@@ -125,5 +152,6 @@ export function useNpcCounts() {
     invalidateCountsFor,
     reloadCountsFor,
     loadingCounts: computed(() => loadingCounts.value),
+    batchLoading: computed(() => batchLoading.value),
   }
 }

--- a/packages/app/app/composables/usePlayerCounts.ts
+++ b/packages/app/app/composables/usePlayerCounts.ts
@@ -3,6 +3,7 @@ import type { PlayerCounts, Player } from '../../types/player.js'
 // SHARED STATE - outside the function so all components share the same cache
 const loadingCounts = ref<Set<number>>(new Set())
 const countsMap = reactive<Record<number, PlayerCounts | undefined>>({})
+const batchLoading = ref(false)
 
 /**
  * Composable to load Player counts asynchronously
@@ -40,11 +41,36 @@ export function usePlayerCounts() {
   }
 
   /**
-   * Load counts for multiple Players in parallel
+   * Load counts for multiple Players in parallel (legacy - uses individual requests)
    */
   async function loadPlayerCountsBatch(players: Player[]): Promise<void> {
     const promises = players.map((player) => loadPlayerCounts(player))
     await Promise.all(promises)
+  }
+
+  /**
+   * Load ALL counts for a campaign in ONE request (efficient!)
+   * Replaces N individual requests with 1 batch request
+   */
+  async function loadAllCountsForCampaign(campaignId: string | number): Promise<void> {
+    if (batchLoading.value) return
+
+    batchLoading.value = true
+    try {
+      const allCounts = await $fetch<Record<number, PlayerCounts>>('/api/players/batch-counts', {
+        query: { campaignId },
+      })
+
+      // Store all counts in the cache
+      for (const [playerIdStr, counts] of Object.entries(allCounts)) {
+        const playerId = Number(playerIdStr)
+        countsMap[playerId] = counts
+      }
+    } catch (error) {
+      console.error('Failed to load Player counts batch:', error)
+    } finally {
+      batchLoading.value = false
+    }
   }
 
   /**
@@ -88,10 +114,12 @@ export function usePlayerCounts() {
   return {
     loadPlayerCounts,
     loadPlayerCountsBatch,
+    loadAllCountsForCampaign,
     getCounts,
     setCounts,
     reloadPlayerCounts,
     clearCountsCache,
     loadingCounts: computed(() => loadingCounts.value),
+    batchLoading: computed(() => batchLoading.value),
   }
 }

--- a/packages/app/app/pages/factions/index.vue
+++ b/packages/app/app/pages/factions/index.vue
@@ -263,7 +263,7 @@ watch(searchQuery, () => {
 // ============================================================================
 // Data Loading
 // ============================================================================
-const { loadFactionCountsBatch } = useFactionCounts()
+const { loadAllCountsForCampaign, loadFactionCountsBatch } = useFactionCounts()
 const { downloadImage } = useImageDownload()
 
 const factions = computed(() => entitiesStore.factions)
@@ -273,7 +273,8 @@ onMounted(async () => {
   await entitiesStore.fetchFactions(activeCampaignId.value!)
 
   if (factions.value && factions.value.length > 0) {
-    loadFactionCountsBatch(factions.value)
+    // Use batch endpoint - 1 request instead of N
+    await loadAllCountsForCampaign(activeCampaignId.value!)
   }
 
   initializeFromQuery()

--- a/packages/app/app/pages/items/index.vue
+++ b/packages/app/app/pages/items/index.vue
@@ -285,7 +285,7 @@ onMounted(async () => {
   await entitiesStore.fetchItems(activeCampaignId.value!)
 
   if (items.value && items.value.length > 0) {
-    await entitiesStore.loadAllItemCounts()
+    await entitiesStore.loadAllItemCounts(activeCampaignId.value!)
   }
 
   initializeFromQuery()

--- a/packages/app/app/pages/lore/index.vue
+++ b/packages/app/app/pages/lore/index.vue
@@ -205,13 +205,9 @@ const previewImageName = ref('')
 onMounted(async () => {
   await entitiesStore.fetchLore(activeCampaignId.value!)
 
-  // Load counts for all lore entries in background using store
+  // Load counts for all lore entries using batch endpoint - 1 request instead of N
   if (lore.value && lore.value.length > 0) {
-    lore.value.forEach((l) => {
-      if (!l._counts) {
-        entitiesStore.loadLoreCounts(l.id)
-      }
-    })
+    await entitiesStore.loadAllLoreCounts(activeCampaignId.value!)
   }
 
   // Handle highlight query parameter

--- a/packages/app/app/pages/npcs/index.vue
+++ b/packages/app/app/pages/npcs/index.vue
@@ -191,8 +191,8 @@ onMounted(async () => {
   // Load races and classes for view dialog
   await loadReferenceData()
 
-  // Load counts for all NPCs via store
-  await entitiesStore.loadAllNpcCounts()
+  // Load counts for all NPCs via store (uses batch endpoint - 1 request instead of N)
+  await entitiesStore.loadAllNpcCounts(activeCampaignId.value!)
 })
 
 // Search with FTS5

--- a/packages/app/app/pages/players/index.vue
+++ b/packages/app/app/pages/players/index.vue
@@ -129,7 +129,7 @@ const router = useRouter()
 const campaignStore = useCampaignStore()
 const entitiesStore = useEntitiesStore()
 const { downloadImage } = useImageDownload()
-const { loadPlayerCountsBatch, reloadPlayerCounts } = usePlayerCounts()
+const { loadAllCountsForCampaign, loadPlayerCountsBatch, reloadPlayerCounts } = usePlayerCounts()
 
 const activeCampaignId = computed(() => campaignStore.activeCampaignId)
 
@@ -199,9 +199,9 @@ watch(searchQuery, async (query) => {
 onMounted(async () => {
   if (activeCampaignId.value) {
     await entitiesStore.fetchPlayers(activeCampaignId.value)
-    // Load counts for all players using the shared composable
+    // Load counts for all players using batch endpoint - 1 request instead of N
     if (players.value.length > 0) {
-      loadPlayerCountsBatch(players.value)
+      await loadAllCountsForCampaign(activeCampaignId.value)
     }
   }
 })

--- a/packages/app/app/stores/entities.ts
+++ b/packages/app/app/stores/entities.ts
@@ -203,9 +203,18 @@ export const useEntitiesStore = defineStore('entities', {
       }
     },
 
-    // Load counts for all NPCs in the store
-    async loadAllNpcCounts() {
-      await Promise.all(this.npcs.map((npc) => this.loadNpcCounts(npc.id)))
+    // Load counts for all NPCs in the store (uses batch endpoint - 1 request instead of N)
+    async loadAllNpcCounts(campaignId: string | number) {
+      const { loadAllCountsForCampaign, getCounts } = useNpcCounts()
+      await loadAllCountsForCampaign(campaignId)
+
+      // Update store NPCs with counts from cache
+      for (const npc of this.npcs) {
+        const counts = getCounts(npc.id)
+        if (counts) {
+          npc._counts = counts
+        }
+      }
     },
 
     // ==================== Factions ====================
@@ -454,9 +463,18 @@ export const useEntitiesStore = defineStore('entities', {
       }
     },
 
-    // Load counts for all Items in the store
-    async loadAllItemCounts() {
-      await Promise.all(this.items.map((item) => this.loadItemCounts(item.id)))
+    // Load counts for all Items in the store (uses batch endpoint - 1 request instead of N)
+    async loadAllItemCounts(campaignId: string | number) {
+      const { loadAllCountsForCampaign, getCounts } = useItemCounts()
+      await loadAllCountsForCampaign(campaignId)
+
+      // Update store Items with counts from cache
+      for (const item of this.items) {
+        const counts = getCounts(item.id)
+        if (counts) {
+          item._counts = counts
+        }
+      }
     },
 
     // ==================== Lore ====================
@@ -573,9 +591,18 @@ export const useEntitiesStore = defineStore('entities', {
       }
     },
 
-    // Load counts for all Lore entries in the store
-    async loadAllLoreCounts() {
-      await Promise.all(this.lore.map((l) => this.loadLoreCounts(l.id)))
+    // Load counts for all Lore entries in the store (uses batch endpoint - 1 request instead of N)
+    async loadAllLoreCounts(campaignId: string | number) {
+      const { loadAllCountsForCampaign, getCounts } = useLoreCounts()
+      await loadAllCountsForCampaign(campaignId)
+
+      // Update store Lore entries with counts from cache
+      for (const loreEntry of this.lore) {
+        const counts = getCounts(loreEntry.id)
+        if (counts) {
+          loreEntry._counts = counts
+        }
+      }
     },
 
     // Set counts directly (without fetching) - used when we already have the data

--- a/packages/app/server/api/factions/batch-counts.get.ts
+++ b/packages/app/server/api/factions/batch-counts.get.ts
@@ -1,0 +1,305 @@
+import { getDb } from '../../utils/db'
+
+interface FactionCounts {
+  members: number
+  items: number
+  locations: number
+  lore: number
+  players: number
+  documents: number
+  images: number
+  relations: number
+}
+
+/**
+ * GET /api/factions/batch-counts
+ * Returns counts for ALL factions in a campaign in one request
+ */
+export default defineEventHandler((event) => {
+  const db = getDb()
+  const query = getQuery(event)
+  const campaignId = query.campaignId
+
+  if (!campaignId) {
+    throw createError({
+      statusCode: 400,
+      message: 'campaignId is required',
+    })
+  }
+
+  // Get all entity type IDs once
+  const entityTypes = db
+    .prepare('SELECT id, name FROM entity_types WHERE name IN (\'Faction\', \'NPC\', \'Item\', \'Location\', \'Lore\', \'Player\')')
+    .all() as Array<{ id: number; name: string }>
+
+  const typeMap = Object.fromEntries(entityTypes.map((t) => [t.name, t.id]))
+  const factionTypeId = typeMap['Faction']
+  const npcTypeId = typeMap['NPC']
+  const itemTypeId = typeMap['Item']
+  const locationTypeId = typeMap['Location']
+  const loreTypeId = typeMap['Lore']
+  const playerTypeId = typeMap['Player']
+
+  if (!factionTypeId) {
+    return {}
+  }
+
+  // Get all Faction IDs for this campaign
+  const factionIds = db
+    .prepare('SELECT id FROM entities WHERE campaign_id = ? AND type_id = ? AND deleted_at IS NULL')
+    .all(Number(campaignId), factionTypeId) as Array<{ id: number }>
+
+  if (factionIds.length === 0) {
+    return {}
+  }
+
+  const result: Record<number, FactionCounts> = {}
+
+  // Initialize all factions with zero counts
+  for (const faction of factionIds) {
+    result[faction.id] = {
+      members: 0,
+      items: 0,
+      locations: 0,
+      lore: 0,
+      players: 0,
+      documents: 0,
+      images: 0,
+      relations: 0,
+    }
+  }
+
+  // 1. Get members count (NPCs that belong to factions)
+  if (npcTypeId) {
+    const membersCounts = db.prepare(`
+      SELECT er.to_entity_id as faction_id, COUNT(*) as count
+      FROM entity_relations er
+      INNER JOIN entities npc ON npc.id = er.from_entity_id
+      INNER JOIN entities faction ON faction.id = er.to_entity_id
+      WHERE faction.campaign_id = ?
+        AND faction.type_id = ?
+        AND faction.deleted_at IS NULL
+        AND npc.type_id = ?
+        AND npc.deleted_at IS NULL
+      GROUP BY er.to_entity_id
+    `).all(Number(campaignId), factionTypeId, npcTypeId) as Array<{ faction_id: number; count: number }>
+
+    for (const row of membersCounts) {
+      if (result[row.faction_id]) {
+        result[row.faction_id].members = row.count
+      }
+    }
+  }
+
+  // 2. Get items count (bidirectional)
+  if (itemTypeId) {
+    const itemsCounts = db.prepare(`
+      SELECT faction_id, COUNT(DISTINCT item_id) as count FROM (
+        SELECT er.from_entity_id as faction_id, e.id as item_id
+        FROM entity_relations er
+        INNER JOIN entities e ON e.id = er.to_entity_id
+        INNER JOIN entities faction ON faction.id = er.from_entity_id
+        WHERE faction.campaign_id = ?
+          AND faction.type_id = ?
+          AND faction.deleted_at IS NULL
+          AND e.type_id = ?
+          AND e.deleted_at IS NULL
+
+        UNION ALL
+
+        SELECT er.to_entity_id as faction_id, e.id as item_id
+        FROM entity_relations er
+        INNER JOIN entities e ON e.id = er.from_entity_id
+        INNER JOIN entities faction ON faction.id = er.to_entity_id
+        WHERE faction.campaign_id = ?
+          AND faction.type_id = ?
+          AND faction.deleted_at IS NULL
+          AND e.type_id = ?
+          AND e.deleted_at IS NULL
+      )
+      GROUP BY faction_id
+    `).all(
+      Number(campaignId), factionTypeId, itemTypeId,
+      Number(campaignId), factionTypeId, itemTypeId,
+    ) as Array<{ faction_id: number; count: number }>
+
+    for (const row of itemsCounts) {
+      if (result[row.faction_id]) {
+        result[row.faction_id].items = row.count
+      }
+    }
+  }
+
+  // 3. Get locations count (bidirectional)
+  if (locationTypeId) {
+    const locationsCounts = db.prepare(`
+      SELECT faction_id, COUNT(DISTINCT location_id) as count FROM (
+        SELECT er.from_entity_id as faction_id, e.id as location_id
+        FROM entity_relations er
+        INNER JOIN entities e ON e.id = er.to_entity_id
+        INNER JOIN entities faction ON faction.id = er.from_entity_id
+        WHERE faction.campaign_id = ?
+          AND faction.type_id = ?
+          AND faction.deleted_at IS NULL
+          AND e.type_id = ?
+          AND e.deleted_at IS NULL
+
+        UNION ALL
+
+        SELECT er.to_entity_id as faction_id, e.id as location_id
+        FROM entity_relations er
+        INNER JOIN entities e ON e.id = er.from_entity_id
+        INNER JOIN entities faction ON faction.id = er.to_entity_id
+        WHERE faction.campaign_id = ?
+          AND faction.type_id = ?
+          AND faction.deleted_at IS NULL
+          AND e.type_id = ?
+          AND e.deleted_at IS NULL
+      )
+      GROUP BY faction_id
+    `).all(
+      Number(campaignId), factionTypeId, locationTypeId,
+      Number(campaignId), factionTypeId, locationTypeId,
+    ) as Array<{ faction_id: number; count: number }>
+
+    for (const row of locationsCounts) {
+      if (result[row.faction_id]) {
+        result[row.faction_id].locations = row.count
+      }
+    }
+  }
+
+  // 4. Get lore count
+  if (loreTypeId) {
+    const loreCounts = db.prepare(`
+      SELECT er.to_entity_id as faction_id, COUNT(*) as count
+      FROM entity_relations er
+      INNER JOIN entities lore ON lore.id = er.from_entity_id
+      INNER JOIN entities faction ON faction.id = er.to_entity_id
+      WHERE faction.campaign_id = ?
+        AND faction.type_id = ?
+        AND faction.deleted_at IS NULL
+        AND lore.type_id = ?
+        AND lore.deleted_at IS NULL
+      GROUP BY er.to_entity_id
+    `).all(Number(campaignId), factionTypeId, loreTypeId) as Array<{ faction_id: number; count: number }>
+
+    for (const row of loreCounts) {
+      if (result[row.faction_id]) {
+        result[row.faction_id].lore = row.count
+      }
+    }
+  }
+
+  // 5. Get players count (bidirectional)
+  if (playerTypeId) {
+    const playersCounts = db.prepare(`
+      SELECT faction_id, COUNT(DISTINCT player_id) as count FROM (
+        SELECT er.from_entity_id as faction_id, e.id as player_id
+        FROM entity_relations er
+        INNER JOIN entities e ON e.id = er.to_entity_id
+        INNER JOIN entities faction ON faction.id = er.from_entity_id
+        WHERE faction.campaign_id = ?
+          AND faction.type_id = ?
+          AND faction.deleted_at IS NULL
+          AND e.type_id = ?
+          AND e.deleted_at IS NULL
+
+        UNION ALL
+
+        SELECT er.to_entity_id as faction_id, e.id as player_id
+        FROM entity_relations er
+        INNER JOIN entities e ON e.id = er.from_entity_id
+        INNER JOIN entities faction ON faction.id = er.to_entity_id
+        WHERE faction.campaign_id = ?
+          AND faction.type_id = ?
+          AND faction.deleted_at IS NULL
+          AND e.type_id = ?
+          AND e.deleted_at IS NULL
+      )
+      GROUP BY faction_id
+    `).all(
+      Number(campaignId), factionTypeId, playerTypeId,
+      Number(campaignId), factionTypeId, playerTypeId,
+    ) as Array<{ faction_id: number; count: number }>
+
+    for (const row of playersCounts) {
+      if (result[row.faction_id]) {
+        result[row.faction_id].players = row.count
+      }
+    }
+  }
+
+  // 6. Get faction-to-faction relations count (bidirectional)
+  const relationsCounts = db.prepare(`
+    SELECT faction_id, COUNT(DISTINCT related_id) as count FROM (
+      SELECT er.from_entity_id as faction_id, e.id as related_id
+      FROM entity_relations er
+      INNER JOIN entities e ON e.id = er.to_entity_id
+      INNER JOIN entities faction ON faction.id = er.from_entity_id
+      WHERE faction.campaign_id = ?
+        AND faction.type_id = ?
+        AND faction.deleted_at IS NULL
+        AND e.type_id = ?
+        AND e.deleted_at IS NULL
+
+      UNION ALL
+
+      SELECT er.to_entity_id as faction_id, e.id as related_id
+      FROM entity_relations er
+      INNER JOIN entities e ON e.id = er.from_entity_id
+      INNER JOIN entities faction ON faction.id = er.to_entity_id
+      WHERE faction.campaign_id = ?
+        AND faction.type_id = ?
+        AND faction.deleted_at IS NULL
+        AND e.type_id = ?
+        AND e.deleted_at IS NULL
+    )
+    GROUP BY faction_id
+  `).all(
+    Number(campaignId), factionTypeId, factionTypeId,
+    Number(campaignId), factionTypeId, factionTypeId,
+  ) as Array<{ faction_id: number; count: number }>
+
+  for (const row of relationsCounts) {
+    if (result[row.faction_id]) {
+      result[row.faction_id].relations = row.count
+    }
+  }
+
+  // 7. Get documents count
+  const documentsCounts = db.prepare(`
+    SELECT ed.entity_id as faction_id, COUNT(*) as count
+    FROM entity_documents ed
+    INNER JOIN entities faction ON faction.id = ed.entity_id
+    WHERE faction.campaign_id = ?
+      AND faction.type_id = ?
+      AND faction.deleted_at IS NULL
+    GROUP BY ed.entity_id
+  `).all(Number(campaignId), factionTypeId) as Array<{ faction_id: number; count: number }>
+
+  for (const row of documentsCounts) {
+    if (result[row.faction_id]) {
+      result[row.faction_id].documents = row.count
+    }
+  }
+
+  // 8. Get images count
+  const imagesCounts = db.prepare(`
+    SELECT ei.entity_id as faction_id, COUNT(*) as count
+    FROM entity_images ei
+    INNER JOIN entities faction ON faction.id = ei.entity_id
+    WHERE faction.campaign_id = ?
+      AND faction.type_id = ?
+      AND faction.deleted_at IS NULL
+    GROUP BY ei.entity_id
+  `).all(Number(campaignId), factionTypeId) as Array<{ faction_id: number; count: number }>
+
+  for (const row of imagesCounts) {
+    if (result[row.faction_id]) {
+      result[row.faction_id].images = row.count
+    }
+  }
+
+  return result
+})

--- a/packages/app/server/api/items/batch-counts.get.ts
+++ b/packages/app/server/api/items/batch-counts.get.ts
@@ -1,0 +1,249 @@
+import { getDb } from '../../utils/db'
+
+interface ItemCounts {
+  owners: number
+  locations: number
+  lore: number
+  factions: number
+  players: number
+  documents: number
+  images: number
+}
+
+/**
+ * GET /api/items/batch-counts
+ * Returns counts for ALL items in a campaign in one request
+ */
+export default defineEventHandler((event) => {
+  const db = getDb()
+  const query = getQuery(event)
+  const campaignId = query.campaignId
+
+  if (!campaignId) {
+    throw createError({
+      statusCode: 400,
+      message: 'campaignId is required',
+    })
+  }
+
+  // Get all entity type IDs once
+  const entityTypes = db
+    .prepare('SELECT id, name FROM entity_types WHERE name IN (\'Item\', \'NPC\', \'Location\', \'Lore\', \'Faction\', \'Player\')')
+    .all() as Array<{ id: number; name: string }>
+
+  const typeMap = Object.fromEntries(entityTypes.map((t) => [t.name, t.id]))
+  const itemTypeId = typeMap['Item']
+  const npcTypeId = typeMap['NPC']
+  const locationTypeId = typeMap['Location']
+  const loreTypeId = typeMap['Lore']
+  const factionTypeId = typeMap['Faction']
+  const playerTypeId = typeMap['Player']
+
+  if (!itemTypeId) {
+    return {}
+  }
+
+  // Get all Item IDs for this campaign
+  const itemIds = db
+    .prepare('SELECT id FROM entities WHERE campaign_id = ? AND type_id = ? AND deleted_at IS NULL')
+    .all(Number(campaignId), itemTypeId) as Array<{ id: number }>
+
+  if (itemIds.length === 0) {
+    return {}
+  }
+
+  const result: Record<number, ItemCounts> = {}
+
+  // Initialize all items with zero counts
+  for (const item of itemIds) {
+    result[item.id] = {
+      owners: 0,
+      locations: 0,
+      lore: 0,
+      factions: 0,
+      players: 0,
+      documents: 0,
+      images: 0,
+    }
+  }
+
+  // 1. Get owners count (NPCs that own items)
+  if (npcTypeId) {
+    const ownersCounts = db.prepare(`
+      SELECT er.to_entity_id as item_id, COUNT(*) as count
+      FROM entity_relations er
+      INNER JOIN entities npc ON npc.id = er.from_entity_id
+      INNER JOIN entities item ON item.id = er.to_entity_id
+      WHERE item.campaign_id = ?
+        AND item.type_id = ?
+        AND item.deleted_at IS NULL
+        AND npc.type_id = ?
+        AND npc.deleted_at IS NULL
+      GROUP BY er.to_entity_id
+    `).all(Number(campaignId), itemTypeId, npcTypeId) as Array<{ item_id: number; count: number }>
+
+    for (const row of ownersCounts) {
+      if (result[row.item_id]) {
+        result[row.item_id].owners = row.count
+      }
+    }
+  }
+
+  // 2. Get locations count
+  if (locationTypeId) {
+    const locationsCounts = db.prepare(`
+      SELECT er.to_entity_id as item_id, COUNT(*) as count
+      FROM entity_relations er
+      INNER JOIN entities loc ON loc.id = er.from_entity_id
+      INNER JOIN entities item ON item.id = er.to_entity_id
+      WHERE item.campaign_id = ?
+        AND item.type_id = ?
+        AND item.deleted_at IS NULL
+        AND loc.type_id = ?
+        AND loc.deleted_at IS NULL
+      GROUP BY er.to_entity_id
+    `).all(Number(campaignId), itemTypeId, locationTypeId) as Array<{ item_id: number; count: number }>
+
+    for (const row of locationsCounts) {
+      if (result[row.item_id]) {
+        result[row.item_id].locations = row.count
+      }
+    }
+  }
+
+  // 3. Get lore count
+  if (loreTypeId) {
+    const loreCounts = db.prepare(`
+      SELECT er.from_entity_id as item_id, COUNT(*) as count
+      FROM entity_relations er
+      INNER JOIN entities lore ON lore.id = er.to_entity_id
+      INNER JOIN entities item ON item.id = er.from_entity_id
+      WHERE item.campaign_id = ?
+        AND item.type_id = ?
+        AND item.deleted_at IS NULL
+        AND lore.type_id = ?
+        AND lore.deleted_at IS NULL
+      GROUP BY er.from_entity_id
+    `).all(Number(campaignId), itemTypeId, loreTypeId) as Array<{ item_id: number; count: number }>
+
+    for (const row of loreCounts) {
+      if (result[row.item_id]) {
+        result[row.item_id].lore = row.count
+      }
+    }
+  }
+
+  // 4. Get factions count (bidirectional)
+  if (factionTypeId) {
+    const factionsCounts = db.prepare(`
+      SELECT item_id, COUNT(DISTINCT faction_id) as count FROM (
+        SELECT er.from_entity_id as item_id, e.id as faction_id
+        FROM entity_relations er
+        INNER JOIN entities e ON e.id = er.to_entity_id
+        INNER JOIN entities item ON item.id = er.from_entity_id
+        WHERE item.campaign_id = ?
+          AND item.type_id = ?
+          AND item.deleted_at IS NULL
+          AND e.type_id = ?
+          AND e.deleted_at IS NULL
+
+        UNION ALL
+
+        SELECT er.to_entity_id as item_id, e.id as faction_id
+        FROM entity_relations er
+        INNER JOIN entities e ON e.id = er.from_entity_id
+        INNER JOIN entities item ON item.id = er.to_entity_id
+        WHERE item.campaign_id = ?
+          AND item.type_id = ?
+          AND item.deleted_at IS NULL
+          AND e.type_id = ?
+          AND e.deleted_at IS NULL
+      )
+      GROUP BY item_id
+    `).all(
+      Number(campaignId), itemTypeId, factionTypeId,
+      Number(campaignId), itemTypeId, factionTypeId,
+    ) as Array<{ item_id: number; count: number }>
+
+    for (const row of factionsCounts) {
+      if (result[row.item_id]) {
+        result[row.item_id].factions = row.count
+      }
+    }
+  }
+
+  // 5. Get players count (bidirectional)
+  if (playerTypeId) {
+    const playersCounts = db.prepare(`
+      SELECT item_id, COUNT(DISTINCT player_id) as count FROM (
+        SELECT er.from_entity_id as item_id, e.id as player_id
+        FROM entity_relations er
+        INNER JOIN entities e ON e.id = er.to_entity_id
+        INNER JOIN entities item ON item.id = er.from_entity_id
+        WHERE item.campaign_id = ?
+          AND item.type_id = ?
+          AND item.deleted_at IS NULL
+          AND e.type_id = ?
+          AND e.deleted_at IS NULL
+
+        UNION ALL
+
+        SELECT er.to_entity_id as item_id, e.id as player_id
+        FROM entity_relations er
+        INNER JOIN entities e ON e.id = er.from_entity_id
+        INNER JOIN entities item ON item.id = er.to_entity_id
+        WHERE item.campaign_id = ?
+          AND item.type_id = ?
+          AND item.deleted_at IS NULL
+          AND e.type_id = ?
+          AND e.deleted_at IS NULL
+      )
+      GROUP BY item_id
+    `).all(
+      Number(campaignId), itemTypeId, playerTypeId,
+      Number(campaignId), itemTypeId, playerTypeId,
+    ) as Array<{ item_id: number; count: number }>
+
+    for (const row of playersCounts) {
+      if (result[row.item_id]) {
+        result[row.item_id].players = row.count
+      }
+    }
+  }
+
+  // 6. Get documents count
+  const documentsCounts = db.prepare(`
+    SELECT ed.entity_id as item_id, COUNT(*) as count
+    FROM entity_documents ed
+    INNER JOIN entities item ON item.id = ed.entity_id
+    WHERE item.campaign_id = ?
+      AND item.type_id = ?
+      AND item.deleted_at IS NULL
+    GROUP BY ed.entity_id
+  `).all(Number(campaignId), itemTypeId) as Array<{ item_id: number; count: number }>
+
+  for (const row of documentsCounts) {
+    if (result[row.item_id]) {
+      result[row.item_id].documents = row.count
+    }
+  }
+
+  // 7. Get images count
+  const imagesCounts = db.prepare(`
+    SELECT ei.entity_id as item_id, COUNT(*) as count
+    FROM entity_images ei
+    INNER JOIN entities item ON item.id = ei.entity_id
+    WHERE item.campaign_id = ?
+      AND item.type_id = ?
+      AND item.deleted_at IS NULL
+    GROUP BY ei.entity_id
+  `).all(Number(campaignId), itemTypeId) as Array<{ item_id: number; count: number }>
+
+  for (const row of imagesCounts) {
+    if (result[row.item_id]) {
+      result[row.item_id].images = row.count
+    }
+  }
+
+  return result
+})

--- a/packages/app/server/api/lore/batch-counts.get.ts
+++ b/packages/app/server/api/lore/batch-counts.get.ts
@@ -1,0 +1,300 @@
+import { getDb } from '../../utils/db'
+
+interface LoreCounts {
+  npcs: number
+  items: number
+  factions: number
+  locations: number
+  players: number
+  documents: number
+  images: number
+}
+
+/**
+ * GET /api/lore/batch-counts
+ * Returns counts for ALL lore entries in a campaign in one request
+ */
+export default defineEventHandler((event) => {
+  const db = getDb()
+  const query = getQuery(event)
+  const campaignId = query.campaignId
+
+  if (!campaignId) {
+    throw createError({
+      statusCode: 400,
+      message: 'campaignId is required',
+    })
+  }
+
+  // Get all entity type IDs once
+  const entityTypes = db
+    .prepare('SELECT id, name FROM entity_types WHERE name IN (\'Lore\', \'NPC\', \'Item\', \'Faction\', \'Location\', \'Player\')')
+    .all() as Array<{ id: number; name: string }>
+
+  const typeMap = Object.fromEntries(entityTypes.map((t) => [t.name, t.id]))
+  const loreTypeId = typeMap['Lore']
+  const npcTypeId = typeMap['NPC']
+  const itemTypeId = typeMap['Item']
+  const factionTypeId = typeMap['Faction']
+  const locationTypeId = typeMap['Location']
+  const playerTypeId = typeMap['Player']
+
+  if (!loreTypeId) {
+    return {}
+  }
+
+  // Get all Lore IDs for this campaign
+  const loreIds = db
+    .prepare('SELECT id FROM entities WHERE campaign_id = ? AND type_id = ? AND deleted_at IS NULL')
+    .all(Number(campaignId), loreTypeId) as Array<{ id: number }>
+
+  if (loreIds.length === 0) {
+    return {}
+  }
+
+  const result: Record<number, LoreCounts> = {}
+
+  // Initialize all lore entries with zero counts
+  for (const lore of loreIds) {
+    result[lore.id] = {
+      npcs: 0,
+      items: 0,
+      factions: 0,
+      locations: 0,
+      players: 0,
+      documents: 0,
+      images: 0,
+    }
+  }
+
+  // 1. Get NPCs count (bidirectional)
+  if (npcTypeId) {
+    const npcsCounts = db.prepare(`
+      SELECT lore_id, COUNT(DISTINCT npc_id) as count FROM (
+        SELECT er.to_entity_id as lore_id, e.id as npc_id
+        FROM entity_relations er
+        INNER JOIN entities e ON e.id = er.from_entity_id
+        INNER JOIN entities lore ON lore.id = er.to_entity_id
+        WHERE lore.campaign_id = ?
+          AND lore.type_id = ?
+          AND lore.deleted_at IS NULL
+          AND e.type_id = ?
+          AND e.deleted_at IS NULL
+
+        UNION ALL
+
+        SELECT er.from_entity_id as lore_id, e.id as npc_id
+        FROM entity_relations er
+        INNER JOIN entities e ON e.id = er.to_entity_id
+        INNER JOIN entities lore ON lore.id = er.from_entity_id
+        WHERE lore.campaign_id = ?
+          AND lore.type_id = ?
+          AND lore.deleted_at IS NULL
+          AND e.type_id = ?
+          AND e.deleted_at IS NULL
+      )
+      GROUP BY lore_id
+    `).all(
+      Number(campaignId), loreTypeId, npcTypeId,
+      Number(campaignId), loreTypeId, npcTypeId,
+    ) as Array<{ lore_id: number; count: number }>
+
+    for (const row of npcsCounts) {
+      if (result[row.lore_id]) {
+        result[row.lore_id].npcs = row.count
+      }
+    }
+  }
+
+  // 2. Get Items count (bidirectional)
+  if (itemTypeId) {
+    const itemsCounts = db.prepare(`
+      SELECT lore_id, COUNT(DISTINCT item_id) as count FROM (
+        SELECT er.to_entity_id as lore_id, e.id as item_id
+        FROM entity_relations er
+        INNER JOIN entities e ON e.id = er.from_entity_id
+        INNER JOIN entities lore ON lore.id = er.to_entity_id
+        WHERE lore.campaign_id = ?
+          AND lore.type_id = ?
+          AND lore.deleted_at IS NULL
+          AND e.type_id = ?
+          AND e.deleted_at IS NULL
+
+        UNION ALL
+
+        SELECT er.from_entity_id as lore_id, e.id as item_id
+        FROM entity_relations er
+        INNER JOIN entities e ON e.id = er.to_entity_id
+        INNER JOIN entities lore ON lore.id = er.from_entity_id
+        WHERE lore.campaign_id = ?
+          AND lore.type_id = ?
+          AND lore.deleted_at IS NULL
+          AND e.type_id = ?
+          AND e.deleted_at IS NULL
+      )
+      GROUP BY lore_id
+    `).all(
+      Number(campaignId), loreTypeId, itemTypeId,
+      Number(campaignId), loreTypeId, itemTypeId,
+    ) as Array<{ lore_id: number; count: number }>
+
+    for (const row of itemsCounts) {
+      if (result[row.lore_id]) {
+        result[row.lore_id].items = row.count
+      }
+    }
+  }
+
+  // 3. Get Factions count (bidirectional)
+  if (factionTypeId) {
+    const factionsCounts = db.prepare(`
+      SELECT lore_id, COUNT(DISTINCT faction_id) as count FROM (
+        SELECT er.to_entity_id as lore_id, e.id as faction_id
+        FROM entity_relations er
+        INNER JOIN entities e ON e.id = er.from_entity_id
+        INNER JOIN entities lore ON lore.id = er.to_entity_id
+        WHERE lore.campaign_id = ?
+          AND lore.type_id = ?
+          AND lore.deleted_at IS NULL
+          AND e.type_id = ?
+          AND e.deleted_at IS NULL
+
+        UNION ALL
+
+        SELECT er.from_entity_id as lore_id, e.id as faction_id
+        FROM entity_relations er
+        INNER JOIN entities e ON e.id = er.to_entity_id
+        INNER JOIN entities lore ON lore.id = er.from_entity_id
+        WHERE lore.campaign_id = ?
+          AND lore.type_id = ?
+          AND lore.deleted_at IS NULL
+          AND e.type_id = ?
+          AND e.deleted_at IS NULL
+      )
+      GROUP BY lore_id
+    `).all(
+      Number(campaignId), loreTypeId, factionTypeId,
+      Number(campaignId), loreTypeId, factionTypeId,
+    ) as Array<{ lore_id: number; count: number }>
+
+    for (const row of factionsCounts) {
+      if (result[row.lore_id]) {
+        result[row.lore_id].factions = row.count
+      }
+    }
+  }
+
+  // 4. Get Locations count (bidirectional)
+  if (locationTypeId) {
+    const locationsCounts = db.prepare(`
+      SELECT lore_id, COUNT(DISTINCT location_id) as count FROM (
+        SELECT er.to_entity_id as lore_id, e.id as location_id
+        FROM entity_relations er
+        INNER JOIN entities e ON e.id = er.from_entity_id
+        INNER JOIN entities lore ON lore.id = er.to_entity_id
+        WHERE lore.campaign_id = ?
+          AND lore.type_id = ?
+          AND lore.deleted_at IS NULL
+          AND e.type_id = ?
+          AND e.deleted_at IS NULL
+
+        UNION ALL
+
+        SELECT er.from_entity_id as lore_id, e.id as location_id
+        FROM entity_relations er
+        INNER JOIN entities e ON e.id = er.to_entity_id
+        INNER JOIN entities lore ON lore.id = er.from_entity_id
+        WHERE lore.campaign_id = ?
+          AND lore.type_id = ?
+          AND lore.deleted_at IS NULL
+          AND e.type_id = ?
+          AND e.deleted_at IS NULL
+      )
+      GROUP BY lore_id
+    `).all(
+      Number(campaignId), loreTypeId, locationTypeId,
+      Number(campaignId), loreTypeId, locationTypeId,
+    ) as Array<{ lore_id: number; count: number }>
+
+    for (const row of locationsCounts) {
+      if (result[row.lore_id]) {
+        result[row.lore_id].locations = row.count
+      }
+    }
+  }
+
+  // 5. Get Players count (bidirectional)
+  if (playerTypeId) {
+    const playersCounts = db.prepare(`
+      SELECT lore_id, COUNT(DISTINCT player_id) as count FROM (
+        SELECT er.to_entity_id as lore_id, e.id as player_id
+        FROM entity_relations er
+        INNER JOIN entities e ON e.id = er.from_entity_id
+        INNER JOIN entities lore ON lore.id = er.to_entity_id
+        WHERE lore.campaign_id = ?
+          AND lore.type_id = ?
+          AND lore.deleted_at IS NULL
+          AND e.type_id = ?
+          AND e.deleted_at IS NULL
+
+        UNION ALL
+
+        SELECT er.from_entity_id as lore_id, e.id as player_id
+        FROM entity_relations er
+        INNER JOIN entities e ON e.id = er.to_entity_id
+        INNER JOIN entities lore ON lore.id = er.from_entity_id
+        WHERE lore.campaign_id = ?
+          AND lore.type_id = ?
+          AND lore.deleted_at IS NULL
+          AND e.type_id = ?
+          AND e.deleted_at IS NULL
+      )
+      GROUP BY lore_id
+    `).all(
+      Number(campaignId), loreTypeId, playerTypeId,
+      Number(campaignId), loreTypeId, playerTypeId,
+    ) as Array<{ lore_id: number; count: number }>
+
+    for (const row of playersCounts) {
+      if (result[row.lore_id]) {
+        result[row.lore_id].players = row.count
+      }
+    }
+  }
+
+  // 6. Get documents count
+  const documentsCounts = db.prepare(`
+    SELECT ed.entity_id as lore_id, COUNT(*) as count
+    FROM entity_documents ed
+    INNER JOIN entities lore ON lore.id = ed.entity_id
+    WHERE lore.campaign_id = ?
+      AND lore.type_id = ?
+      AND lore.deleted_at IS NULL
+    GROUP BY ed.entity_id
+  `).all(Number(campaignId), loreTypeId) as Array<{ lore_id: number; count: number }>
+
+  for (const row of documentsCounts) {
+    if (result[row.lore_id]) {
+      result[row.lore_id].documents = row.count
+    }
+  }
+
+  // 7. Get images count
+  const imagesCounts = db.prepare(`
+    SELECT ei.entity_id as lore_id, COUNT(*) as count
+    FROM entity_images ei
+    INNER JOIN entities lore ON lore.id = ei.entity_id
+    WHERE lore.campaign_id = ?
+      AND lore.type_id = ?
+      AND lore.deleted_at IS NULL
+    GROUP BY ei.entity_id
+  `).all(Number(campaignId), loreTypeId) as Array<{ lore_id: number; count: number }>
+
+  for (const row of imagesCounts) {
+    if (result[row.lore_id]) {
+      result[row.lore_id].images = row.count
+    }
+  }
+
+  return result
+})

--- a/packages/app/server/api/npcs/batch-counts.get.ts
+++ b/packages/app/server/api/npcs/batch-counts.get.ts
@@ -1,0 +1,318 @@
+import { getDb } from '../../utils/db'
+
+interface NpcCounts {
+  relations: number
+  items: number
+  locations: number
+  documents: number
+  images: number
+  memberships: number
+  lore: number
+  notes: number
+  players: number
+  factionName: string | null
+}
+
+/**
+ * GET /api/npcs/batch-counts
+ * Returns counts for ALL NPCs in a campaign in one request
+ * Replaces N individual /api/npcs/:id/counts requests with 1 batch request
+ */
+export default defineEventHandler((event) => {
+  const db = getDb()
+  const query = getQuery(event)
+  const campaignId = query.campaignId
+
+  if (!campaignId) {
+    throw createError({
+      statusCode: 400,
+      message: 'campaignId is required',
+    })
+  }
+
+  // Get all entity type IDs once
+  const entityTypes = db
+    .prepare('SELECT id, name FROM entity_types WHERE name IN (\'NPC\', \'Item\', \'Location\', \'Faction\', \'Lore\', \'Player\')')
+    .all() as Array<{ id: number; name: string }>
+
+  const typeMap = Object.fromEntries(entityTypes.map((t) => [t.name, t.id]))
+  const npcTypeId = typeMap['NPC']
+  const itemTypeId = typeMap['Item']
+  const locationTypeId = typeMap['Location']
+  const factionTypeId = typeMap['Faction']
+  const loreTypeId = typeMap['Lore']
+  const playerTypeId = typeMap['Player']
+
+  if (!npcTypeId) {
+    return {}
+  }
+
+  // Get all NPC IDs for this campaign
+  const npcIds = db
+    .prepare(
+      'SELECT id FROM entities WHERE campaign_id = ? AND type_id = ? AND deleted_at IS NULL',
+    )
+    .all(Number(campaignId), npcTypeId) as Array<{ id: number }>
+
+  if (npcIds.length === 0) {
+    return {}
+  }
+
+  const result: Record<number, NpcCounts> = {}
+
+  // Initialize all NPCs with zero counts
+  for (const npc of npcIds) {
+    result[npc.id] = {
+      relations: 0,
+      items: 0,
+      locations: 0,
+      documents: 0,
+      images: 0,
+      memberships: 0,
+      lore: 0,
+      notes: 0,
+      players: 0,
+      factionName: null,
+    }
+  }
+
+  // 1. Get NPC-to-NPC relations count (bidirectional) for all NPCs at once
+  const relationsQuery = db.prepare(`
+    SELECT npc_id, COUNT(DISTINCT related_id) as count FROM (
+      SELECT er.from_entity_id as npc_id, e.id as related_id
+      FROM entity_relations er
+      INNER JOIN entities e ON e.id = er.to_entity_id
+      INNER JOIN entities npc ON npc.id = er.from_entity_id
+      WHERE npc.campaign_id = ?
+        AND npc.type_id = ?
+        AND npc.deleted_at IS NULL
+        AND e.type_id = ?
+        AND e.deleted_at IS NULL
+
+      UNION ALL
+
+      SELECT er.to_entity_id as npc_id, e.id as related_id
+      FROM entity_relations er
+      INNER JOIN entities e ON e.id = er.from_entity_id
+      INNER JOIN entities npc ON npc.id = er.to_entity_id
+      WHERE npc.campaign_id = ?
+        AND npc.type_id = ?
+        AND npc.deleted_at IS NULL
+        AND e.type_id = ?
+        AND e.deleted_at IS NULL
+    )
+    GROUP BY npc_id
+  `)
+  const relationsCounts = relationsQuery.all(
+    Number(campaignId), npcTypeId, npcTypeId,
+    Number(campaignId), npcTypeId, npcTypeId,
+  ) as Array<{ npc_id: number; count: number }>
+
+  for (const row of relationsCounts) {
+    if (result[row.npc_id]) {
+      result[row.npc_id].relations = row.count
+    }
+  }
+
+  // 2. Get items count for all NPCs
+  if (itemTypeId) {
+    const itemsCounts = db.prepare(`
+      SELECT er.from_entity_id as npc_id, COUNT(*) as count
+      FROM entity_relations er
+      INNER JOIN entities item ON item.id = er.to_entity_id
+      INNER JOIN entities npc ON npc.id = er.from_entity_id
+      WHERE npc.campaign_id = ?
+        AND npc.type_id = ?
+        AND npc.deleted_at IS NULL
+        AND item.type_id = ?
+        AND item.deleted_at IS NULL
+      GROUP BY er.from_entity_id
+    `).all(Number(campaignId), npcTypeId, itemTypeId) as Array<{ npc_id: number; count: number }>
+
+    for (const row of itemsCounts) {
+      if (result[row.npc_id]) {
+        result[row.npc_id].items = row.count
+      }
+    }
+  }
+
+  // 3. Get locations count for all NPCs
+  if (locationTypeId) {
+    const locationsCounts = db.prepare(`
+      SELECT er.from_entity_id as npc_id, COUNT(*) as count
+      FROM entity_relations er
+      INNER JOIN entities loc ON loc.id = er.to_entity_id
+      INNER JOIN entities npc ON npc.id = er.from_entity_id
+      WHERE npc.campaign_id = ?
+        AND npc.type_id = ?
+        AND npc.deleted_at IS NULL
+        AND loc.type_id = ?
+        AND loc.deleted_at IS NULL
+      GROUP BY er.from_entity_id
+    `).all(Number(campaignId), npcTypeId, locationTypeId) as Array<{ npc_id: number; count: number }>
+
+    for (const row of locationsCounts) {
+      if (result[row.npc_id]) {
+        result[row.npc_id].locations = row.count
+      }
+    }
+  }
+
+  // 4. Get memberships count (factions) for all NPCs
+  if (factionTypeId) {
+    const membershipsCounts = db.prepare(`
+      SELECT er.from_entity_id as npc_id, COUNT(*) as count
+      FROM entity_relations er
+      INNER JOIN entities faction ON faction.id = er.to_entity_id
+      INNER JOIN entities npc ON npc.id = er.from_entity_id
+      WHERE npc.campaign_id = ?
+        AND npc.type_id = ?
+        AND npc.deleted_at IS NULL
+        AND faction.type_id = ?
+        AND faction.deleted_at IS NULL
+      GROUP BY er.from_entity_id
+    `).all(Number(campaignId), npcTypeId, factionTypeId) as Array<{ npc_id: number; count: number }>
+
+    for (const row of membershipsCounts) {
+      if (result[row.npc_id]) {
+        result[row.npc_id].memberships = row.count
+      }
+    }
+
+    // Get primary faction name for each NPC (first faction found)
+    const factionNames = db.prepare(`
+      SELECT npc.id as npc_id, faction.name as faction_name
+      FROM entities npc
+      INNER JOIN entity_relations er ON er.from_entity_id = npc.id
+      INNER JOIN entities faction ON faction.id = er.to_entity_id
+      WHERE npc.campaign_id = ?
+        AND npc.type_id = ?
+        AND npc.deleted_at IS NULL
+        AND faction.type_id = ?
+        AND faction.deleted_at IS NULL
+      GROUP BY npc.id
+    `).all(Number(campaignId), npcTypeId, factionTypeId) as Array<{ npc_id: number; faction_name: string }>
+
+    for (const row of factionNames) {
+      if (result[row.npc_id]) {
+        result[row.npc_id].factionName = row.faction_name
+      }
+    }
+  }
+
+  // 5. Get lore count for all NPCs
+  if (loreTypeId) {
+    const loreCounts = db.prepare(`
+      SELECT er.from_entity_id as npc_id, COUNT(*) as count
+      FROM entity_relations er
+      INNER JOIN entities lore ON lore.id = er.to_entity_id
+      INNER JOIN entities npc ON npc.id = er.from_entity_id
+      WHERE npc.campaign_id = ?
+        AND npc.type_id = ?
+        AND npc.deleted_at IS NULL
+        AND lore.type_id = ?
+        AND lore.deleted_at IS NULL
+      GROUP BY er.from_entity_id
+    `).all(Number(campaignId), npcTypeId, loreTypeId) as Array<{ npc_id: number; count: number }>
+
+    for (const row of loreCounts) {
+      if (result[row.npc_id]) {
+        result[row.npc_id].lore = row.count
+      }
+    }
+  }
+
+  // 6. Get players count (bidirectional) for all NPCs
+  if (playerTypeId) {
+    const playersCounts = db.prepare(`
+      SELECT npc_id, COUNT(DISTINCT player_id) as count FROM (
+        SELECT er.from_entity_id as npc_id, e.id as player_id
+        FROM entity_relations er
+        INNER JOIN entities e ON e.id = er.to_entity_id
+        INNER JOIN entities npc ON npc.id = er.from_entity_id
+        WHERE npc.campaign_id = ?
+          AND npc.type_id = ?
+          AND npc.deleted_at IS NULL
+          AND e.type_id = ?
+          AND e.deleted_at IS NULL
+
+        UNION ALL
+
+        SELECT er.to_entity_id as npc_id, e.id as player_id
+        FROM entity_relations er
+        INNER JOIN entities e ON e.id = er.from_entity_id
+        INNER JOIN entities npc ON npc.id = er.to_entity_id
+        WHERE npc.campaign_id = ?
+          AND npc.type_id = ?
+          AND npc.deleted_at IS NULL
+          AND e.type_id = ?
+          AND e.deleted_at IS NULL
+      )
+      GROUP BY npc_id
+    `).all(
+      Number(campaignId), npcTypeId, playerTypeId,
+      Number(campaignId), npcTypeId, playerTypeId,
+    ) as Array<{ npc_id: number; count: number }>
+
+    for (const row of playersCounts) {
+      if (result[row.npc_id]) {
+        result[row.npc_id].players = row.count
+      }
+    }
+  }
+
+  // 7. Get documents count for all NPCs
+  const documentsCounts = db.prepare(`
+    SELECT ed.entity_id as npc_id, COUNT(*) as count
+    FROM entity_documents ed
+    INNER JOIN entities npc ON npc.id = ed.entity_id
+    WHERE npc.campaign_id = ?
+      AND npc.type_id = ?
+      AND npc.deleted_at IS NULL
+    GROUP BY ed.entity_id
+  `).all(Number(campaignId), npcTypeId) as Array<{ npc_id: number; count: number }>
+
+  for (const row of documentsCounts) {
+    if (result[row.npc_id]) {
+      result[row.npc_id].documents = row.count
+    }
+  }
+
+  // 8. Get images count for all NPCs
+  const imagesCounts = db.prepare(`
+    SELECT ei.entity_id as npc_id, COUNT(*) as count
+    FROM entity_images ei
+    INNER JOIN entities npc ON npc.id = ei.entity_id
+    WHERE npc.campaign_id = ?
+      AND npc.type_id = ?
+      AND npc.deleted_at IS NULL
+    GROUP BY ei.entity_id
+  `).all(Number(campaignId), npcTypeId) as Array<{ npc_id: number; count: number }>
+
+  for (const row of imagesCounts) {
+    if (result[row.npc_id]) {
+      result[row.npc_id].images = row.count
+    }
+  }
+
+  // 9. Get notes count (sessions mentioning the NPC) for all NPCs
+  const notesCounts = db.prepare(`
+    SELECT sm.entity_id as npc_id, COUNT(*) as count
+    FROM session_mentions sm
+    INNER JOIN sessions s ON s.id = sm.session_id
+    INNER JOIN entities npc ON npc.id = sm.entity_id
+    WHERE npc.campaign_id = ?
+      AND npc.type_id = ?
+      AND npc.deleted_at IS NULL
+      AND s.deleted_at IS NULL
+    GROUP BY sm.entity_id
+  `).all(Number(campaignId), npcTypeId) as Array<{ npc_id: number; count: number }>
+
+  for (const row of notesCounts) {
+    if (result[row.npc_id]) {
+      result[row.npc_id].notes = row.count
+    }
+  }
+
+  return result
+})

--- a/packages/app/server/api/players/batch-counts.get.ts
+++ b/packages/app/server/api/players/batch-counts.get.ts
@@ -1,0 +1,236 @@
+import { getDb } from '../../utils/db'
+
+interface PlayerCounts {
+  characters: number
+  items: number
+  locations: number
+  factions: number
+  lore: number
+  sessions: number
+  documents: number
+  images: number
+}
+
+/**
+ * GET /api/players/batch-counts
+ * Returns counts for ALL players in a campaign in one request
+ */
+export default defineEventHandler((event) => {
+  const db = getDb()
+  const query = getQuery(event)
+  const campaignId = query.campaignId
+
+  if (!campaignId) {
+    throw createError({
+      statusCode: 400,
+      message: 'campaignId is required',
+    })
+  }
+
+  // Get all entity type IDs once
+  const entityTypes = db
+    .prepare('SELECT id, name FROM entity_types WHERE name IN (\'Player\', \'NPC\', \'Item\', \'Location\', \'Faction\', \'Lore\')')
+    .all() as Array<{ id: number; name: string }>
+
+  const typeMap = Object.fromEntries(entityTypes.map((t) => [t.name, t.id]))
+  const playerTypeId = typeMap['Player']
+  const npcTypeId = typeMap['NPC']
+  const itemTypeId = typeMap['Item']
+  const locationTypeId = typeMap['Location']
+  const factionTypeId = typeMap['Faction']
+  const loreTypeId = typeMap['Lore']
+
+  if (!playerTypeId) {
+    return {}
+  }
+
+  // Get all Player IDs for this campaign
+  const playerIds = db
+    .prepare('SELECT id FROM entities WHERE campaign_id = ? AND type_id = ? AND deleted_at IS NULL')
+    .all(Number(campaignId), playerTypeId) as Array<{ id: number }>
+
+  if (playerIds.length === 0) {
+    return {}
+  }
+
+  const result: Record<number, PlayerCounts> = {}
+
+  // Initialize all players with zero counts
+  for (const player of playerIds) {
+    result[player.id] = {
+      characters: 0,
+      items: 0,
+      locations: 0,
+      factions: 0,
+      lore: 0,
+      sessions: 0,
+      documents: 0,
+      images: 0,
+    }
+  }
+
+  // 1. Get characters count (NPCs the player plays)
+  if (npcTypeId) {
+    const charactersCounts = db.prepare(`
+      SELECT er.from_entity_id as player_id, COUNT(*) as count
+      FROM entity_relations er
+      INNER JOIN entities npc ON npc.id = er.to_entity_id
+      INNER JOIN entities player ON player.id = er.from_entity_id
+      WHERE player.campaign_id = ?
+        AND player.type_id = ?
+        AND player.deleted_at IS NULL
+        AND npc.type_id = ?
+        AND npc.deleted_at IS NULL
+      GROUP BY er.from_entity_id
+    `).all(Number(campaignId), playerTypeId, npcTypeId) as Array<{ player_id: number; count: number }>
+
+    for (const row of charactersCounts) {
+      if (result[row.player_id]) {
+        result[row.player_id].characters = row.count
+      }
+    }
+  }
+
+  // 2. Get items count
+  if (itemTypeId) {
+    const itemsCounts = db.prepare(`
+      SELECT er.from_entity_id as player_id, COUNT(*) as count
+      FROM entity_relations er
+      INNER JOIN entities item ON item.id = er.to_entity_id
+      INNER JOIN entities player ON player.id = er.from_entity_id
+      WHERE player.campaign_id = ?
+        AND player.type_id = ?
+        AND player.deleted_at IS NULL
+        AND item.type_id = ?
+        AND item.deleted_at IS NULL
+      GROUP BY er.from_entity_id
+    `).all(Number(campaignId), playerTypeId, itemTypeId) as Array<{ player_id: number; count: number }>
+
+    for (const row of itemsCounts) {
+      if (result[row.player_id]) {
+        result[row.player_id].items = row.count
+      }
+    }
+  }
+
+  // 3. Get locations count
+  if (locationTypeId) {
+    const locationsCounts = db.prepare(`
+      SELECT er.from_entity_id as player_id, COUNT(*) as count
+      FROM entity_relations er
+      INNER JOIN entities loc ON loc.id = er.to_entity_id
+      INNER JOIN entities player ON player.id = er.from_entity_id
+      WHERE player.campaign_id = ?
+        AND player.type_id = ?
+        AND player.deleted_at IS NULL
+        AND loc.type_id = ?
+        AND loc.deleted_at IS NULL
+      GROUP BY er.from_entity_id
+    `).all(Number(campaignId), playerTypeId, locationTypeId) as Array<{ player_id: number; count: number }>
+
+    for (const row of locationsCounts) {
+      if (result[row.player_id]) {
+        result[row.player_id].locations = row.count
+      }
+    }
+  }
+
+  // 4. Get factions count
+  if (factionTypeId) {
+    const factionsCounts = db.prepare(`
+      SELECT er.from_entity_id as player_id, COUNT(*) as count
+      FROM entity_relations er
+      INNER JOIN entities faction ON faction.id = er.to_entity_id
+      INNER JOIN entities player ON player.id = er.from_entity_id
+      WHERE player.campaign_id = ?
+        AND player.type_id = ?
+        AND player.deleted_at IS NULL
+        AND faction.type_id = ?
+        AND faction.deleted_at IS NULL
+      GROUP BY er.from_entity_id
+    `).all(Number(campaignId), playerTypeId, factionTypeId) as Array<{ player_id: number; count: number }>
+
+    for (const row of factionsCounts) {
+      if (result[row.player_id]) {
+        result[row.player_id].factions = row.count
+      }
+    }
+  }
+
+  // 5. Get lore count
+  if (loreTypeId) {
+    const loreCounts = db.prepare(`
+      SELECT er.from_entity_id as player_id, COUNT(*) as count
+      FROM entity_relations er
+      INNER JOIN entities lore ON lore.id = er.to_entity_id
+      INNER JOIN entities player ON player.id = er.from_entity_id
+      WHERE player.campaign_id = ?
+        AND player.type_id = ?
+        AND player.deleted_at IS NULL
+        AND lore.type_id = ?
+        AND lore.deleted_at IS NULL
+      GROUP BY er.from_entity_id
+    `).all(Number(campaignId), playerTypeId, loreTypeId) as Array<{ player_id: number; count: number }>
+
+    for (const row of loreCounts) {
+      if (result[row.player_id]) {
+        result[row.player_id].lore = row.count
+      }
+    }
+  }
+
+  // 6. Get sessions count (where players are mentioned)
+  const sessionsCounts = db.prepare(`
+    SELECT sm.entity_id as player_id, COUNT(*) as count
+    FROM session_mentions sm
+    INNER JOIN sessions s ON s.id = sm.session_id
+    INNER JOIN entities player ON player.id = sm.entity_id
+    WHERE player.campaign_id = ?
+      AND player.type_id = ?
+      AND player.deleted_at IS NULL
+      AND s.deleted_at IS NULL
+    GROUP BY sm.entity_id
+  `).all(Number(campaignId), playerTypeId) as Array<{ player_id: number; count: number }>
+
+  for (const row of sessionsCounts) {
+    if (result[row.player_id]) {
+      result[row.player_id].sessions = row.count
+    }
+  }
+
+  // 7. Get documents count
+  const documentsCounts = db.prepare(`
+    SELECT ed.entity_id as player_id, COUNT(*) as count
+    FROM entity_documents ed
+    INNER JOIN entities player ON player.id = ed.entity_id
+    WHERE player.campaign_id = ?
+      AND player.type_id = ?
+      AND player.deleted_at IS NULL
+    GROUP BY ed.entity_id
+  `).all(Number(campaignId), playerTypeId) as Array<{ player_id: number; count: number }>
+
+  for (const row of documentsCounts) {
+    if (result[row.player_id]) {
+      result[row.player_id].documents = row.count
+    }
+  }
+
+  // 8. Get images count
+  const imagesCounts = db.prepare(`
+    SELECT ei.entity_id as player_id, COUNT(*) as count
+    FROM entity_images ei
+    INNER JOIN entities player ON player.id = ei.entity_id
+    WHERE player.campaign_id = ?
+      AND player.type_id = ?
+      AND player.deleted_at IS NULL
+    GROUP BY ei.entity_id
+  `).all(Number(campaignId), playerTypeId) as Array<{ player_id: number; count: number }>
+
+  for (const row of imagesCounts) {
+    if (result[row.player_id]) {
+      result[row.player_id].images = row.count
+    }
+  }
+
+  return result
+})


### PR DESCRIPTION
## Summary
- Created batch endpoints for all entity types that return counts for ALL entities in one request
- Replaces N individual `/api/{entity}/:id/counts` requests with 1 `/api/{entity}/batch-counts` request
- Significant performance improvement for pages with many entities (e.g., 60 NPCs = 1 request instead of 60)

## New Endpoints
- `GET /api/npcs/batch-counts?campaignId=X`
- `GET /api/factions/batch-counts?campaignId=X`
- `GET /api/items/batch-counts?campaignId=X`
- `GET /api/lore/batch-counts?campaignId=X`
- `GET /api/players/batch-counts?campaignId=X`

## Updated Files
- All `use*Counts.ts` composables: Added `loadAllCountsForCampaign(campaignId)` function
- `entities.ts` store: Updated `loadAllNpcCounts`, `loadAllItemCounts`, `loadAllLoreCounts` to use batch endpoints
- All entity list pages: Updated `onMounted` to use batch loading

Closes #181