### PR TITLE
fix: normalize location relation type to i18n key (#255)

### DIFF
--- a/.changeset/fix-location-relation-i18n.md
+++ b/.changeset/fix-location-relation-i18n.md
@@ -1,0 +1,5 @@
+---
+"@dm-hero/app": patch
+---
+
+Fix hardcoded German relation type 'befindet sich in' → 'currentlyAt'

--- a/packages/app/app/components/locations/LocationEditDialog.vue
+++ b/packages/app/app/components/locations/LocationEditDialog.vue
@@ -749,7 +749,7 @@ async function addNpcRelation(payload: { npcId: number }) {
       body: {
         fromEntityId: payload.npcId,
         toEntityId: location.value.id,
-        relationType: 'befindet sich in',
+        relationType: 'currentlyAt',
       },
     })
 

--- a/packages/app/server/utils/migrations.ts
+++ b/packages/app/server/utils/migrations.ts
@@ -2426,6 +2426,17 @@ export const migrations: Migration[] = [
       console.log('✅ Migration 46: Created encounter_effects table')
     },
   },
+  {
+    version: 47,
+    name: 'normalize_befindet_sich_in',
+    up: (db) => {
+      const result = db.prepare(`
+        UPDATE entity_relations SET relation_type = 'currentlyAt' WHERE relation_type = 'befindet sich in'
+      `).run()
+
+      console.log(`✅ Migration 47: Normalized 'befindet sich in' → 'currentlyAt' (${result.changes} rows)`)
+    },
+  },
 ]
 
 export async function runMigrations(db: Database.Database) {

--- a/packages/app/test/unit/location-linking.test.ts
+++ b/packages/app/test/unit/location-linking.test.ts
@@ -87,7 +87,7 @@ describe('Location Linking - NPCs', () => {
     // Link NPC to Location (NPC → Location)
     db.prepare(
       'INSERT INTO entity_relations (from_entity_id, to_entity_id, relation_type) VALUES (?, ?, ?)',
-    ).run(npcId, locationId, 'befindet sich in')
+    ).run(npcId, locationId, 'currentlyAt')
 
     // Query linked NPCs (like /api/locations/[id]/npcs.get.ts)
     const linkedNpcs = db
@@ -140,7 +140,7 @@ describe('Location Linking - NPCs', () => {
     ).run(npc1.lastInsertRowid, locationId, 'arbeitet bei')
     db.prepare(
       'INSERT INTO entity_relations (from_entity_id, to_entity_id, relation_type) VALUES (?, ?, ?)',
-    ).run(npc2.lastInsertRowid, locationId, 'befindet sich in')
+    ).run(npc2.lastInsertRowid, locationId, 'currentlyAt')
     db.prepare(
       'INSERT INTO entity_relations (from_entity_id, to_entity_id, relation_type) VALUES (?, ?, ?)',
     ).run(npc3.lastInsertRowid, locationId, 'bewacht')


### PR DESCRIPTION
## Summary
- Replace hardcoded German `'befindet sich in'` with i18n key `'currentlyAt'` in LocationEditDialog
- Add migration 47 to normalize existing DB entries
- Update tests

Closes #255

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed NPC location relation handling to use standardized relation types for improved localization support across the application.

* **Chores**
  * Added database migration to normalize existing relation data.
  * Updated tests to validate new relation type handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->