### PR TITLE
fix: lose state in details when add entites

### DIFF
--- a/packages/app/app/components/factions/FactionEditDialog.vue
+++ b/packages/app/app/components/factions/FactionEditDialog.vue
@@ -821,7 +821,6 @@ async function loadRelations(factionId: number) {
 async function refreshFaction() {
   if (faction.value?.id) {
     await Promise.all([
-      loadFaction(faction.value.id),
       loadRelations(faction.value.id),
       loadCounts(faction.value.id),
     ])

--- a/packages/app/app/components/groups/GroupEditDialog.vue
+++ b/packages/app/app/components/groups/GroupEditDialog.vue
@@ -29,7 +29,7 @@
         <!-- Color Selection -->
         <div class="mb-4">
           <label class="v-label text-caption mb-2 d-block">{{ $t('groups.color') }}</label>
-          <div class="d-flex flex-wrap gap-2">
+          <div class="d-flex flex-wrap ga-2">
             <v-avatar
               v-for="color in GROUP_COLORS"
               :key="color"

--- a/packages/app/app/components/lore/LoreCard.vue
+++ b/packages/app/app/components/lore/LoreCard.vue
@@ -297,13 +297,7 @@
           {{ $t('chaos.title') }}
         </v-tooltip>
       </v-btn>
-      <v-btn icon="mdi-pencil" size="small" variant="text" @click.stop="$emit('edit', lore)">
-        <v-icon>mdi-pencil</v-icon>
-        <v-tooltip activator="parent" location="bottom">
-          {{ $t('common.edit') }}
-        </v-tooltip>
-      </v-btn>
-      <v-spacer />
+
       <v-btn
         icon="mdi-download"
         size="small"
@@ -314,6 +308,13 @@
         <v-icon>mdi-download</v-icon>
         <v-tooltip activator="parent" location="bottom">
           {{ $t('common.download') }}
+        </v-tooltip>
+      </v-btn>
+      <v-spacer />
+      <v-btn icon="mdi-pencil" size="small" variant="text" @click.stop="$emit('edit', lore)">
+        <v-icon>mdi-pencil</v-icon>
+        <v-tooltip activator="parent" location="bottom">
+          {{ $t('common.edit') }}
         </v-tooltip>
       </v-btn>
       <v-btn

--- a/packages/app/app/components/lore/LoreEditDialog.vue
+++ b/packages/app/app/components/lore/LoreEditDialog.vue
@@ -752,7 +752,7 @@ async function loadRelations(loreId: number) {
 
 async function refreshLore() {
   if (lore.value?.id) {
-    await Promise.all([loadLore(lore.value.id), loadRelations(lore.value.id), loadCounts(lore.value.id)])
+    await Promise.all([loadRelations(lore.value.id), loadCounts(lore.value.id)])
   }
 }
 

--- a/packages/app/app/components/npcs/NpcEditDialog.vue
+++ b/packages/app/app/components/npcs/NpcEditDialog.vue
@@ -941,7 +941,6 @@ async function loadRelations(npcId: number) {
 async function refreshNpc() {
   if (npc.value?.id) {
     await Promise.all([
-      loadNpc(npc.value.id),
       loadRelations(npc.value.id),
       loadCounts(npc.value.id),
     ])


### PR DESCRIPTION
## Summary

When adding documents, items e.g. while unsaved changed exists in details tab they were lost. This aim all pages.

## Changes

- removed refreshXXX methods in save documents/items e.g. function

## Related Issue

Fixes: #183 

## Test Plan

- [X] Tested locally
- [X] No console errors
- [X] Works in both light and dark theme

