### PR TITLE
fix: update checker download button not working (#194)

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -100,7 +100,11 @@
       "target": [
         "nsis",
         "zip"
-      ]
+      ],
+      "artifactName": "DM-Hero-${version}-win.${ext}"
+    },
+    "nsis": {
+      "artifactName": "DM-Hero-Setup-${version}.${ext}"
     },
     "linux": {
       "target": [


### PR DESCRIPTION
## Summary
- Add explicit `artifactName` configuration for Windows electron-builder targets
- Ensures consistent artifact naming (DM-Hero instead of DM.Hero or DM Hero)
- Fixes 404 error when electron-updater tries to download updates

## Problem
The update checker "Download Now" button failed with 404 error because `latest.yml` referenced `DM-Hero-Setup-1.0.1.exe` but the actual file was `DM.Hero.Setup.1.0.1.exe`. This happened because electron-builder inconsistently handles the productName "DM Hero" (with space).

## Solution
Added explicit `artifactName` in package.json:
- `win.artifactName`: `DM-Hero-${version}-win.${ext}` 
- `nsis.artifactName`: `DM-Hero-Setup-${version}.${ext}`

This ensures consistent naming with hyphens for all future releases.

Closes #194