### PR TITLE
fix: update image in dialog and card after upload

### DIFF
--- a/.changeset/fix-image-upload-refresh.md
+++ b/.changeset/fix-image-upload-refresh.md
@@ -1,0 +1,5 @@
+---
+"@dm-hero/app": patch
+---
+
+Fix image not updating in dialog and card after upload

--- a/packages/app/app/components/factions/FactionEditDialog.vue
+++ b/packages/app/app/components/factions/FactionEditDialog.vue
@@ -1333,6 +1333,11 @@ async function handleImageUpload(event: Event) {
       throw new Error('Upload failed')
     }
 
+    const result = await response.json()
+    if (result.imageUrl && faction.value) {
+      faction.value = { ...faction.value, image_url: result.imageUrl }
+    }
+    await entitiesStore.refreshFaction(faction.value!.id)
     await refreshFaction()
   }
   catch (error) {

--- a/packages/app/app/components/items/ItemEditDialog.vue
+++ b/packages/app/app/components/items/ItemEditDialog.vue
@@ -1550,8 +1550,11 @@ async function handleImageUpload(event: Event) {
 
     if (!response.ok) throw new Error('Upload failed')
 
-    await entitiesStore.refreshItem(item.value.id)
-    await loadItem(item.value.id)
+    const result = await response.json()
+    if (result.imageUrl && item.value) {
+      item.value = { ...item.value, image_url: result.imageUrl }
+    }
+    await entitiesStore.refreshItem(item.value!.id)
   }
   catch (error) {
     console.error('[ItemEditDialog] Failed to upload image:', error)

--- a/packages/app/app/components/npcs/NpcEditDialog.vue
+++ b/packages/app/app/components/npcs/NpcEditDialog.vue
@@ -1429,6 +1429,13 @@ async function handleImageUpload(event: Event) {
       throw new Error('Upload failed')
     }
 
+    // Update image_url from upload response
+    const result = await response.json()
+    if (result.imageUrl && npc.value) {
+      npc.value = { ...npc.value, image_url: result.imageUrl }
+    }
+    // Refresh list/card view so image shows even without save
+    await entitiesStore.refreshNPC(npc.value!.id)
     await refreshNpc()
   }
   catch (error) {

--- a/packages/app/app/components/players/PlayerEditDialog.vue
+++ b/packages/app/app/components/players/PlayerEditDialog.vue
@@ -838,8 +838,10 @@ async function handleImageUpload(event: Event) {
       throw new Error('Upload failed')
     }
 
-    // Refresh player data and gallery
-    await loadPlayer(player.value.id)
+    const result = await response.json()
+    if (result.imageUrl && player.value) {
+      player.value = { ...player.value, image_url: result.imageUrl }
+    }
     await entitiesStore.refreshPlayer(player.value.id)
     await imageGalleryRef.value?.refresh()
     await playerStore.loadCounts(player.value.id)

--- a/packages/app/app/components/shared/EntityImageUpload.vue
+++ b/packages/app/app/components/shared/EntityImageUpload.vue
@@ -13,6 +13,7 @@
           >
             <v-img
               v-if="imageUrl"
+              :key="imageUrl"
               :src="`/uploads/${imageUrl}`"
               cover
               :class="{ 'blur-image': uploading || generating }"

--- a/packages/app/app/components/shared/EntityNpcsTab.vue
+++ b/packages/app/app/components/shared/EntityNpcsTab.vue
@@ -201,8 +201,8 @@ const props = withDefaults(defineProps<Props>(), {
 })
 
 const emit = defineEmits<{
-  add: [payload: { npcId: number; membershipType?: string; rank?: string }]
-  update: [payload: { relationId: number; membershipType?: string; rank?: string }]
+  add: [payload: { npcId: number, membershipType?: string, rank?: string }]
+  update: [payload: { relationId: number, membershipType?: string, rank?: string }]
   remove: [npcId: number]
 }>()
 
@@ -227,7 +227,7 @@ const isDirty = computed(() => {
   const hasFormData = !!localNpcId.value || !!localMembershipType.value || !!localRank.value
   return hasFormData || showEditDialog.value
 })
-watch(isDirty, (dirty) => markDirty(dirty), { immediate: true })
+watch(isDirty, dirty => markDirty(dirty), { immediate: true })
 
 const canAdd = computed(() => {
   if (!localNpcId.value) return false
@@ -237,7 +237,7 @@ const canAdd = computed(() => {
 
 function getMembershipTypeLabel(membershipType: string): string {
   // Try to find in suggestions first
-  const suggestion = props.membershipTypeSuggestions.find((s) => s.value === membershipType)
+  const suggestion = props.membershipTypeSuggestions.find(s => s.value === membershipType)
   if (suggestion) return suggestion.title
   return membershipType
 }
@@ -245,7 +245,7 @@ function getMembershipTypeLabel(membershipType: string): string {
 function handleAdd() {
   if (!localNpcId.value) return
 
-  const payload: { npcId: number; membershipType?: string; rank?: string } = {
+  const payload: { npcId: number, membershipType?: string, rank?: string } = {
     npcId: localNpcId.value,
   }
 
@@ -295,7 +295,7 @@ function closeEditDialog() {
   editForm.value = { membershipType: '', rank: '' }
 }
 
-async function handleQuickCreated(newEntity: { id: number; name: string }) {
+async function handleQuickCreated(newEntity: { id: number, name: string }) {
   // Reload NPCs to include the new NPC
   const campaignId = campaignStore.activeCampaignId
   if (campaignId) {


### PR DESCRIPTION
## Summary
- Update `image_url` from upload response in NPC, Faction, Item, Player edit dialogs
- Refresh entity in store after upload so card/list view also updates
- Add `:key` to `v-img` in EntityImageUpload to force re-render
- ESLint fixes in EntityNpcsTab

Fixes image not visually updating after upload in edit dialog and entity cards.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Images now update immediately in dialogs and cards after upload across all entity types, eliminating the need for manual refresh or save.
  * Image preview rendering improved for better responsiveness.

* **Style**
  * Minor code formatting improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->