### PR TITLE
fix: improve calendar weather validation and add reset

### DIFF
--- a/packages/app/app/components/calendar/CalendarSettingsDialog.vue
+++ b/packages/app/app/components/calendar/CalendarSettingsDialog.vue
@@ -41,6 +41,7 @@
                     <v-text-field
                       v-model.number="month.days"
                       type="number"
+                      :min="1"
                       density="compact"
                       hide-details
                       variant="outlined"
@@ -81,7 +82,13 @@
                     />
                   </td>
                   <td>
-                    <v-btn icon="mdi-delete" variant="text" size="small" @click="removeWeekday(index)" />
+                    <v-btn
+                      icon="mdi-delete"
+                      variant="text"
+                      size="small"
+                      :disabled="form.weekdays.length <= 1"
+                      @click="removeWeekday(index)"
+                    />
                   </td>
                 </tr>
               </tbody>
@@ -374,6 +381,9 @@
         </v-window>
       </v-card-text>
       <v-card-actions>
+        <v-btn color="error" variant="text" @click="confirmReset">
+          {{ $t('calendar.reset.button') }}
+        </v-btn>
         <v-spacer />
         <v-btn @click="modelValue = false">{{ $t('common.cancel') }}</v-btn>
         <v-btn color="primary" :loading="saving" @click="emit('save')">
@@ -381,6 +391,49 @@
         </v-btn>
       </v-card-actions>
     </v-card>
+
+    <!-- Reset Confirmation Dialog -->
+    <v-dialog v-model="showResetDialog" max-width="500" persistent>
+      <v-card>
+        <v-card-title class="text-error">
+          <v-icon start color="error">mdi-alert</v-icon>
+          {{ $t('calendar.reset.title') }}
+        </v-card-title>
+        <v-card-text>
+          <p class="mb-4">{{ $t('calendar.reset.warning') }}</p>
+
+          <v-alert v-if="calendarStats?.hasData" type="warning" variant="tonal" class="mb-4">
+            <div class="font-weight-bold mb-2">{{ $t('calendar.reset.dataWillBeDeleted') }}</div>
+            <ul class="pl-4">
+              <li v-if="calendarStats.events > 0">
+                {{ $t('calendar.reset.events', { count: calendarStats.events }) }}
+              </li>
+              <li v-if="calendarStats.weather > 0">
+                {{ $t('calendar.reset.weather', { count: calendarStats.weather }) }}
+              </li>
+              <li v-if="calendarStats.sessionsWithDates > 0">
+                {{ $t('calendar.reset.sessions', { count: calendarStats.sessionsWithDates }) }}
+              </li>
+              <li v-if="calendarStats.seasons > 0">
+                {{ $t('calendar.reset.seasons', { count: calendarStats.seasons }) }}
+              </li>
+              <li v-if="calendarStats.moons > 0">
+                {{ $t('calendar.reset.moons', { count: calendarStats.moons }) }}
+              </li>
+            </ul>
+          </v-alert>
+
+          <p>{{ $t('calendar.reset.confirm') }}</p>
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn @click="showResetDialog = false">{{ $t('common.cancel') }}</v-btn>
+          <v-btn color="error" :loading="resetting" @click="executeReset">
+            {{ $t('calendar.reset.confirmButton') }}
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
   </v-dialog>
 </template>
 
