### PR TITLE
feat: isolate unit tests from the dev database

### DIFF
--- a/.changeset/isolated-test-db.md
+++ b/.changeset/isolated-test-db.md
@@ -1,0 +1,5 @@
+---
+"@dm-hero/app": patch
+---
+
+chore: run unit tests against an isolated in-memory database instead of the dev DB

--- a/packages/app/test/unit/batch-counts-bidirectional.test.ts
+++ b/packages/app/test/unit/batch-counts-bidirectional.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
-import { getDb } from '../../server/utils/db'
+import { getTestDb } from '../utils/test-db'
 import type Database from 'better-sqlite3'
 
 /**
@@ -22,7 +22,7 @@ let factionTypeId: number
 let loreTypeId: number
 
 beforeAll(() => {
-  db = getDb()
+  db = getTestDb()
 
   const getTypeId = (name: string) => {
     const type = db.prepare('SELECT id FROM entity_types WHERE name = ?').get(name) as { id: number }

--- a/packages/app/test/unit/calendar-events.test.ts
+++ b/packages/app/test/unit/calendar-events.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
-import { getDb } from '../../server/utils/db'
+import { getTestDb } from '../utils/test-db'
 import type Database from 'better-sqlite3'
 
 // Calendar Events Tests
@@ -10,7 +10,7 @@ let testCampaignId: number
 let npcTypeId: number
 
 beforeAll(() => {
-  db = getDb()
+  db = getTestDb()
 
   // Get NPC type ID
   const npcType = db.prepare('SELECT id FROM entity_types WHERE name = ?').get('NPC') as { id: number }

--- a/packages/app/test/unit/calendar-structure-validation.test.ts
+++ b/packages/app/test/unit/calendar-structure-validation.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
-import { getDb } from '../../server/utils/db'
+import { getTestDb } from '../utils/test-db'
 import type Database from 'better-sqlite3'
 
 // Calendar Structure Validation Tests
@@ -9,7 +9,7 @@ let db: Database.Database
 let testCampaignId: number
 
 beforeAll(() => {
-  db = getDb()
+  db = getTestDb()
 
   // Create test campaign
   const campaign = db

--- a/packages/app/test/unit/calendar-weather.test.ts
+++ b/packages/app/test/unit/calendar-weather.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
-import { getDb } from '../../server/utils/db'
+import { getTestDb } from '../utils/test-db'
 import type Database from 'better-sqlite3'
 
 // Calendar Weather Tests
@@ -29,7 +29,7 @@ let db: Database.Database
 let testCampaignId: number
 
 beforeAll(() => {
-  db = getDb()
+  db = getTestDb()
 
   // Create test campaign
   const campaign = db

--- a/packages/app/test/unit/calendar.test.ts
+++ b/packages/app/test/unit/calendar.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
-import { getDb } from '../../server/utils/db'
+import { getTestDb } from '../utils/test-db'
 import type Database from 'better-sqlite3'
 
 // Calendar Database Tests
@@ -9,7 +9,7 @@ let db: Database.Database
 let testCampaignId: number
 
 beforeAll(() => {
-  db = getDb()
+  db = getTestDb()
 
   // Create test campaign
   const campaign = db

--- a/packages/app/test/unit/campaigns.test.ts
+++ b/packages/app/test/unit/campaigns.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
-import { getDb } from '../../server/utils/db'
+import { getTestDb } from '../utils/test-db'
 import type Database from 'better-sqlite3'
 
 // Campaigns CRUD Tests
@@ -9,7 +9,7 @@ let db: Database.Database
 let npcTypeId: number
 
 beforeAll(() => {
-  db = getDb()
+  db = getTestDb()
 
   // Get NPC type ID for entity tests
   const npcType = db.prepare('SELECT id FROM entity_types WHERE name = ?').get('NPC') as { id: number }

--- a/packages/app/test/unit/chaos-graph.test.ts
+++ b/packages/app/test/unit/chaos-graph.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
-import { getDb } from '../../server/utils/db'
+import { getTestDb } from '../utils/test-db'
 import type Database from 'better-sqlite3'
 
 // Chaos Graph Tests
@@ -10,7 +10,7 @@ let testCampaignId: number
 let entityTypeIds: Record<string, number> = {}
 
 beforeAll(() => {
-  db = getDb()
+  db = getTestDb()
 
   // Get all entity type IDs
   const entityTypes = ['NPC', 'Location', 'Item', 'Faction', 'Lore', 'Player']

--- a/packages/app/test/unit/custom-races-classes.test.ts
+++ b/packages/app/test/unit/custom-races-classes.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
-import { getDb } from '../../server/utils/db'
+import { getTestDb } from '../utils/test-db'
 import type Database from 'better-sqlite3'
 
 // Custom Races & Classes Tests
@@ -8,7 +8,7 @@ import type Database from 'better-sqlite3'
 let db: Database.Database
 
 beforeAll(() => {
-  db = getDb()
+  db = getTestDb()
 })
 
 afterAll(() => {

--- a/packages/app/test/unit/documents.test.ts
+++ b/packages/app/test/unit/documents.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
-import { getDb } from '../../server/utils/db'
+import { getTestDb } from '../utils/test-db'
 import type Database from 'better-sqlite3'
 
 // Entity Documents Tests
@@ -10,7 +10,7 @@ let testCampaignId: number
 let npcTypeId: number
 
 beforeAll(() => {
-  db = getDb()
+  db = getTestDb()
 
   // Get NPC type ID
   const npcType = db.prepare('SELECT id FROM entity_types WHERE name = ?').get('NPC') as { id: number }

--- a/packages/app/test/unit/encounters.test.ts
+++ b/packages/app/test/unit/encounters.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
-import { getDb } from '../../server/utils/db'
+import { getTestDb } from '../utils/test-db'
 import type Database from 'better-sqlite3'
 
 // Encounter Tracker Tests
@@ -11,7 +11,7 @@ let npcTypeId: number
 let playerTypeId: number
 
 beforeAll(() => {
-  db = getDb()
+  db = getTestDb()
 
   const npcType = db.prepare('SELECT id FROM entity_types WHERE name = ?').get('NPC') as { id: number }
   const playerType = db.prepare('SELECT id FROM entity_types WHERE name = ?').get('Player') as { id: number }

--- a/packages/app/test/unit/entity-counts.test.ts
+++ b/packages/app/test/unit/entity-counts.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
-import { getDb } from '../../server/utils/db'
+import { getTestDb } from '../utils/test-db'
 import type Database from 'better-sqlite3'
 
 /**
@@ -23,7 +23,7 @@ let loreTypeId: number
 let playerTypeId: number
 
 beforeAll(() => {
-  db = getDb()
+  db = getTestDb()
 
   const getTypeId = (name: string) => {
     const type = db.prepare('SELECT id FROM entity_types WHERE name = ?').get(name) as { id: number }

--- a/packages/app/test/unit/entity-images.test.ts
+++ b/packages/app/test/unit/entity-images.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
-import { getDb } from '../../server/utils/db'
+import { getTestDb } from '../utils/test-db'
 import type Database from 'better-sqlite3'
 
 // Entity Images Tests
@@ -10,7 +10,7 @@ let testCampaignId: number
 let npcTypeId: number
 
 beforeAll(() => {
-  db = getDb()
+  db = getTestDb()
 
   // Get NPC type ID
   const npcType = db.prepare('SELECT id FROM entity_types WHERE name = ?').get('NPC') as { id: number }

--- a/packages/app/test/unit/entity-relations.test.ts
+++ b/packages/app/test/unit/entity-relations.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
-import { getDb } from '../../server/utils/db'
+import { getTestDb } from '../utils/test-db'
 import type Database from 'better-sqlite3'
 
 // Entity Relations CRUD Tests
@@ -14,7 +14,7 @@ let factionTypeId: number
 let loreTypeId: number
 
 beforeAll(() => {
-  db = getDb()
+  db = getTestDb()
 
   // Get entity type IDs
   const getTypeId = (name: string) => {

--- a/packages/app/test/unit/faction-counts.test.ts
+++ b/packages/app/test/unit/faction-counts.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
-import { getDb } from '../../server/utils/db'
+import { getTestDb } from '../utils/test-db'
 import type Database from 'better-sqlite3'
 
 // Faction Counts Tests - Testing the /api/factions/[id]/counts endpoint logic
@@ -12,7 +12,7 @@ let locationTypeId: number
 let loreTypeId: number
 
 beforeAll(() => {
-  db = getDb()
+  db = getTestDb()
 
   // Get entity type IDs
   const factionType = db.prepare('SELECT id FROM entity_types WHERE name = ?').get('Faction') as {

--- a/packages/app/test/unit/faction-linking.test.ts
+++ b/packages/app/test/unit/faction-linking.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
-import { getDb } from '../../server/utils/db'
+import { getTestDb } from '../utils/test-db'
 import type Database from 'better-sqlite3'
 
 // Faction Linking Tests - Testing bidirectional Lore relations and cross-search
@@ -10,7 +10,7 @@ let factionTypeId: number
 let loreTypeId: number
 
 beforeAll(() => {
-  db = getDb()
+  db = getTestDb()
 
   // Get entity type IDs
   const factionType = db.prepare('SELECT id FROM entity_types WHERE name = ?').get('Faction') as {

--- a/packages/app/test/unit/factions.test.ts
+++ b/packages/app/test/unit/factions.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
-import { getDb } from '../../server/utils/db'
+import { getTestDb } from '../utils/test-db'
 import type Database from 'better-sqlite3'
 
 // Factions CRUD Tests
@@ -11,7 +11,7 @@ let factionTypeId: number
 let npcTypeId: number
 
 beforeAll(() => {
-  db = getDb()
+  db = getTestDb()
 
   // Get type IDs
   const factionType = db.prepare('SELECT id FROM entity_types WHERE name = ?').get('Faction') as { id: number }

--- a/packages/app/test/unit/global-search.test.ts
+++ b/packages/app/test/unit/global-search.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
-import { getDb } from '../../server/utils/db'
+import { getTestDb } from '../utils/test-db'
 import { createLevenshtein } from '../../server/utils/levenshtein'
 import { normalizeText } from '../../server/utils/normalize'
 import type Database from 'better-sqlite3'
@@ -19,7 +19,7 @@ let playerTypeId: number
 const levenshtein = createLevenshtein()
 
 beforeAll(() => {
-  db = getDb()
+  db = getTestDb()
 
   // Get type IDs
   const getTypeId = (name: string) => {

--- a/packages/app/test/unit/groups.test.ts
+++ b/packages/app/test/unit/groups.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
-import { getDb } from '../../server/utils/db'
+import { getTestDb } from '../utils/test-db'
 import { getContrastColor, GROUP_COLORS, GROUP_ICONS } from '../../types/group'
 import type Database from 'better-sqlite3'
 
@@ -13,7 +13,7 @@ let locationTypeId: number
 let itemTypeId: number
 
 beforeAll(() => {
-  db = getDb()
+  db = getTestDb()
 
   // Get entity type IDs
   const npcType = db.prepare('SELECT id FROM entity_types WHERE name = ?').get('NPC') as { id: number }

--- a/packages/app/test/unit/image-gallery-sync.test.ts
+++ b/packages/app/test/unit/image-gallery-sync.test.ts
@@ -1,12 +1,12 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
-import { getDb } from '../../server/utils/db'
+import { getTestDb } from '../utils/test-db'
 
 describe('Image Gallery Synchronization', () => {
-  let db: ReturnType<typeof getDb>
+  let db: ReturnType<typeof getTestDb>
   let testEntityId: number
 
   beforeEach(async () => {
-    db = getDb()
+    db = getTestDb()
 
     // Get campaign ID
     const campaign = db.prepare('SELECT id FROM campaigns LIMIT 1').get() as { id: number }

--- a/packages/app/test/unit/image-upload.test.ts
+++ b/packages/app/test/unit/image-upload.test.ts
@@ -1,15 +1,15 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { existsSync, unlinkSync } from 'node:fs'
 import { join } from 'node:path'
-import { getDb } from '../../server/utils/db'
+import { getTestDb } from '../utils/test-db'
 
 describe('Image Upload System', () => {
-  let db: ReturnType<typeof getDb>
+  let db: ReturnType<typeof getTestDb>
   let testEntityId: number
   const uploadsPath = join(process.cwd(), 'public', 'uploads')
 
   beforeEach(async () => {
-    db = getDb()
+    db = getTestDb()
 
     // Get campaign ID
     const campaign = db.prepare('SELECT id FROM campaigns LIMIT 1').get() as { id: number }

--- a/packages/app/test/unit/item-lore-search.test.ts
+++ b/packages/app/test/unit/item-lore-search.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
-import { getDb } from '../../server/utils/db'
+import { getTestDb } from '../utils/test-db'
 import { normalizeText } from '../../server/utils/normalize'
 import { distance } from 'fastest-levenshtein'
 import type Database from 'better-sqlite3'
@@ -34,7 +34,7 @@ interface ScoredItem extends ItemWithLoreNames {
 }
 
 beforeAll(() => {
-  db = getDb()
+  db = getTestDb()
 
   // Get entity type IDs
   const itemType = db.prepare('SELECT id FROM entity_types WHERE name = ?').get('Item') as {

--- a/packages/app/test/unit/items.test.ts
+++ b/packages/app/test/unit/items.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
-import { getDb } from '../../server/utils/db'
+import { getTestDb } from '../utils/test-db'
 import type Database from 'better-sqlite3'
 
 // Items CRUD Tests
@@ -11,7 +11,7 @@ let itemTypeId: number
 let npcTypeId: number
 
 beforeAll(() => {
-  db = getDb()
+  db = getTestDb()
 
   // Get type IDs
   const itemType = db.prepare('SELECT id FROM entity_types WHERE name = ?').get('Item') as { id: number }

--- a/packages/app/test/unit/location-linking.test.ts
+++ b/packages/app/test/unit/location-linking.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
-import { getDb } from '../../server/utils/db'
+import { getTestDb } from '../utils/test-db'
 import type Database from 'better-sqlite3'
 
 // Location Linking Tests - Testing bidirectional NPC and Lore relations
@@ -27,7 +27,7 @@ interface IdOnlyResult {
 }
 
 beforeAll(() => {
-  db = getDb()
+  db = getTestDb()
 
   // Get entity type IDs
   const npcType = db.prepare('SELECT id FROM entity_types WHERE name = ?').get('NPC') as {

--- a/packages/app/test/unit/locations.test.ts
+++ b/packages/app/test/unit/locations.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
-import { getDb } from '../../server/utils/db'
+import { getTestDb } from '../utils/test-db'
 import type Database from 'better-sqlite3'
 import { LOCATION_TYPES } from '../../types/location'
 
@@ -12,7 +12,7 @@ let locationTypeId: number
 let npcTypeId: number
 
 beforeAll(() => {
-  db = getDb()
+  db = getTestDb()
 
   // Get entity type IDs
   const locationType = db.prepare('SELECT id FROM entity_types WHERE name = ?').get('Location') as { id: number }

--- a/packages/app/test/unit/lore.test.ts
+++ b/packages/app/test/unit/lore.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
-import { getDb } from '../../server/utils/db'
+import { getTestDb } from '../utils/test-db'
 import type Database from 'better-sqlite3'
 
 // Lore CRUD Tests
@@ -11,7 +11,7 @@ let loreTypeId: number
 let npcTypeId: number
 
 beforeAll(() => {
-  db = getDb()
+  db = getTestDb()
 
   // Get type IDs
   const loreType = db.prepare('SELECT id FROM entity_types WHERE name = ?').get('Lore') as { id: number }

--- a/packages/app/test/unit/maps.test.ts
+++ b/packages/app/test/unit/maps.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
-import { getDb } from '../../server/utils/db'
+import { getTestDb } from '../utils/test-db'
 import type Database from 'better-sqlite3'
 
 // Maps CRUD Tests
@@ -11,7 +11,7 @@ let npcTypeId: number
 let locationTypeId: number
 
 beforeAll(() => {
-  db = getDb()
+  db = getTestDb()
 
   // Get type IDs
   const npcType = db.prepare('SELECT id FROM entity_types WHERE name = ?').get('NPC') as { id: number }

--- a/packages/app/test/unit/notes.test.ts
+++ b/packages/app/test/unit/notes.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
-import { getDb } from '../../server/utils/db'
+import { getTestDb } from '../utils/test-db'
 import type Database from 'better-sqlite3'
 
 // Notes Tests
@@ -19,7 +19,7 @@ interface NoteRow {
 }
 
 beforeAll(() => {
-  db = getDb()
+  db = getTestDb()
 
   // Create test campaign
   const result = db

--- a/packages/app/test/unit/npc-counts-reactivity.test.ts
+++ b/packages/app/test/unit/npc-counts-reactivity.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
-import { getDb } from '../../server/utils/db'
+import { getTestDb } from '../utils/test-db'
 import type Database from 'better-sqlite3'
 
 // NPC Counts Reactivity Tests - Critical for tab count updates
@@ -11,7 +11,7 @@ let loreTypeId: number
 let factionTypeId: number
 
 beforeAll(() => {
-  db = getDb()
+  db = getTestDb()
 
   const npcType = db.prepare('SELECT id FROM entity_types WHERE name = ?').get('NPC') as {
     id: number

--- a/packages/app/test/unit/npc-counts.test.ts
+++ b/packages/app/test/unit/npc-counts.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
-import { getDb } from '../../server/utils/db'
+import { getTestDb } from '../utils/test-db'
 import type Database from 'better-sqlite3'
 
 /**
@@ -23,7 +23,7 @@ let loreTypeId: number
 let playerTypeId: number
 
 beforeAll(() => {
-  db = getDb()
+  db = getTestDb()
 
   const getTypeId = (name: string) => {
     const type = db.prepare('SELECT id FROM entity_types WHERE name = ?').get(name) as { id: number }

--- a/packages/app/test/unit/npc-search.test.ts
+++ b/packages/app/test/unit/npc-search.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
-import { getDb } from '../../server/utils/db'
+import { getTestDb } from '../utils/test-db'
 import { normalizeText } from '../../server/utils/normalize'
 import { getRaceKey, getClassKey, getNpcTypeKey } from '../../server/utils/i18n-lookup'
 import { parseSearchQuery } from '../../server/utils/search-query-parser'
@@ -15,7 +15,7 @@ let factionTypeId: number
 let locationTypeId: number
 
 beforeAll(() => {
-  db = getDb()
+  db = getTestDb()
 
   // Get entity type IDs
   const npcType = db.prepare('SELECT id FROM entity_types WHERE name = ?').get('NPC') as {

--- a/packages/app/test/unit/npcs.test.ts
+++ b/packages/app/test/unit/npcs.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
-import { getDb } from '../../server/utils/db'
+import { getTestDb } from '../utils/test-db'
 import type Database from 'better-sqlite3'
 
 // NPCs CRUD Tests
@@ -10,7 +10,7 @@ let testCampaignId: number
 let npcTypeId: number
 
 beforeAll(() => {
-  db = getDb()
+  db = getTestDb()
 
   // Get NPC type ID
   const npcType = db.prepare('SELECT id FROM entity_types WHERE name = ?').get('NPC') as { id: number }

--- a/packages/app/test/unit/pinboard.test.ts
+++ b/packages/app/test/unit/pinboard.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest'
-import { getDb } from '../../server/utils/db'
+import { getTestDb } from '../utils/test-db'
 import type Database from 'better-sqlite3'
 
 // Pinboard Tests
@@ -25,7 +25,7 @@ interface EntityRow {
 }
 
 beforeAll(() => {
-  db = getDb()
+  db = getTestDb()
 
   // Get entity type IDs
   const npcType = db.prepare('SELECT id FROM entity_types WHERE name = ?').get('NPC') as { id: number }

--- a/packages/app/test/unit/player-birthday.test.ts
+++ b/packages/app/test/unit/player-birthday.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
-import { getDb } from '../../server/utils/db'
+import { getTestDb } from '../utils/test-db'
 import type Database from 'better-sqlite3'
 
 // Player Birthday Tests
@@ -10,7 +10,7 @@ let testCampaignId: number
 let playerTypeId: number
 
 beforeAll(() => {
-  db = getDb()
+  db = getTestDb()
 
   // Get Player type ID
   const playerType = db.prepare('SELECT id FROM entity_types WHERE name = ?').get('Player') as { id: number }

--- a/packages/app/test/unit/player-counts.test.ts
+++ b/packages/app/test/unit/player-counts.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
-import { getDb } from '../../server/utils/db'
+import { getTestDb } from '../utils/test-db'
 
 describe('Player Counts', () => {
-  let db: ReturnType<typeof getDb>
+  let db: ReturnType<typeof getTestDb>
   let testPlayerId: number
   let testCampaignId: number
   let playerTypeId: number
@@ -10,7 +10,7 @@ describe('Player Counts', () => {
   let itemTypeId: number
 
   beforeEach(async () => {
-    db = getDb()
+    db = getTestDb()
 
     // Get campaign ID
     const campaign = db.prepare('SELECT id FROM campaigns LIMIT 1').get() as { id: number }

--- a/packages/app/test/unit/players.test.ts
+++ b/packages/app/test/unit/players.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
-import { getDb } from '../../server/utils/db'
+import { getTestDb } from '../utils/test-db'
 import type Database from 'better-sqlite3'
 
 // Players CRUD Tests
@@ -12,7 +12,7 @@ let npcTypeId: number
 let itemTypeId: number
 
 beforeAll(() => {
-  db = getDb()
+  db = getTestDb()
 
   // Get type IDs
   const playerType = db.prepare('SELECT id FROM entity_types WHERE name = ?').get('Player') as { id: number }

--- a/packages/app/test/unit/quoted-phrase-search.test.ts
+++ b/packages/app/test/unit/quoted-phrase-search.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
-import { getDb } from '../../server/utils/db'
+import { getTestDb } from '../utils/test-db'
 import { normalizeText } from '../../server/utils/normalize'
 import { parseSearchQuery } from '../../server/utils/search-query-parser'
 import type Database from 'better-sqlite3'
@@ -28,7 +28,7 @@ let factionTypeId: number
 let _loreTypeId: number
 
 beforeAll(() => {
-  db = getDb()
+  db = getTestDb()
 
   // Get entity type IDs
   npcTypeId = (

--- a/packages/app/test/unit/reference-data.test.ts
+++ b/packages/app/test/unit/reference-data.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
-import { getDb } from '../../server/utils/db'
+import { getTestDb } from '../utils/test-db'
 import type Database from 'better-sqlite3'
 
 // Reference Data Tests
@@ -8,7 +8,7 @@ import type Database from 'better-sqlite3'
 let db: Database.Database
 
 beforeAll(() => {
-  db = getDb()
+  db = getTestDb()
 })
 
 afterAll(() => {

--- a/packages/app/test/unit/session-audio.test.ts
+++ b/packages/app/test/unit/session-audio.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
-import { getDb } from '../../server/utils/db'
+import { getTestDb } from '../utils/test-db'
 import type Database from 'better-sqlite3'
 
 // Session Audio & Markers Tests
@@ -10,7 +10,7 @@ let testCampaignId: number
 let testSessionId: number
 
 beforeAll(() => {
-  db = getDb()
+  db = getTestDb()
 
   // Create test campaign
   const campaign = db

--- a/packages/app/test/unit/session-mentions.test.ts
+++ b/packages/app/test/unit/session-mentions.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
-import { getDb } from '../../server/utils/db'
+import { getTestDb } from '../utils/test-db'
 import { syncSessionMentions } from '../../server/utils/extract-mentions'
 import type Database from 'better-sqlite3'
 
@@ -14,7 +14,7 @@ let testSessionId: number
 let npcTypeId: number
 
 beforeAll(() => {
-  db = getDb()
+  db = getTestDb()
 
   // Get NPC type ID
   const npcType = db.prepare('SELECT id FROM entity_types WHERE name = ?').get('NPC') as { id: number }

--- a/packages/app/test/unit/sessions.test.ts
+++ b/packages/app/test/unit/sessions.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
-import { getDb } from '../../server/utils/db'
+import { getTestDb } from '../utils/test-db'
 import type Database from 'better-sqlite3'
 
 // Sessions CRUD Tests
@@ -10,7 +10,7 @@ let testCampaignId: number
 let npcTypeId: number
 
 beforeAll(() => {
-  db = getDb()
+  db = getTestDb()
 
   // Get NPC type ID for mentions
   const npcType = db.prepare('SELECT id FROM entity_types WHERE name = ?').get('NPC') as { id: number }

--- a/packages/app/test/unit/stat-templates.test.ts
+++ b/packages/app/test/unit/stat-templates.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
-import { getDb } from '../../server/utils/db'
+import { getTestDb } from '../utils/test-db'
 import type Database from 'better-sqlite3'
 import type { StatTemplate, StatTemplateDbRow, StatTemplateGroupDbRow, StatTemplateFieldDbRow } from '../../types/stat-template'
 
@@ -66,7 +66,7 @@ function loadTemplate(id: number): StatTemplate | null {
 }
 
 beforeAll(() => {
-  db = getDb()
+  db = getTestDb()
 
   const playerType = db.prepare('SELECT id FROM entity_types WHERE name = ?').get('Player') as { id: number }
   playerTypeId = playerType.id

--- a/packages/app/test/utils/test-db.ts
+++ b/packages/app/test/utils/test-db.ts
@@ -8,7 +8,7 @@ import { getCurrentVersion, setVersion } from '../../server/utils/db'
  */
 export function getTestDb(): Database.Database {
   const db = new Database(':memory:')
-  db.pragma('journal_mode = WAL')
+  // No journal_mode=WAL — WAL needs a real file and breaks FTS5 on :memory:.
   db.pragma('foreign_keys = ON')
 
   // Run all migrations
@@ -20,5 +20,41 @@ export function getTestDb(): Database.Database {
     setVersion(db, migration.version)
   }
 
+  // Seed a default campaign + a handful of entities so legacy tests that assumed
+  // the dev DB had some content (campaigns, NPCs, items, etc.) keep working.
+  seedDemoData(db)
+
   return db
+}
+
+/**
+ * Inserts one campaign and a couple of entities per type. Kept intentionally small —
+ * tests that need specific data should still create their own.
+ */
+function seedDemoData(db: Database.Database) {
+  const campaignId = Number(
+    db.prepare('INSERT INTO campaigns (name, description) VALUES (?, ?)').run(
+      'Test Campaign',
+      'Default test campaign',
+    ).lastInsertRowid,
+  )
+
+  const typeRow = (name: string) =>
+    db.prepare('SELECT id FROM entity_types WHERE name = ?').get(name) as { id: number } | undefined
+
+  const seed = (typeName: string, names: string[]) => {
+    const t = typeRow(typeName)
+    if (!t) return
+    const insert = db.prepare(
+      'INSERT INTO entities (type_id, campaign_id, name, description) VALUES (?, ?, ?, ?)',
+    )
+    for (const n of names) insert.run(t.id, campaignId, n, `${typeName} ${n} description`)
+  }
+
+  seed('NPC', ['Demo NPC Alpha', 'Demo NPC Beta'])
+  seed('Item', ['Demo Sword', 'Demo Potion'])
+  seed('Location', ['Demo Tavern', 'Demo Forest'])
+  seed('Faction', ['Demo Guild'])
+  seed('Lore', ['Demo Legend'])
+  seed('Player', ['Demo Player'])
 }


### PR DESCRIPTION
Closes #275.

All 40 unit-test files were running against `data/dm-hero.db`. A cleanup bug could quietly corrupt dev data. Now everything runs against an in-memory SQLite spun up by `getTestDb()`.

- `getTestDb()` extended: dropped `journal_mode=WAL` (pointless on `:memory:` and was breaking FTS5), seeds one default campaign and a handful of demo entities so tests that implicitly relied on existing dev-DB content still pass
- All 40 test files switched from `getDb()` to `getTestDb()`
- Confirmed: `data/dm-hero.db` mtime unchanged after a full run
- 1285/1285 tests green