### PR TITLE
fix: chaos graph view/edit buttons (#197)

### DIFF
--- a/packages/app/app/components/players/PlayerViewDialog.vue
+++ b/packages/app/app/components/players/PlayerViewDialog.vue
@@ -263,6 +263,8 @@ const emit = defineEmits<{
   'view-faction': [factionId: number]
 }>()
 
+const { getCounts, loadPlayerCounts } = usePlayerCounts()
+
 const internalShow = computed({
   get: () => props.show,
   set: (value) => emit('update:show', value),
@@ -271,8 +273,8 @@ const internalShow = computed({
 const activeTab = ref('overview')
 const loading = ref(false)
 
-// Counts from player
-const counts = computed(() => props.player?._counts)
+// Reactive counts - use getCounts() with fallback to _counts
+const counts = computed(() => (props.player ? getCounts(props.player.id) || props.player._counts : undefined))
 
 // Data refs
 const characters = ref<
@@ -337,6 +339,11 @@ watch(
   () => [props.show, props.player] as const,
   async ([isVisible, newPlayer]) => {
     if (!isVisible || !newPlayer) return
+
+    // Load counts if not already cached
+    if (!getCounts(newPlayer.id)) {
+      loadPlayerCounts(newPlayer)
+    }
 
     loading.value = true
     try {

--- a/packages/app/app/pages/chaos/[id].vue
+++ b/packages/app/app/pages/chaos/[id].vue
@@ -161,6 +161,7 @@
       :model-value="viewDialogOpen"
       :item="viewingItem"
       @update:model-value="viewDialogOpen = $event"
+      @edit="openEditDialogFromItem"
     />
 
     <LocationViewDialog
@@ -168,6 +169,7 @@
       :model-value="viewDialogOpen"
       :location="viewingLocation"
       @update:model-value="viewDialogOpen = $event"
+      @edit="openEditDialogFromLocation"
     />
 
     <FactionViewDialog
@@ -195,6 +197,14 @@
       :loading-locations="loadingViewLocations"
       @update:model-value="viewDialogOpen = $event"
       @edit="openEditDialogFromLore"
+    />
+
+    <PlayerViewDialog
+      v-if="viewDialogTypeName === 'Player'"
+      :show="viewDialogOpen"
+      :player="viewingPlayer"
+      @update:show="viewDialogOpen = $event"
+      @edit="openEditDialogFromPlayer"
     />
 
     <!-- Edit Dialogs -->
@@ -266,7 +276,9 @@ import FactionEditDialog from '~/components/factions/FactionEditDialog.vue'
 import LoreViewDialog from '~/components/lore/LoreViewDialog.vue'
 import LoreEditDialog from '~/components/lore/LoreEditDialog.vue'
 import PlayerEditDialog from '~/components/players/PlayerEditDialog.vue'
+import PlayerViewDialog from '~/components/players/PlayerViewDialog.vue'
 import type { NPC } from '~~/types/npc'
+import type { Player } from '~~/types/player'
 import type { Item } from '~~/types/item'
 import type { Location } from '~~/types/location'
 import type { Faction } from '~~/types/faction'
@@ -406,6 +418,7 @@ const viewingItem = ref<Item | null>(null)
 const viewingLocation = ref<Location | null>(null)
 const viewingFaction = ref<Faction | null>(null)
 const viewingLore = ref<Lore | null>(null)
+const viewingPlayer = ref<Player | null>(null)
 
 // Lore view dialog data
 const viewDialogNpcs = ref<Array<{ id: number; name: string; description: string | null; image_url: string | null }>>([])
@@ -786,6 +799,8 @@ async function openViewDialog(ent: Entity, entType: EntityType) {
     Player: 'players',
   }
 
+  // Player type is now supported with ViewDialog
+
   const apiRoute = typeRoutes[entType.name]
   if (!apiRoute) {
     // Unsupported type - navigate to page instead
@@ -793,13 +808,6 @@ async function openViewDialog(ent: Entity, entType: EntityType) {
     return
   }
 
-  // Player has no ViewDialog - open EditDialog directly
-  if (entType.name === 'Player') {
-    editingEntityId.value = ent.id
-    editDialogTypeName.value = 'Player'
-    editDialogOpen.value = true
-    return
-  }
 
   try {
     const data = await $fetch(`/api/${apiRoute}/${ent.id}`)
@@ -810,6 +818,7 @@ async function openViewDialog(ent: Entity, entType: EntityType) {
     viewingLocation.value = null
     viewingFaction.value = null
     viewingLore.value = null
+    viewingPlayer.value = null
 
     switch (entType.name) {
       case 'NPC':
@@ -828,6 +837,9 @@ async function openViewDialog(ent: Entity, entType: EntityType) {
         viewingLore.value = data as Lore
         // Load additional data for Lore view dialog
         loadLoreViewData(ent.id)
+        break
+      case 'Player':
+        viewingPlayer.value = data as Player
         break
     }
 
@@ -877,6 +889,32 @@ function openEditDialogFromFaction(faction: Faction) {
 function openEditDialogFromLore(lore: Lore) {
   editingEntityId.value = lore.id
   editDialogTypeName.value = 'Lore'
+  editDialogOpen.value = true
+  viewDialogOpen.value = false
+}
+
+// Helper for ItemViewDialog edit event (receives Item directly, not Connection)
+// Use generic type to match ItemViewDialog's local Item interface
+function openEditDialogFromItem(item: { id: number }) {
+  editingEntityId.value = item.id
+  editDialogTypeName.value = 'Item'
+  editDialogOpen.value = true
+  viewDialogOpen.value = false
+}
+
+// Helper for LocationViewDialog edit event (receives Location directly, not Connection)
+// Use generic type to match LocationViewDialog's local Location interface
+function openEditDialogFromLocation(location: { id: number }) {
+  editingEntityId.value = location.id
+  editDialogTypeName.value = 'Location'
+  editDialogOpen.value = true
+  viewDialogOpen.value = false
+}
+
+// Helper for PlayerViewDialog edit event (receives Player directly, not Connection)
+function openEditDialogFromPlayer(player: { id: number }) {
+  editingEntityId.value = player.id
+  editDialogTypeName.value = 'Player'
   editDialogOpen.value = true
   viewDialogOpen.value = false
 }

--- a/packages/app/test/unit/chaos-graph.test.ts
+++ b/packages/app/test/unit/chaos-graph.test.ts
@@ -1,0 +1,380 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
+import { getDb } from '../../server/utils/db'
+import type Database from 'better-sqlite3'
+
+// Chaos Graph Tests
+// Tests the entity connections API used by the chaos graph visualization
+
+let db: Database.Database
+let testCampaignId: number
+let entityTypeIds: Record<string, number> = {}
+
+beforeAll(() => {
+  db = getDb()
+
+  // Get all entity type IDs
+  const entityTypes = ['NPC', 'Location', 'Item', 'Faction', 'Lore', 'Player']
+  for (const typeName of entityTypes) {
+    const type = db.prepare('SELECT id FROM entity_types WHERE name = ?').get(typeName) as { id: number }
+    entityTypeIds[typeName] = type.id
+  }
+
+  // Create test campaign
+  const campaign = db
+    .prepare('INSERT INTO campaigns (name, description) VALUES (?, ?)')
+    .run('Test Campaign Chaos', 'Test description')
+  testCampaignId = Number(campaign.lastInsertRowid)
+})
+
+afterAll(() => {
+  if (db) {
+    db.prepare('DELETE FROM entity_relations WHERE from_entity_id IN (SELECT id FROM entities WHERE campaign_id = ?)').run(testCampaignId)
+    db.prepare('DELETE FROM entity_relations WHERE to_entity_id IN (SELECT id FROM entities WHERE campaign_id = ?)').run(testCampaignId)
+    db.prepare('DELETE FROM entities WHERE campaign_id = ?').run(testCampaignId)
+    db.prepare('DELETE FROM campaigns WHERE id = ?').run(testCampaignId)
+  }
+})
+
+beforeEach(() => {
+  db.prepare('DELETE FROM entity_relations WHERE from_entity_id IN (SELECT id FROM entities WHERE campaign_id = ?)').run(testCampaignId)
+  db.prepare('DELETE FROM entity_relations WHERE to_entity_id IN (SELECT id FROM entities WHERE campaign_id = ?)').run(testCampaignId)
+  db.prepare('DELETE FROM entities WHERE campaign_id = ?').run(testCampaignId)
+})
+
+// Helper to create an entity of any type
+function createEntity(typeName: string, name: string, metadata?: Record<string, unknown>): number {
+  const result = db
+    .prepare('INSERT INTO entities (type_id, campaign_id, name, metadata) VALUES (?, ?, ?, ?)')
+    .run(entityTypeIds[typeName], testCampaignId, name, metadata ? JSON.stringify(metadata) : null)
+  return Number(result.lastInsertRowid)
+}
+
+// Helper to create a relation
+function createRelation(fromId: number, toId: number, relationType: string): number {
+  const result = db
+    .prepare('INSERT INTO entity_relations (from_entity_id, to_entity_id, relation_type) VALUES (?, ?, ?)')
+    .run(fromId, toId, relationType)
+  return Number(result.lastInsertRowid)
+}
+
+// Helper to get connections (simulates the API)
+function getConnections(entityId: number) {
+  interface DbConnection {
+    relation_id: number
+    entity_id: number
+    entity_name: string
+    entity_type: string
+    entity_type_id: number
+    entity_icon: string
+    entity_color: string
+    entity_image_url: string | null
+    relation_type: string
+    relation_notes: string | null
+    direction: 'outgoing' | 'incoming'
+  }
+
+  // Get outgoing relations
+  const outgoing = db
+    .prepare<unknown[], DbConnection>(`
+      SELECT
+        er.id as relation_id,
+        e.id as entity_id,
+        e.name as entity_name,
+        et.name as entity_type,
+        et.id as entity_type_id,
+        et.icon as entity_icon,
+        et.color as entity_color,
+        e.image_url as entity_image_url,
+        er.relation_type,
+        er.notes as relation_notes,
+        'outgoing' as direction
+      FROM entity_relations er
+      INNER JOIN entities e ON er.to_entity_id = e.id
+      INNER JOIN entity_types et ON e.type_id = et.id
+      WHERE er.from_entity_id = ?
+        AND e.deleted_at IS NULL
+      ORDER BY et.name, e.name
+    `)
+    .all(entityId)
+
+  // Get incoming relations
+  const incoming = db
+    .prepare<unknown[], DbConnection>(`
+      SELECT
+        er.id as relation_id,
+        e.id as entity_id,
+        e.name as entity_name,
+        et.name as entity_type,
+        et.id as entity_type_id,
+        et.icon as entity_icon,
+        et.color as entity_color,
+        e.image_url as entity_image_url,
+        er.relation_type,
+        er.notes as relation_notes,
+        'incoming' as direction
+      FROM entity_relations er
+      INNER JOIN entities e ON er.from_entity_id = e.id
+      INNER JOIN entity_types et ON e.type_id = et.id
+      WHERE er.to_entity_id = ?
+        AND e.deleted_at IS NULL
+      ORDER BY et.name, e.name
+    `)
+    .all(entityId)
+
+  return [...outgoing, ...incoming]
+}
+
+describe('Chaos Graph - Entity Connections', () => {
+  it('should return outgoing connections', () => {
+    const npcId = createEntity('NPC', 'Test NPC')
+    const locationId = createEntity('Location', 'Test Location')
+    createRelation(npcId, locationId, 'lives_at')
+
+    const connections = getConnections(npcId)
+
+    expect(connections).toHaveLength(1)
+    expect(connections[0].entity_name).toBe('Test Location')
+    expect(connections[0].entity_type).toBe('Location')
+    expect(connections[0].direction).toBe('outgoing')
+  })
+
+  it('should return incoming connections', () => {
+    const npcId = createEntity('NPC', 'Test NPC')
+    const locationId = createEntity('Location', 'Test Location')
+    createRelation(npcId, locationId, 'lives_at')
+
+    const connections = getConnections(locationId)
+
+    expect(connections).toHaveLength(1)
+    expect(connections[0].entity_name).toBe('Test NPC')
+    expect(connections[0].entity_type).toBe('NPC')
+    expect(connections[0].direction).toBe('incoming')
+  })
+
+  it('should return both incoming and outgoing connections', () => {
+    const npc1 = createEntity('NPC', 'NPC 1')
+    const npc2 = createEntity('NPC', 'NPC 2')
+    const npc3 = createEntity('NPC', 'NPC 3')
+
+    // NPC1 -> NPC2 (outgoing from NPC2's perspective: incoming)
+    createRelation(npc1, npc2, 'friend')
+    // NPC2 -> NPC3 (outgoing from NPC2's perspective)
+    createRelation(npc2, npc3, 'enemy')
+
+    const connections = getConnections(npc2)
+
+    expect(connections).toHaveLength(2)
+
+    const incoming = connections.find(c => c.direction === 'incoming')
+    const outgoing = connections.find(c => c.direction === 'outgoing')
+
+    expect(incoming?.entity_name).toBe('NPC 1')
+    expect(outgoing?.entity_name).toBe('NPC 3')
+  })
+})
+
+describe('Chaos Graph - All Entity Types', () => {
+  it('should handle NPC connections', () => {
+    const npcId = createEntity('NPC', 'Gandalf', { race: 'human', class: 'wizard' })
+    const itemId = createEntity('Item', 'Staff of Power')
+    createRelation(npcId, itemId, 'owns')
+
+    const connections = getConnections(npcId)
+
+    expect(connections).toHaveLength(1)
+    expect(connections[0].entity_type).toBe('Item')
+  })
+
+  it('should handle Location connections', () => {
+    const locationId = createEntity('Location', 'Moria', { type: 'dungeon' })
+    const npcId = createEntity('NPC', 'Balrog')
+    createRelation(npcId, locationId, 'guards')
+
+    const connections = getConnections(locationId)
+
+    expect(connections).toHaveLength(1)
+    expect(connections[0].entity_type).toBe('NPC')
+  })
+
+  it('should handle Item connections', () => {
+    const itemId = createEntity('Item', 'The One Ring', { rarity: 'artifact' })
+    const npcId = createEntity('NPC', 'Frodo')
+    createRelation(npcId, itemId, 'carries')
+
+    const connections = getConnections(itemId)
+
+    expect(connections).toHaveLength(1)
+    expect(connections[0].entity_type).toBe('NPC')
+  })
+
+  it('should handle Faction connections', () => {
+    const factionId = createEntity('Faction', 'Fellowship', { type: 'alliance' })
+    const npcId = createEntity('NPC', 'Aragorn')
+    createRelation(npcId, factionId, 'member')
+
+    const connections = getConnections(factionId)
+
+    expect(connections).toHaveLength(1)
+    expect(connections[0].entity_type).toBe('NPC')
+  })
+
+  it('should handle Lore connections', () => {
+    const loreId = createEntity('Lore', 'The Silmarillion', { category: 'history' })
+    const npcId = createEntity('NPC', 'Elrond')
+    createRelation(loreId, npcId, 'mentions')
+
+    const connections = getConnections(loreId)
+
+    expect(connections).toHaveLength(1)
+    expect(connections[0].entity_type).toBe('NPC')
+  })
+
+  it('should handle Player connections', () => {
+    const playerId = createEntity('Player', 'John', { player_name: 'John Doe' })
+    const npcId = createEntity('NPC', 'Legolas')
+    createRelation(playerId, npcId, 'plays')
+
+    const connections = getConnections(playerId)
+
+    expect(connections).toHaveLength(1)
+    expect(connections[0].entity_type).toBe('NPC')
+  })
+})
+
+describe('Chaos Graph - Complex Networks', () => {
+  it('should handle entity with multiple connections of different types', () => {
+    const npcId = createEntity('NPC', 'Central NPC')
+    const location1 = createEntity('Location', 'Home')
+    const location2 = createEntity('Location', 'Work')
+    const item1 = createEntity('Item', 'Sword')
+    const faction1 = createEntity('Faction', 'Guild')
+
+    createRelation(npcId, location1, 'lives_at')
+    createRelation(npcId, location2, 'works_at')
+    createRelation(npcId, item1, 'owns')
+    createRelation(npcId, faction1, 'member_of')
+
+    const connections = getConnections(npcId)
+
+    expect(connections).toHaveLength(4)
+
+    const types = connections.map(c => c.entity_type)
+    expect(types).toContain('Location')
+    expect(types).toContain('Item')
+    expect(types).toContain('Faction')
+  })
+
+  it('should not include soft-deleted entities in connections', () => {
+    const npcId = createEntity('NPC', 'Active NPC')
+    const deletedNpcId = createEntity('NPC', 'Deleted NPC')
+
+    createRelation(npcId, deletedNpcId, 'friend')
+
+    // Soft-delete the connected NPC
+    db.prepare('UPDATE entities SET deleted_at = CURRENT_TIMESTAMP WHERE id = ?').run(deletedNpcId)
+
+    const connections = getConnections(npcId)
+
+    expect(connections).toHaveLength(0)
+  })
+
+  it('should handle bidirectional relationships correctly', () => {
+    const npc1 = createEntity('NPC', 'Alice')
+    const npc2 = createEntity('NPC', 'Bob')
+
+    // Create bidirectional relationship
+    createRelation(npc1, npc2, 'friend')
+    createRelation(npc2, npc1, 'friend')
+
+    const connectionsNpc1 = getConnections(npc1)
+    const connectionsNpc2 = getConnections(npc2)
+
+    // Each should see the other twice (once outgoing, once incoming)
+    expect(connectionsNpc1).toHaveLength(2)
+    expect(connectionsNpc2).toHaveLength(2)
+  })
+})
+
+describe('Chaos Graph - Entity Type Metadata', () => {
+  it('should return entity type icon and color', () => {
+    const npcId = createEntity('NPC', 'Test NPC')
+    const locationId = createEntity('Location', 'Test Location')
+    createRelation(npcId, locationId, 'visits')
+
+    const connections = getConnections(npcId)
+
+    expect(connections[0].entity_icon).toBeDefined()
+    expect(connections[0].entity_color).toBeDefined()
+    expect(connections[0].entity_type_id).toBe(entityTypeIds['Location'])
+  })
+
+  it('should return entity image URL if present', () => {
+    const npcId = createEntity('NPC', 'NPC with Image')
+    const locationId = createEntity('Location', 'Location')
+
+    // Set image URL
+    db.prepare('UPDATE entities SET image_url = ? WHERE id = ?').run('test-image.jpg', locationId)
+
+    createRelation(npcId, locationId, 'visits')
+
+    const connections = getConnections(npcId)
+
+    expect(connections[0].entity_image_url).toBe('test-image.jpg')
+  })
+
+  it('should return null for entity without image', () => {
+    const npcId = createEntity('NPC', 'NPC')
+    const locationId = createEntity('Location', 'Location without image')
+
+    createRelation(npcId, locationId, 'visits')
+
+    const connections = getConnections(npcId)
+
+    expect(connections[0].entity_image_url).toBeNull()
+  })
+})
+
+describe('Chaos Graph - Relation Types', () => {
+  it('should return relation type', () => {
+    const npcId = createEntity('NPC', 'NPC')
+    const locationId = createEntity('Location', 'Location')
+
+    createRelation(npcId, locationId, 'guards')
+
+    const connections = getConnections(npcId)
+
+    expect(connections[0].relation_type).toBe('guards')
+  })
+
+  it('should handle custom relation types', () => {
+    const npcId = createEntity('NPC', 'NPC')
+    const itemId = createEntity('Item', 'Item')
+
+    createRelation(npcId, itemId, 'custom_relation_type')
+
+    const connections = getConnections(npcId)
+
+    expect(connections[0].relation_type).toBe('custom_relation_type')
+  })
+
+  it('should handle i18n key relation types', () => {
+    const npc1 = createEntity('NPC', 'NPC 1')
+    const npc2 = createEntity('NPC', 'NPC 2')
+
+    createRelation(npc1, npc2, 'friend')
+
+    const connections = getConnections(npc1)
+
+    expect(connections[0].relation_type).toBe('friend')
+  })
+})
+
+describe('Chaos Graph - Empty States', () => {
+  it('should return empty array for entity with no connections', () => {
+    const npcId = createEntity('NPC', 'Lonely NPC')
+
+    const connections = getConnections(npcId)
+
+    expect(connections).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
## Summary
- Add PlayerViewDialog to chaos graph (was opening EditDialog directly)
- Add @edit handler for ItemViewDialog 
- Add @edit handler for LocationViewDialog
- PlayerViewDialog now uses usePlayerCounts() for tab badges

## Test plan
- [x] Unit tests added (chaos-graph.test.ts - 19 tests)
- [x] Manual: Click "View" on Player in chaos graph → ViewDialog opens
- [x] Manual: Click "Edit" in Item ViewDialog → EditDialog opens
- [x] Manual: Click "Edit" in Location ViewDialog → EditDialog opens

Fixes #197