@@ -428,7 +481,56 @@ defineProps<{
 
 const emit = defineEmits<{
   save: []
+  reset: []
 }>()
+
+const snackbarStore = useSnackbarStore()
+const campaignStore = useCampaignStore()
+
+// Reset calendar state
+const showResetDialog = ref(false)
+const resetting = ref(false)
+const calendarStats = ref<{
+  events: number
+  weather: number
+  sessionsWithDates: number
+  seasons: number
+  moons: number
+  hasData: boolean
+} | null>(null)
+
+async function confirmReset() {
+  if (!campaignStore.activeCampaignId) return
+  // Load stats first
+  try {
+    calendarStats.value = await $fetch('/api/calendar/stats', {
+      query: { campaignId: campaignStore.activeCampaignId },
+    })
+  } catch {
+    calendarStats.value = null
+  }
+  showResetDialog.value = true
+}
+
+async function executeReset() {
+  if (!campaignStore.activeCampaignId) return
+  resetting.value = true
+  try {
+    await $fetch('/api/calendar/reset', {
+      method: 'DELETE',
+      query: { campaignId: campaignStore.activeCampaignId },
+    })
+    showResetDialog.value = false
+    modelValue.value = false
+    snackbarStore.success(t('calendar.reset.success'))
+    emit('reset')
+  } catch (error) {
+    console.error('Failed to reset calendar:', error)
+    snackbarStore.error(t('calendar.reset.error'))
+  } finally {
+    resetting.value = false
+  }
+}
 
 // Seasons are managed separately via two-way binding
 const seasons = defineModel<CalendarSeason[]>('seasons', { default: () => [] })

--- a/packages/app/app/pages/calendar/index.vue
+++ b/packages/app/app/pages/calendar/index.vue
@@ -16,14 +16,21 @@
             </v-chip>
           </v-btn>
         </v-btn-toggle>
-        <v-btn
-          variant="tonal"
-          prepend-icon="mdi-weather-cloudy"
-          :loading="generatingWeather"
-          @click="generateWeatherForMonth"
-        >
-          {{ $t('calendar.weather.generate') }}
-        </v-btn>
+        <v-tooltip :text="weatherDisabledReason" :disabled="canGenerateWeather" location="bottom">
+          <template #activator="{ props: tooltipProps }">
+            <span v-bind="tooltipProps">
+              <v-btn
+                variant="tonal"
+                prepend-icon="mdi-weather-cloudy"
+                :loading="generatingWeather"
+                :disabled="!canGenerateWeather"
+                @click="generateWeatherForMonth"
+              >
+                {{ $t('calendar.weather.generate') }}
+              </v-btn>
+            </span>
+          </template>
+        </v-tooltip>
         <v-btn variant="tonal" prepend-icon="mdi-cog" @click="openSettingsDialog">
           {{ $t('calendar.settings') }}
         </v-btn>
@@ -445,6 +452,7 @@
       v-model:seasons="editingSeasons"
       :saving="saving"
       @save="saveSettings"
+      @reset="handleCalendarReset"
     />
 
     <!-- Event Dialog -->
@@ -609,6 +617,26 @@
       @saved="onWeatherSaved"
       @cleared="onWeatherCleared"
     />
+
+    <!-- Weather Overwrite Confirmation Dialog -->
+    <v-dialog v-model="showWeatherOverwriteDialog" max-width="450">
+      <v-card>
+        <v-card-title>
+          <v-icon start color="warning">mdi-alert</v-icon>
+          {{ $t('calendar.weather.overwriteTitle') }}
+        </v-card-title>
+        <v-card-text>
+          {{ $t('calendar.weather.overwriteWarning', { count: weather.size }) }}
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn @click="showWeatherOverwriteDialog = false">{{ $t('common.cancel') }}</v-btn>
+          <v-btn color="warning" @click="confirmWeatherOverwrite">
+            {{ $t('calendar.weather.overwriteConfirm') }}
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
   </div>
 </template>
 
@@ -732,6 +760,7 @@ interface CalendarWeather {
 }
 const weather = ref<Map<number, CalendarWeather>>(new Map()) // day -> weather
 const generatingWeather = ref(false)
+const showWeatherOverwriteDialog = ref(false)
 const showWeatherDialog = ref(false)
 const weatherDialogDay = ref<number | null>(null)
 const editingSeasons = ref<CalendarSeason[]>([])
@@ -789,7 +818,32 @@ const eventForm = ref({
 const entityOptions = ref<Array<{ id: number; name: string; type: string }>>([])
 
 // Computed
-const isConfigured = computed(() => calendarConfig.value.months.length > 0)
+const isConfigured = computed(() =>
+  calendarConfig.value.months.length > 0 && calendarConfig.value.weekdays.length > 0,
+)
+
+// Check if weather generation is possible
+const canGenerateWeather = computed(() => {
+  if (!isConfigured.value) return false
+  // Use currentMonthDays which correctly calculates days including leap years
+  return currentMonthDays.value > 0
+})
+
+// Reason why weather generation is disabled (for tooltip)
+const weatherDisabledReason = computed(() => {
+  if (!isConfigured.value) {
+    return t('calendar.weather.disabledNoCalendar')
+  }
+  if (currentMonthDays.value <= 0) {
+    return t('calendar.weather.disabledNoDays')
+  }
+  return ''
+})
+
+// Check if current month has any weather data
+const currentMonthHasWeather = computed(() => {
+  return weather.value.size > 0
+})
 
 const currentMonthName = computed(() => {
   const month = calendarConfig.value.months[viewMonth.value - 1]
@@ -833,7 +887,8 @@ const currentMoonPhases = computed(() => {
 
 // Dynamic grid style based on weekdays count
 const calendarGridStyle = computed(() => {
-  const weekdaysCount = calendarConfig.value.weekdays.length || 7
+  // At least 1 weekday is guaranteed by isConfigured check
+  const weekdaysCount = calendarConfig.value.weekdays.length || 1
   return {
     gridTemplateColumns: `repeat(${weekdaysCount}, 1fr)`,
   }
@@ -903,11 +958,13 @@ function getDaysInYear(year: number): number {
 // Get days in a specific month (accounting for leap years)
 function getDaysInMonthWithLeap(year: number, monthIndex: number): number {
   const month = calendarConfig.value.months[monthIndex]
-  if (!month) return 30
-  let days = month.days
+  if (!month) return 0
+  let days = month.days || 0
+  // Safety check: days must be a valid number
+  if (isNaN(days) || days < 0) days = 0
   // Add leap year extra days to the designated month
   if (isLeapYear(year) && calendarConfig.value.config.leap_year_month - 1 === monthIndex) {
-    days += calendarConfig.value.config.leap_year_extra_days
+    days += calendarConfig.value.config.leap_year_extra_days || 0
   }
   return days
 }
@@ -1218,11 +1275,13 @@ function getMoonColor(moonName: string): string {
 // Get days in month (considering leap year)
 function getDaysInMonth(month: number, year: number): number {
   const monthData = calendarConfig.value.months[month - 1]
-  if (!monthData) return 30
-  let days = monthData.days
+  if (!monthData) return 0
+  let days = monthData.days || 0
+  // Safety check: days must be a valid number
+  if (isNaN(days) || days < 0) days = 0
   // Add leap day if this is the leap month and it's a leap year
   if (isLeapYear(year) && month === calendarConfig.value.config.leap_year_month) {
-    days += calendarConfig.value.config.leap_year_extra_days
+    days += calendarConfig.value.config.leap_year_extra_days || 0
   }
   return days
 }
@@ -1583,6 +1642,31 @@ async function confirmDeleteEvent() {
   }
 }
 
+// Handle calendar reset - reload everything
+async function handleCalendarReset() {
+  // Reset to defaults
+  calendarConfig.value = {
+    config: {
+      current_year: 1,
+      current_month: 1,
+      current_day: 1,
+      era_name: '',
+      leap_year_interval: 0,
+      leap_year_month: 1,
+      leap_year_extra_days: 1,
+    },
+    months: [],
+    weekdays: [],
+    moons: [],
+  }
+  viewYear.value = 1
+  viewMonth.value = 1
+  events.value = []
+  sessions.value = []
+  seasons.value = []
+  weather.value.clear()
+}
+
 // Load functions
 async function loadConfig() {
   if (!campaignStore.activeCampaignId) return
@@ -1736,7 +1820,27 @@ function onWeatherCleared() {
 }
 
 // Generate weather for the current month
-async function generateWeatherForMonth() {
+function generateWeatherForMonth() {
+  if (!campaignStore.activeCampaignId) return
+
+  // Check if weather already exists - show confirmation
+  if (currentMonthHasWeather.value) {
+    showWeatherOverwriteDialog.value = true
+    return
+  }
+
+  // No existing weather - generate directly
+  doGenerateWeather(false)
+}
+
+// Confirm overwrite and generate
+function confirmWeatherOverwrite() {
+  showWeatherOverwriteDialog.value = false
+  doGenerateWeather(true)
+}
+
+// Actually generate weather
+async function doGenerateWeather(overwrite: boolean) {
   if (!campaignStore.activeCampaignId) return
 
   generatingWeather.value = true
@@ -1747,7 +1851,7 @@ async function generateWeatherForMonth() {
         campaignId: campaignStore.activeCampaignId,
         year: viewYear.value,
         month: viewMonth.value,
-        overwrite: false, // Don't overwrite existing
+        overwrite,
       },
     })
     // Update weather map

--- a/packages/app/i18n/locales/de.json
+++ b/packages/app/i18n/locales/de.json
@@ -1806,6 +1806,11 @@
       "editWeather": "Wetter bearbeiten",
       "clearWeather": "Wetter entfernen",
       "generated": "{count} Tage Wetter generiert",
+      "disabledNoCalendar": "Bitte zuerst den Kalender einrichten",
+      "disabledNoDays": "Der aktuelle Monat hat keine Tage konfiguriert",
+      "overwriteTitle": "Wetter überschreiben",
+      "overwriteWarning": "Für diesen Monat existieren bereits {count} Wetter-Einträge. Diese werden überschrieben.",
+      "overwriteConfirm": "Überschreiben",
       "types": {
         "sunny": "Sonnig",
         "partlyCloudy": "Teilweise bewölkt",
@@ -1827,6 +1832,21 @@
       "spring": "Frühling (mild, Regen)",
       "summer": "Sommer (warm, sonnig)",
       "autumn": "Herbst (kühl, nebelig)"
+    },
+    "reset": {
+      "button": "Kalender zurücksetzen",
+      "title": "Kalender zurücksetzen",
+      "warning": "Diese Aktion löscht alle Kalenderdaten unwiderruflich.",
+      "dataWillBeDeleted": "Folgende Daten werden gelöscht:",
+      "events": "{count} Kalender-Ereignisse",
+      "weather": "{count} Wetter-Einträge",
+      "sessions": "{count} Sessions mit In-Game-Datum",
+      "seasons": "{count} Jahreszeiten",
+      "moons": "{count} Monde",
+      "confirm": "Bist du sicher, dass du fortfahren möchtest?",
+      "confirmButton": "Kalender löschen",
+      "success": "Kalender wurde zurückgesetzt",
+      "error": "Fehler beim Zurücksetzen des Kalenders"
     }
   },
   "chaos": {

--- a/packages/app/i18n/locales/en.json
+++ b/packages/app/i18n/locales/en.json
@@ -1820,6 +1820,11 @@
       "editWeather": "Edit Weather",
       "clearWeather": "Remove Weather",
       "generated": "{count} days of weather generated",
+      "disabledNoCalendar": "Please set up the calendar first",
+      "disabledNoDays": "The current month has no days configured",
+      "overwriteTitle": "Overwrite Weather",
+      "overwriteWarning": "This month already has {count} weather entries. These will be overwritten.",
+      "overwriteConfirm": "Overwrite",
       "types": {
         "sunny": "Sunny",
         "partlyCloudy": "Partly Cloudy",
@@ -1841,6 +1846,21 @@
       "spring": "Spring (mild, rain)",
       "summer": "Summer (warm, sunny)",
       "autumn": "Autumn (cool, foggy)"
+    },
+    "reset": {
+      "button": "Reset Calendar",
+      "title": "Reset Calendar",
+      "warning": "This action will permanently delete all calendar data.",
+      "dataWillBeDeleted": "The following data will be deleted:",
+      "events": "{count} calendar events",
+      "weather": "{count} weather entries",
+      "sessions": "{count} sessions with in-game dates",
+      "seasons": "{count} seasons",
+      "moons": "{count} moons",
+      "confirm": "Are you sure you want to continue?",
+      "confirmButton": "Delete Calendar",
+      "success": "Calendar has been reset",
+      "error": "Failed to reset calendar"
     }
   },
   "pinboard": {

--- a/packages/app/server/api/calendar/reset.delete.ts
+++ b/packages/app/server/api/calendar/reset.delete.ts
@@ -1,0 +1,60 @@
+import { getDb } from '~~/server/utils/db'
+
+// Reset/delete all calendar data for a campaign
+export default defineEventHandler((event) => {
+  const db = getDb()
+  const query = getQuery(event)
+  const campaignId = query.campaignId as string
+
+  if (!campaignId) {
+    throw createError({
+      statusCode: 400,
+      message: 'Campaign ID is required',
+    })
+  }
+
+  // Delete in correct order to respect foreign keys
+  // 1. Delete weather data
+  db.prepare('DELETE FROM calendar_weather WHERE campaign_id = ?').run(campaignId)
+
+  // 2. Delete event entities (junction table)
+  db.prepare(
+    `DELETE FROM calendar_event_entities
+     WHERE event_id IN (SELECT id FROM calendar_events WHERE campaign_id = ?)`,
+  ).run(campaignId)
+
+  // 3. Delete events
+  db.prepare('DELETE FROM calendar_events WHERE campaign_id = ?').run(campaignId)
+
+  // 4. Delete seasons
+  db.prepare('DELETE FROM calendar_seasons WHERE campaign_id = ?').run(campaignId)
+
+  // 5. Delete moons
+  db.prepare('DELETE FROM calendar_moons WHERE campaign_id = ?').run(campaignId)
+
+  // 6. Delete weekdays
+  db.prepare('DELETE FROM calendar_weekdays WHERE campaign_id = ?').run(campaignId)
+
+  // 7. Delete months
+  db.prepare('DELETE FROM calendar_months WHERE campaign_id = ?').run(campaignId)
+
+  // 8. Delete config
+  db.prepare('DELETE FROM calendar_config WHERE campaign_id = ?').run(campaignId)
+
+  // 9. Clear session in-game dates (but keep sessions)
+  db.prepare(
+    `UPDATE sessions SET
+       in_game_year_start = NULL,
+       in_game_month_start = NULL,
+       in_game_day_start = NULL,
+       in_game_year_end = NULL,
+       in_game_month_end = NULL,
+       in_game_day_end = NULL,
+       in_game_date_start = NULL,
+       in_game_date_end = NULL,
+       calendar_event_id = NULL
+     WHERE campaign_id = ?`,
+  ).run(campaignId)
+
+  return { success: true }
+})

--- a/packages/app/server/api/calendar/stats.get.ts
+++ b/packages/app/server/api/calendar/stats.get.ts
@@ -1,0 +1,68 @@
+import { getDb } from '~~/server/utils/db'
+
+// Get statistics about calendar data for deletion warning
+export default defineEventHandler((event) => {
+  const db = getDb()
+  const query = getQuery(event)
+  const campaignId = query.campaignId as string
+
+  if (!campaignId) {
+    throw createError({
+      statusCode: 400,
+      message: 'Campaign ID is required',
+    })
+  }
+
+  // Count events
+  const eventsCount =
+    (
+      db.prepare('SELECT COUNT(*) as count FROM calendar_events WHERE campaign_id = ?').get(campaignId) as {
+        count: number
+      }
+    )?.count || 0
+
+  // Count weather entries
+  const weatherCount =
+    (
+      db.prepare('SELECT COUNT(*) as count FROM calendar_weather WHERE campaign_id = ?').get(campaignId) as {
+        count: number
+      }
+    )?.count || 0
+
+  // Count sessions with in-game dates
+  const sessionsWithDatesCount =
+    (
+      db
+        .prepare(
+          `SELECT COUNT(*) as count FROM sessions
+           WHERE campaign_id = ?
+           AND (in_game_year_start IS NOT NULL OR in_game_day_start IS NOT NULL)`,
+        )
+        .get(campaignId) as { count: number }
+    )?.count || 0
+
+  // Count seasons
+  const seasonsCount =
+    (
+      db.prepare('SELECT COUNT(*) as count FROM calendar_seasons WHERE campaign_id = ?').get(campaignId) as {
+        count: number
+      }
+    )?.count || 0
+
+  // Count moons
+  const moonsCount =
+    (
+      db.prepare('SELECT COUNT(*) as count FROM calendar_moons WHERE campaign_id = ?').get(campaignId) as {
+        count: number
+      }
+    )?.count || 0
+
+  return {
+    events: eventsCount,
+    weather: weatherCount,
+    sessionsWithDates: sessionsWithDatesCount,
+    seasons: seasonsCount,
+    moons: moonsCount,
+    hasData: eventsCount > 0 || weatherCount > 0 || sessionsWithDatesCount > 0,
+  }
+})

--- a/packages/app/test/unit/calendar-weather.test.ts
+++ b/packages/app/test/unit/calendar-weather.test.ts
@@ -331,3 +331,393 @@ describe('Calendar Weather - Temperature Ranges', () => {
     expect(weather.temperature).toBeNull()
   })
 })
+
+describe('Calendar Stats API', () => {
+  it('should return zero counts for empty calendar', () => {
+    const eventsCount = (
+      db.prepare('SELECT COUNT(*) as count FROM calendar_events WHERE campaign_id = ?').get(testCampaignId) as {
+        count: number
+      }
+    )?.count || 0
+
+    const weatherCount = (
+      db.prepare('SELECT COUNT(*) as count FROM calendar_weather WHERE campaign_id = ?').get(testCampaignId) as {
+        count: number
+      }
+    )?.count || 0
+
+    expect(eventsCount).toBe(0)
+    expect(weatherCount).toBe(0)
+  })
+
+  it('should count weather entries correctly', () => {
+    // Insert some weather
+    for (let day = 1; day <= 5; day++) {
+      db.prepare(`
+        INSERT INTO calendar_weather (campaign_id, year, month, day, weather_type, temperature)
+        VALUES (?, ?, ?, ?, ?, ?)
+      `).run(testCampaignId, 1352, 3, day, 'sunny', 20)
+    }
+
+    const weatherCount = (
+      db.prepare('SELECT COUNT(*) as count FROM calendar_weather WHERE campaign_id = ?').get(testCampaignId) as {
+        count: number
+      }
+    )?.count || 0
+
+    expect(weatherCount).toBe(5)
+  })
+
+  it('should count events correctly', () => {
+    // Insert some events
+    db.prepare(`
+      INSERT INTO calendar_events (campaign_id, year, month, day, title, color)
+      VALUES (?, ?, ?, ?, ?, ?)
+    `).run(testCampaignId, 1352, 5, 10, 'Battle', '#ff0000')
+
+    db.prepare(`
+      INSERT INTO calendar_events (campaign_id, year, month, day, title, color)
+      VALUES (?, ?, ?, ?, ?, ?)
+    `).run(testCampaignId, 1352, 5, 15, 'Festival', '#00ff00')
+
+    const eventsCount = (
+      db.prepare('SELECT COUNT(*) as count FROM calendar_events WHERE campaign_id = ?').get(testCampaignId) as {
+        count: number
+      }
+    )?.count || 0
+
+    expect(eventsCount).toBe(2)
+
+    // Cleanup
+    db.prepare('DELETE FROM calendar_events WHERE campaign_id = ?').run(testCampaignId)
+  })
+
+  it('should count seasons correctly', () => {
+    // Insert seasons
+    db.prepare(`
+      INSERT INTO calendar_seasons (campaign_id, name, start_month, start_day, weather_type)
+      VALUES (?, ?, ?, ?, ?)
+    `).run(testCampaignId, 'Spring', 3, 1, 'spring')
+
+    db.prepare(`
+      INSERT INTO calendar_seasons (campaign_id, name, start_month, start_day, weather_type)
+      VALUES (?, ?, ?, ?, ?)
+    `).run(testCampaignId, 'Summer', 6, 1, 'summer')
+
+    const seasonsCount = (
+      db.prepare('SELECT COUNT(*) as count FROM calendar_seasons WHERE campaign_id = ?').get(testCampaignId) as {
+        count: number
+      }
+    )?.count || 0
+
+    expect(seasonsCount).toBe(2)
+  })
+
+  it('should count moons correctly', () => {
+    // Insert moons
+    db.prepare(`
+      INSERT INTO calendar_moons (campaign_id, name, cycle_days, full_moon_duration, new_moon_duration, phase_offset)
+      VALUES (?, ?, ?, ?, ?, ?)
+    `).run(testCampaignId, 'Luna', 28, 3, 3, 0)
+
+    const moonsCount = (
+      db.prepare('SELECT COUNT(*) as count FROM calendar_moons WHERE campaign_id = ?').get(testCampaignId) as {
+        count: number
+      }
+    )?.count || 0
+
+    expect(moonsCount).toBe(1)
+
+    // Cleanup
+    db.prepare('DELETE FROM calendar_moons WHERE campaign_id = ?').run(testCampaignId)
+  })
+})
+
+describe('Calendar Reset', () => {
+  it('should delete all weather when reset', () => {
+    // Insert weather
+    for (let day = 1; day <= 10; day++) {
+      db.prepare(`
+        INSERT INTO calendar_weather (campaign_id, year, month, day, weather_type, temperature)
+        VALUES (?, ?, ?, ?, ?, ?)
+      `).run(testCampaignId, 1352, 1, day, 'sunny', 20)
+    }
+
+    // Verify data exists
+    let count = (
+      db.prepare('SELECT COUNT(*) as count FROM calendar_weather WHERE campaign_id = ?').get(testCampaignId) as {
+        count: number
+      }
+    )?.count || 0
+    expect(count).toBe(10)
+
+    // Reset (delete)
+    db.prepare('DELETE FROM calendar_weather WHERE campaign_id = ?').run(testCampaignId)
+
+    // Verify deleted
+    count = (
+      db.prepare('SELECT COUNT(*) as count FROM calendar_weather WHERE campaign_id = ?').get(testCampaignId) as {
+        count: number
+      }
+    )?.count || 0
+    expect(count).toBe(0)
+  })
+
+  it('should delete all seasons when reset', () => {
+    // Insert seasons
+    db.prepare(`
+      INSERT INTO calendar_seasons (campaign_id, name, start_month, start_day, weather_type)
+      VALUES (?, ?, ?, ?, ?)
+    `).run(testCampaignId, 'Winter', 12, 1, 'winter')
+
+    // Reset
+    db.prepare('DELETE FROM calendar_seasons WHERE campaign_id = ?').run(testCampaignId)
+
+    const count = (
+      db.prepare('SELECT COUNT(*) as count FROM calendar_seasons WHERE campaign_id = ?').get(testCampaignId) as {
+        count: number
+      }
+    )?.count || 0
+    expect(count).toBe(0)
+  })
+
+  it('should delete events and their entity links when reset', () => {
+    // Insert event
+    const eventResult = db
+      .prepare(`
+        INSERT INTO calendar_events (campaign_id, year, month, day, title, color)
+        VALUES (?, ?, ?, ?, ?, ?)
+      `)
+      .run(testCampaignId, 1352, 5, 10, 'Test Event', '#ff0000')
+
+    const eventId = Number(eventResult.lastInsertRowid)
+
+    // Insert event entity link
+    db.prepare(`
+      INSERT INTO calendar_event_entities (event_id, entity_id, entity_type)
+      VALUES (?, ?, ?)
+    `).run(eventId, 1, 'npc')
+
+    // Reset - first delete entity links
+    db.prepare(`
+      DELETE FROM calendar_event_entities
+      WHERE event_id IN (SELECT id FROM calendar_events WHERE campaign_id = ?)
+    `).run(testCampaignId)
+
+    // Then delete events
+    db.prepare('DELETE FROM calendar_events WHERE campaign_id = ?').run(testCampaignId)
+
+    const eventCount = (
+      db.prepare('SELECT COUNT(*) as count FROM calendar_events WHERE campaign_id = ?').get(testCampaignId) as {
+        count: number
+      }
+    )?.count || 0
+    expect(eventCount).toBe(0)
+  })
+
+  it('should not affect other campaigns when reset', () => {
+    // Create another campaign
+    const campaign2 = db.prepare('INSERT INTO campaigns (name) VALUES (?)').run('Campaign 2 Reset Test')
+    const campaign2Id = Number(campaign2.lastInsertRowid)
+
+    // Create config for campaign2
+    db.prepare(`
+      INSERT INTO calendar_config (campaign_id, current_year, current_month, current_day)
+      VALUES (?, ?, ?, ?)
+    `).run(campaign2Id, 1, 1, 1)
+
+    // Insert weather for both campaigns
+    db.prepare(`
+      INSERT INTO calendar_weather (campaign_id, year, month, day, weather_type, temperature)
+      VALUES (?, ?, ?, ?, ?, ?)
+    `).run(testCampaignId, 1352, 1, 1, 'sunny', 20)
+
+    db.prepare(`
+      INSERT INTO calendar_weather (campaign_id, year, month, day, weather_type, temperature)
+      VALUES (?, ?, ?, ?, ?, ?)
+    `).run(campaign2Id, 1, 1, 1, 'rain', 15)
+
+    // Reset only testCampaign
+    db.prepare('DELETE FROM calendar_weather WHERE campaign_id = ?').run(testCampaignId)
+
+    // Verify campaign2 weather still exists
+    const campaign2Weather = db
+      .prepare('SELECT * FROM calendar_weather WHERE campaign_id = ?')
+      .get(campaign2Id) as CalendarWeather | undefined
+
+    expect(campaign2Weather).toBeDefined()
+    expect(campaign2Weather?.weather_type).toBe('rain')
+
+    // Cleanup
+    db.prepare('DELETE FROM calendar_weather WHERE campaign_id = ?').run(campaign2Id)
+    db.prepare('DELETE FROM calendar_config WHERE campaign_id = ?').run(campaign2Id)
+    db.prepare('DELETE FROM campaigns WHERE id = ?').run(campaign2Id)
+  })
+})
+
+describe('Calendar Weather Overwrite', () => {
+  it('should overwrite existing weather when overwrite=true', () => {
+    // Insert initial weather
+    for (let day = 1; day <= 5; day++) {
+      db.prepare(`
+        INSERT INTO calendar_weather (campaign_id, year, month, day, weather_type, temperature)
+        VALUES (?, ?, ?, ?, ?, ?)
+      `).run(testCampaignId, 1352, 8, day, 'sunny', 25)
+    }
+
+    // Overwrite with new weather using UPSERT
+    for (let day = 1; day <= 5; day++) {
+      db.prepare(`
+        INSERT INTO calendar_weather (campaign_id, year, month, day, weather_type, temperature)
+        VALUES (?, ?, ?, ?, ?, ?)
+        ON CONFLICT(campaign_id, year, month, day)
+        DO UPDATE SET
+          weather_type = excluded.weather_type,
+          temperature = excluded.temperature
+      `).run(testCampaignId, 1352, 8, day, 'rain', 18)
+    }
+
+    // Verify all weather is updated
+    const weather = db
+      .prepare('SELECT * FROM calendar_weather WHERE campaign_id = ? AND year = ? AND month = ? ORDER BY day')
+      .all(testCampaignId, 1352, 8) as CalendarWeather[]
+
+    expect(weather).toHaveLength(5)
+    weather.forEach((w) => {
+      expect(w.weather_type).toBe('rain')
+      expect(w.temperature).toBe(18)
+    })
+  })
+
+  it('should skip existing weather when overwrite=false (insert only new)', () => {
+    // Insert weather for days 1-3
+    for (let day = 1; day <= 3; day++) {
+      db.prepare(`
+        INSERT INTO calendar_weather (campaign_id, year, month, day, weather_type, temperature)
+        VALUES (?, ?, ?, ?, ?, ?)
+      `).run(testCampaignId, 1352, 9, day, 'sunny', 25)
+    }
+
+    // Try to insert for days 1-5, but use INSERT OR IGNORE
+    for (let day = 1; day <= 5; day++) {
+      db.prepare(`
+        INSERT OR IGNORE INTO calendar_weather (campaign_id, year, month, day, weather_type, temperature)
+        VALUES (?, ?, ?, ?, ?, ?)
+      `).run(testCampaignId, 1352, 9, day, 'rain', 18)
+    }
+
+    // Days 1-3 should still be sunny (not overwritten)
+    const existingWeather = db
+      .prepare('SELECT * FROM calendar_weather WHERE campaign_id = ? AND year = ? AND month = ? AND day <= 3 ORDER BY day')
+      .all(testCampaignId, 1352, 9) as CalendarWeather[]
+
+    existingWeather.forEach((w) => {
+      expect(w.weather_type).toBe('sunny')
+      expect(w.temperature).toBe(25)
+    })
+
+    // Days 4-5 should be rain (newly inserted)
+    const newWeather = db
+      .prepare('SELECT * FROM calendar_weather WHERE campaign_id = ? AND year = ? AND month = ? AND day > 3 ORDER BY day')
+      .all(testCampaignId, 1352, 9) as CalendarWeather[]
+
+    expect(newWeather).toHaveLength(2)
+    newWeather.forEach((w) => {
+      expect(w.weather_type).toBe('rain')
+      expect(w.temperature).toBe(18)
+    })
+  })
+
+  it('should detect if month has existing weather', () => {
+    // Empty month
+    let count = (
+      db.prepare('SELECT COUNT(*) as count FROM calendar_weather WHERE campaign_id = ? AND year = ? AND month = ?')
+        .get(testCampaignId, 1352, 10) as { count: number }
+    )?.count || 0
+    expect(count).toBe(0)
+
+    // Insert weather
+    db.prepare(`
+      INSERT INTO calendar_weather (campaign_id, year, month, day, weather_type, temperature)
+      VALUES (?, ?, ?, ?, ?, ?)
+    `).run(testCampaignId, 1352, 10, 1, 'cloudy', 15)
+
+    // Month now has weather
+    count = (
+      db.prepare('SELECT COUNT(*) as count FROM calendar_weather WHERE campaign_id = ? AND year = ? AND month = ?')
+        .get(testCampaignId, 1352, 10) as { count: number }
+    )?.count || 0
+    expect(count).toBe(1)
+  })
+})
+
+describe('Calendar Configuration Validation', () => {
+  it('should require at least one month for valid calendar', () => {
+    const monthsCount = (
+      db.prepare('SELECT COUNT(*) as count FROM calendar_months WHERE campaign_id = ?').get(testCampaignId) as {
+        count: number
+      }
+    )?.count || 0
+
+    expect(monthsCount).toBeGreaterThan(0)
+  })
+
+  it('should track weekdays for calendar', () => {
+    // Insert weekdays
+    db.prepare(`
+      INSERT INTO calendar_weekdays (campaign_id, name, sort_order)
+      VALUES (?, ?, ?)
+    `).run(testCampaignId, 'Montag', 0)
+
+    db.prepare(`
+      INSERT INTO calendar_weekdays (campaign_id, name, sort_order)
+      VALUES (?, ?, ?)
+    `).run(testCampaignId, 'Dienstag', 1)
+
+    const weekdaysCount = (
+      db.prepare('SELECT COUNT(*) as count FROM calendar_weekdays WHERE campaign_id = ?').get(testCampaignId) as {
+        count: number
+      }
+    )?.count || 0
+
+    expect(weekdaysCount).toBe(2)
+
+    // isConfigured should be true when both months AND weekdays exist
+    const hasMonths = (
+      db.prepare('SELECT COUNT(*) as count FROM calendar_months WHERE campaign_id = ?').get(testCampaignId) as {
+        count: number
+      }
+    )?.count > 0
+
+    const hasWeekdays = weekdaysCount > 0
+    const isConfigured = hasMonths && hasWeekdays
+
+    expect(isConfigured).toBe(true)
+
+    // Cleanup
+    db.prepare('DELETE FROM calendar_weekdays WHERE campaign_id = ?').run(testCampaignId)
+  })
+
+  it('should not be configured if weekdays are missing', () => {
+    // Ensure no weekdays
+    db.prepare('DELETE FROM calendar_weekdays WHERE campaign_id = ?').run(testCampaignId)
+
+    const hasMonths = (
+      db.prepare('SELECT COUNT(*) as count FROM calendar_months WHERE campaign_id = ?').get(testCampaignId) as {
+        count: number
+      }
+    )?.count > 0
+
+    const hasWeekdays = (
+      db.prepare('SELECT COUNT(*) as count FROM calendar_weekdays WHERE campaign_id = ?').get(testCampaignId) as {
+        count: number
+      }
+    )?.count > 0
+
+    const isConfigured = hasMonths && hasWeekdays
+
+    expect(hasMonths).toBe(true)
+    expect(hasWeekdays).toBe(false)
+    expect(isConfigured).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- Disable weather generation button when calendar not configured (no months or weekdays)
- Show tooltip explaining why button is disabled
- Prevent deleting the last weekday in calendar settings
- Add weather overwrite confirmation dialog when regenerating for a month with existing weather
- Add calendar reset functionality with linked data warnings
- Fix weekdays count fallback (use 1 instead of 7 for safety)

## Changes
- `CalendarSettingsDialog.vue`: Disable delete button when only 1 weekday, add reset button with confirmation
- `calendar/index.vue`: Add validation computed properties, weather overwrite dialog, handle calendar reset
- New API: `/api/calendar/stats` - Get counts of linked calendar data
- New API: `/api/calendar/reset` - Delete all calendar data for campaign
- i18n translations for all new features (DE + EN)
- 15 new unit tests for stats, reset, overwrite, and validation

## Test plan
- [x] Weather button disabled when no calendar configured
- [x] Tooltip shows reason for disabled button
- [x] Cannot delete last weekday
- [x] Weather overwrite shows confirmation dialog
- [x] Calendar reset shows linked data warnings
- [x] Reset deletes all calendar data
- [x] 823 unit tests passing

Closes #195