### PR TITLE
chore: add PR and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,65 @@
+name: Bug Report
+description: Something not working? Let us know!
+labels: ["bug", "needs triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report this! Your feedback helps make DM Hero better for everyone.
+
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Platform
+      description: How are you running DM Hero?
+      options:
+        - Windows (Desktop App)
+        - Mac (Desktop App)
+        - Linux (Desktop App)
+        - Docker
+        - Browser (self-hosted)
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: Which version are you using? (Found in Settings or About)
+      placeholder: "e.g. 1.0.2"
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: Describe the problem. What did you expect to happen?
+      placeholder: |
+        When I tried to... I expected... but instead...
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: How can we recreate this issue?
+      placeholder: |
+        1. Go to...
+        2. Click on...
+        3. See the problem
+    validations:
+      required: true
+
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots
+      description: If applicable, add screenshots to help explain the problem (drag & drop images here)
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Anything else that might help us understand the issue?

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Discussions
+    url: https://github.com/Flo0806/dm-hero/discussions
+    about: Questions or general feedback? Start a discussion!
+  - name: DM Hero Website
+    url: https://dm-hero.com
+    about: Visit the official website

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,49 @@
+name: Feature Request
+description: Have an idea to make DM Hero better?
+labels: ["enhancement", "needs triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for sharing your idea! We love hearing how DM Hero can better serve Dungeon Masters.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What would you like to do?
+      description: Describe the feature or improvement you'd like to see
+      placeholder: |
+        I would like to be able to...
+    validations:
+      required: true
+
+  - type: textarea
+    id: usecase
+    attributes:
+      label: How would this help your campaigns?
+      description: Tell us about your use case
+      placeholder: |
+        This would help me because...
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Current workaround
+      description: How are you handling this today? (optional)
+      placeholder: |
+        Right now I'm doing...
+
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Mockups or examples
+      description: Any sketches, screenshots, or examples that help illustrate your idea? (drag & drop images here)
+
+  - type: checkboxes
+    id: contrib
+    attributes:
+      label: Contribution
+      options:
+        - label: I'd be willing to help implement this feature

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+## Summary
+
+<!-- Brief description of what this PR does -->
+
+## Changes
+
+-
+
+## Related Issue
+
+<!-- Link to issue: Closes #123 -->
+
+## Test Plan
+
+- [ ] Tested locally
+- [ ] No console errors
+- [ ] Works in both light and dark theme
+
+## Screenshots
+
+<!-- If applicable, add screenshots of the changes -->
+


### PR DESCRIPTION
## Summary

Adds GitHub templates for better issue reporting and PR consistency.

## Changes

- **Bug Report template** (`bug-report.yml`)
  - Platform dropdown (Windows, Mac, Linux, Docker, Browser)
  - Version field
  - Description, steps to reproduce, screenshots
  - User-friendly language

- **Feature Request template** (`feature-request.yml`)
  - Simple and inviting
  - Use case focused ("How would this help your campaigns?")
  - Optional contribution checkbox

- **PR template** (`pull_request_template.md`)
  - Summary, changes, related issue
  - Test plan checklist

- **Config** (`config.yml`)
  - Disables blank issues
  - Links to Discussions and website

Closes #210

## Test Plan

- [x] Templates created
- [x] YAML syntax valid