### PR TITLE
chore: add changeset for multi-provider AI

### DIFF
--- a/.changeset/multi-provider-ai.md
+++ b/.changeset/multi-provider-ai.md
@@ -1,0 +1,5 @@
+---
+"@dm-hero/app": minor
+---
+
+Add multi-provider AI support: OpenAI + Google Gemini with model selection, shared abstraction, and no-text image rules (#249)


### PR DESCRIPTION
## Summary
- Add missing changeset for #249 / #250 (multi-provider AI feature)

This was forgotten before merging the feature PR.