### PR TITLE
upgrade to vuetify 4 with 7 themes and feature-tooltip bubble

### DIFF
--- a/.changeset/vuetify-4-themes.md
+++ b/.changeset/vuetify-4-themes.md
@@ -1,0 +1,5 @@
+---
+"@dm-hero/app": minor
+---
+
+feat: upgrade to vuetify 4 with 7 themes, persistent theme switcher and reusable feature-tooltip bubble

--- a/packages/app/app/app.vue
+++ b/packages/app/app/app.vue
@@ -6,10 +6,8 @@
         v-model:rail="rail"
         :has-active-campaign="hasActiveCampaign"
         :active-campaign-name="activeCampaignName"
-        :is-dark="theme.global.current.value.dark"
         :is-search-active="showSearch"
         @search-click="showSearch = true"
-        @toggle-theme="toggleTheme"
       />
     </ClientOnly>
 
@@ -57,12 +55,11 @@
 </template>
 
 <script setup lang="ts">
-import { useTheme, useLocale } from 'vuetify'
+import { useLocale } from 'vuetify'
 import NavigationDrawer from '~/components/layout/NavigationDrawer.vue'
 import AppBar from '~/components/layout/AppBar.vue'
 import GlobalSearch from '~/components/layout/GlobalSearch.vue'
 
-const theme = useTheme()
 const vuetifyLocale = useLocale()
 const { locale, setLocale } = useI18n()
 const drawer = ref(true)
@@ -139,10 +136,6 @@ if (import.meta.client) {
     },
     { immediate: true },
   )
-}
-
-function toggleTheme() {
-  theme.global.name.value = theme.global.current.value.dark ? 'light' : 'dark'
 }
 
 function changeLocale(newLocale: string) {

--- a/packages/app/app/assets/css/animations.css
+++ b/packages/app/app/assets/css/animations.css
@@ -1,30 +1,33 @@
 /**
  * Global animations for DM Hero
  * Available to all components without imports
+ *
+ * Wrapped in @layer overrides so it wins over Vuetify's `vuetify` layer.
  */
+@layer overrides {
+  /**
+   * Highlight Blink Animation
+   * Use: Add class "highlight-blink" to any element
+   * Duration: 2s (2 blinks: 1s each)
+   * Effect: Simple background color blink - clean and minimal
+   */
+  .highlight-blink {
+    animation: highlight-blink-animation 1s ease-in-out;
+    animation-iteration-count: 2;
+  }
 
-/**
- * Highlight Blink Animation
- * Use: Add class "highlight-blink" to any element
- * Duration: 2s (2 blinks: 1s each)
- * Effect: Simple background color blink - clean and minimal
- */
-.highlight-blink {
-  animation: highlight-blink-animation 1s ease-in-out;
-  animation-iteration-count: 2;
-}
-
-@keyframes highlight-blink-animation {
-  0% {
-    background-color: transparent;
-  }
-  25% {
-    background-color: rgba(var(--v-theme-primary), 0.25);
-  }
-  50% {
-    background-color: rgba(var(--v-theme-primary), 0.25);
-  }
-  100% {
-    background-color: transparent;
+  @keyframes highlight-blink-animation {
+    0% {
+      background-color: transparent;
+    }
+    25% {
+      background-color: rgba(var(--v-theme-primary), 0.25);
+    }
+    50% {
+      background-color: rgba(var(--v-theme-primary), 0.25);
+    }
+    100% {
+      background-color: transparent;
+    }
   }
 }

--- a/packages/app/app/assets/css/dashboard.css
+++ b/packages/app/app/assets/css/dashboard.css
@@ -1,24 +1,27 @@
 /* Shared styles for dashboard widgets */
 
-.dashboard-card {
-  background: rgba(var(--v-theme-surface-variant), 0.3);
-  border-color: rgba(var(--v-theme-primary), 0.2);
-  transition: all 0.2s ease;
-  min-width: 0 !important;
-  overflow: hidden;
-}
+/* Wrapped in @layer overrides so it wins over Vuetify's `vuetify` layer. */
+@layer overrides {
+  .dashboard-card {
+    background: rgba(var(--v-theme-surface-variant), 0.3);
+    border-color: rgba(var(--v-theme-primary), 0.2);
+    transition: all 0.2s ease;
+    min-width: 0 !important;
+    overflow: hidden;
+  }
 
-.dashboard-card:hover {
-  border-color: rgba(var(--v-theme-primary), 0.4);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
-}
+  .dashboard-card:hover {
+    border-color: rgba(var(--v-theme-primary), 0.4);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  }
 
-/* Ensure card content can shrink */
-.dashboard-card .v-card-text {
-  min-width: 0;
-  overflow: hidden;
-}
+  /* Ensure card content can shrink */
+  .dashboard-card .v-card-text {
+    min-width: 0;
+    overflow: hidden;
+  }
 
-.dashboard-info-box {
-  background: rgba(var(--v-theme-surface), 0.5);
+  .dashboard-info-box {
+    background: rgba(var(--v-theme-surface), 0.5);
+  }
 }

--- a/packages/app/app/assets/css/layer-order.css
+++ b/packages/app/app/assets/css/layer-order.css
@@ -1,0 +1,6 @@
+/*
+ * CSS cascade layer order — must be loaded BEFORE vuetify/styles.
+ * Vuetify 4 puts all its styles in the `vuetify` layer; our overrides go in
+ * `overrides` which sits after it, so app-level CSS wins without !important.
+ */
+@layer base, vuetify, overrides;

--- a/packages/app/app/assets/md-editor-theme.css
+++ b/packages/app/app/assets/md-editor-theme.css
@@ -1,77 +1,80 @@
 /* assets/md-editor-theme.css */
-.v-theme--light .md-editor {
-  background: var(--v-md-bg);
-  color: var(--v-md-text);
-}
-.v-theme--light .md-editor .md-toolbar-wrapper {
-  background: var(--v-md-surface);
-  border-bottom: 1px solid var(--v-md-border);
-}
-.v-theme--light .md-editor .md-editor-toolbar-item {
-  color: var(--v-md-muted);
-}
-.v-theme--light .md-editor .md-editor-toolbar-item:hover {
-  color: var(--v-md-primary);
-}
-.v-theme--light .md-editor .md-editor-content-editor {
-  background: var(--v-md-bg);
-}
-.v-theme--light .md-editor pre,
-.v-theme--light .md-editor code {
-  background: var(--v-md-code-bg);
-}
-
-/* Dark */
-.v-theme--dark .md-editor {
-  background: var(--v-md-bg);
-  color: var(--v-md-text);
-}
-.v-theme--dark .md-editor .md-toolbar-wrapper {
-  background: var(--v-md-surface);
-  border-bottom: 1px solid var(--v-md-border);
-}
-.v-theme--dark .md-editor .md-editor-toolbar-item {
-  color: var(--v-md-muted);
-}
-.v-theme--dark .md-editor .md-editor-toolbar-item:hover {
-  color: var(--v-md-primary);
-}
-.v-theme--dark .md-editor .md-editor-content-editor {
-  background: var(--v-md-bg);
-}
-.v-theme--dark .md-editor pre,
-.v-theme--dark .md-editor code {
-  background: var(--v-md-code-bg);
-}
-
-/* Fix: Prevent breaking words mid-character (override md-editor-v3 defaults) */
-.md-editor,
-.md-editor *,
-.md-editor .cm-editor,
-.md-editor .cm-editor .cm-scroller,
-.md-editor .cm-editor .cm-content,
-.md-editor .cm-editor .cm-line,
-.md-editor .md-editor-input-wrapper,
-.md-editor .md-editor-input-wrapper textarea,
-.md-editor-preview-wrapper,
-.md-editor-preview-wrapper *,
-.md-editor-preview,
-.md-editor-preview *,
-.md-editor-preview h1,
-.md-editor-preview h2,
-.md-editor-preview h3,
-.md-editor-preview h4,
-.md-editor-preview h5,
-.md-editor-preview h6,
-.md-editor-preview p,
-.md-editor-preview li,
-.md-editor-preview blockquote,
-.md-editor-preview td,
-.md-editor-preview th,
-.md-editor-catalog,
-.md-editor-catalog * {
-  word-break: normal !important;
-  overflow-wrap: break-word !important;
-  word-wrap: break-word !important;
-  hyphens: auto;
+/* Wrapped in @layer overrides so it wins over Vuetify and md-editor-v3 base styles. */
+@layer overrides {
+  .v-theme--light .md-editor {
+    background: var(--v-md-bg);
+    color: var(--v-md-text);
+  }
+  .v-theme--light .md-editor .md-toolbar-wrapper {
+    background: var(--v-md-surface);
+    border-bottom: 1px solid var(--v-md-border);
+  }
+  .v-theme--light .md-editor .md-editor-toolbar-item {
+    color: var(--v-md-muted);
+  }
+  .v-theme--light .md-editor .md-editor-toolbar-item:hover {
+    color: var(--v-md-primary);
+  }
+  .v-theme--light .md-editor .md-editor-content-editor {
+    background: var(--v-md-bg);
+  }
+  .v-theme--light .md-editor pre,
+  .v-theme--light .md-editor code {
+    background: var(--v-md-code-bg);
+  }
+  
+  /* Dark */
+  .v-theme--dark .md-editor {
+    background: var(--v-md-bg);
+    color: var(--v-md-text);
+  }
+  .v-theme--dark .md-editor .md-toolbar-wrapper {
+    background: var(--v-md-surface);
+    border-bottom: 1px solid var(--v-md-border);
+  }
+  .v-theme--dark .md-editor .md-editor-toolbar-item {
+    color: var(--v-md-muted);
+  }
+  .v-theme--dark .md-editor .md-editor-toolbar-item:hover {
+    color: var(--v-md-primary);
+  }
+  .v-theme--dark .md-editor .md-editor-content-editor {
+    background: var(--v-md-bg);
+  }
+  .v-theme--dark .md-editor pre,
+  .v-theme--dark .md-editor code {
+    background: var(--v-md-code-bg);
+  }
+  
+  /* Fix: Prevent breaking words mid-character (override md-editor-v3 defaults) */
+  .md-editor,
+  .md-editor *,
+  .md-editor .cm-editor,
+  .md-editor .cm-editor .cm-scroller,
+  .md-editor .cm-editor .cm-content,
+  .md-editor .cm-editor .cm-line,
+  .md-editor .md-editor-input-wrapper,
+  .md-editor .md-editor-input-wrapper textarea,
+  .md-editor-preview-wrapper,
+  .md-editor-preview-wrapper *,
+  .md-editor-preview,
+  .md-editor-preview *,
+  .md-editor-preview h1,
+  .md-editor-preview h2,
+  .md-editor-preview h3,
+  .md-editor-preview h4,
+  .md-editor-preview h5,
+  .md-editor-preview h6,
+  .md-editor-preview p,
+  .md-editor-preview li,
+  .md-editor-preview blockquote,
+  .md-editor-preview td,
+  .md-editor-preview th,
+  .md-editor-catalog,
+  .md-editor-catalog * {
+    word-break: normal !important;
+    overflow-wrap: break-word !important;
+    word-wrap: break-word !important;
+    hyphens: auto;
+  }
 }

--- a/packages/app/app/components/audio/Player.vue
+++ b/packages/app/app/components/audio/Player.vue
@@ -39,10 +39,10 @@
         >
           <v-tooltip activator="parent" location="top">
             <strong>{{ marker.label }}</strong>
-            <span v-if="marker.description" class="d-block text-caption">
+            <span v-if="marker.description" class="d-block text-body-small">
               {{ marker.description }}
             </span>
-            <span class="text-caption">{{ formatTime(marker.timestampSeconds) }}</span>
+            <span class="text-body-small">{{ formatTime(marker.timestampSeconds) }}</span>
           </v-tooltip>
         </div>
 
@@ -151,7 +151,7 @@
       <v-expand-transition>
         <div v-if="markers.length > 0" class="mt-3">
           <v-divider class="mb-2" />
-          <div class="text-caption text-medium-emphasis mb-2">
+          <div class="text-body-small text-medium-emphasis mb-2">
             {{ $t('audio.markers') }} ({{ markers.length }})
           </div>
           <div class="markers-list">
@@ -222,7 +222,7 @@
             </v-btn>
           </div>
           <div class="mt-3">
-            <v-label class="text-caption">{{ $t('audio.markerColor') }}</v-label>
+            <v-label class="text-body-small">{{ $t('audio.markerColor') }}</v-label>
             <div class="d-flex ga-3 mt-1">
               <v-btn
                 v-for="color in markerColors"

--- a/packages/app/app/components/calendar/CalendarEventDialog.vue
+++ b/packages/app/app/components/calendar/CalendarEventDialog.vue
@@ -72,26 +72,26 @@
           :hint="$t('calendar.linkedEntitiesHint')"
           persistent-hint
         >
-          <template #chip="{ props: chipProps, item }">
+          <template #chip="{ props: chipProps, internalItem }">
             <v-chip
               v-bind="chipProps"
-              :color="getEntityColor(item.raw.type)"
+              :color="getEntityColor(internalItem.raw.type)"
               size="small"
-              :class="{ 'text-decoration-line-through': item.raw.deleted }"
+              :class="{ 'text-decoration-line-through': internalItem.raw.deleted }"
             >
-              <v-icon start size="small">{{ getEntityIcon(item.raw.type) }}</v-icon>
-              {{ item.raw.name }}
+              <v-icon start size="small">{{ getEntityIcon(internalItem.raw.type) }}</v-icon>
+              {{ internalItem.raw.name }}
             </v-chip>
           </template>
-          <template #item="{ props: itemProps, item }">
+          <template #item="{ props: itemProps, internalItem }">
             <v-list-item
               v-bind="itemProps"
-              :title="item.raw.name"
-              :subtitle="$t(`entityTypes.${item.raw.type}`)"
+              :title="internalItem.raw.name"
+              :subtitle="$t(`entityTypes.${internalItem.raw.type}`)"
             >
               <template #prepend>
-                <v-icon :color="getEntityColor(item.raw.type)" size="small">
-                  {{ getEntityIcon(item.raw.type) }}
+                <v-icon :color="getEntityColor(internalItem.raw.type)" size="small">
+                  {{ getEntityIcon(internalItem.raw.type) }}
                 </v-icon>
               </template>
             </v-list-item>

--- a/packages/app/app/components/calendar/CalendarSettingsDialog.vue
+++ b/packages/app/app/components/calendar/CalendarSettingsDialog.vue
@@ -304,7 +304,7 @@
 
           <!-- Current Date Tab -->
           <v-window-item value="current">
-            <h3 class="text-h6 mb-4">{{ $t('calendar.currentDate') }}</h3>
+            <h3 class="text-headline-small mb-4">{{ $t('calendar.currentDate') }}</h3>
             <v-row>
               <v-col cols="4">
                 <v-text-field
@@ -337,7 +337,7 @@
             </v-row>
 
             <v-divider class="my-4" />
-            <h3 class="text-h6 mb-4">{{ $t('calendar.eraName') }}</h3>
+            <h3 class="text-headline-small mb-4">{{ $t('calendar.eraName') }}</h3>
             <v-text-field
               v-model="form.eraName"
               :label="$t('calendar.eraName')"
@@ -347,7 +347,7 @@
             />
 
             <v-divider class="my-4" />
-            <h3 class="text-h6 mb-4">{{ $t('calendar.leapYear') }}</h3>
+            <h3 class="text-headline-small mb-4">{{ $t('calendar.leapYear') }}</h3>
             <v-row>
               <v-col cols="4">
                 <v-text-field

--- a/packages/app/app/components/calendar/CalendarSettingsDialog.vue
+++ b/packages/app/app/components/calendar/CalendarSettingsDialog.vue
@@ -502,11 +502,14 @@ const calendarStats = ref<{
 
 async function confirmReset() {
   if (!campaignStore.activeCampaignId) return
-  // Load stats first
+  // Load stats first.
+  // Note: query is inlined in the URL so we skip $fetch's heavy generic
+  // type-inference path, which currently trips "Excessive stack depth" in the
+  // ts-plugin on Nuxt 4.4 + Nitro 2.13. tsc --noEmit is clean either way.
   try {
-    calendarStats.value = await $fetch('/api/calendar/stats', {
-      query: { campaignId: campaignStore.activeCampaignId },
-    })
+    calendarStats.value = await $fetch<typeof calendarStats.value>(
+      `/api/calendar/stats?campaignId=${campaignStore.activeCampaignId}`,
+    )
   }
   catch {
     calendarStats.value = null
@@ -518,9 +521,8 @@ async function executeReset() {
   if (!campaignStore.activeCampaignId) return
   resetting.value = true
   try {
-    await $fetch('/api/calendar/reset', {
+    await $fetch(`/api/calendar/reset?campaignId=${campaignStore.activeCampaignId}`, {
       method: 'DELETE',
-      query: { campaignId: campaignStore.activeCampaignId },
     })
     showResetDialog.value = false
     modelValue.value = false

--- a/packages/app/app/components/calendar/CalendarSettingsDialog.vue
+++ b/packages/app/app/components/calendar/CalendarSettingsDialog.vue
@@ -235,19 +235,19 @@
                     variant="outlined"
                     style="width: 200px"
                   >
-                    <template #selection="{ item }">
+                    <template #selection="{ internalItem }">
                       <div class="d-flex align-center ga-2">
-                        <v-icon size="18" :color="getWeatherTypeColor(item.value)">
-                          {{ getWeatherTypeIcon(item.value) }}
+                        <v-icon size="18" :color="getWeatherTypeColor(internalItem.value)">
+                          {{ getWeatherTypeIcon(internalItem.value) }}
                         </v-icon>
-                        <span>{{ item.title }}</span>
+                        <span>{{ internalItem.title }}</span>
                       </div>
                     </template>
-                    <template #item="{ item, props: itemProps }">
+                    <template #item="{ internalItem, props: itemProps }">
                       <v-list-item v-bind="itemProps">
                         <template #prepend>
-                          <v-icon :color="getWeatherTypeColor(item.value)" class="mr-2">
-                            {{ getWeatherTypeIcon(item.value) }}
+                          <v-icon :color="getWeatherTypeColor(internalItem.value)" class="mr-2">
+                            {{ getWeatherTypeIcon(internalItem.value) }}
                           </v-icon>
                         </template>
                       </v-list-item>
@@ -265,19 +265,19 @@
                     style="width: 180px"
                     :rules="[v => !!v || $t('calendar.seasonBackgroundRequired')]"
                   >
-                    <template #selection="{ item }">
+                    <template #selection="{ internalItem }">
                       <div class="d-flex align-center ga-2">
-                        <v-avatar v-if="item.value" size="20" rounded="sm">
-                          <v-img :src="item.value" />
+                        <v-avatar v-if="internalItem.value" size="20" rounded="sm">
+                          <v-img :src="internalItem.value" />
                         </v-avatar>
-                        <span>{{ item.title }}</span>
+                        <span>{{ internalItem.title }}</span>
                       </div>
                     </template>
-                    <template #item="{ item, props: itemProps }">
+                    <template #item="{ internalItem, props: itemProps }">
                       <v-list-item v-bind="itemProps">
                         <template #prepend>
-                          <v-avatar v-if="item.value" size="28" rounded="sm" class="mr-2">
-                            <v-img :src="item.value" />
+                          <v-avatar v-if="internalItem.value" size="28" rounded="sm" class="mr-2">
+                            <v-img :src="internalItem.value" />
                           </v-avatar>
                         </template>
                       </v-list-item>

--- a/packages/app/app/components/calendar/CalendarWeatherDialog.vue
+++ b/packages/app/app/components/calendar/CalendarWeatherDialog.vue
@@ -22,20 +22,20 @@
           variant="outlined"
           class="mb-3"
         >
-          <template #item="{ item, props: itemProps }">
+          <template #item="{ internalItem, props: itemProps }">
             <v-list-item v-bind="itemProps">
               <template #prepend>
-                <v-icon :color="item.value === 'sunny' ? 'amber' : 'blue-grey'">
-                  {{ getWeatherIcon(item.value) }}
+                <v-icon :color="internalItem.value === 'sunny' ? 'amber' : 'blue-grey'">
+                  {{ getWeatherIcon(internalItem.value) }}
                 </v-icon>
               </template>
             </v-list-item>
           </template>
-          <template #selection="{ item }">
-            <v-icon :color="item.value === 'sunny' ? 'amber' : 'blue-grey'" class="mr-2">
-              {{ getWeatherIcon(item.value) }}
+          <template #selection="{ internalItem }">
+            <v-icon :color="internalItem.value === 'sunny' ? 'amber' : 'blue-grey'" class="mr-2">
+              {{ getWeatherIcon(internalItem.value) }}
             </v-icon>
-            {{ item.title }}
+            {{ internalItem.title }}
           </template>
         </v-select>
 

--- a/packages/app/app/components/calendar/InGameDatePicker.vue
+++ b/packages/app/app/components/calendar/InGameDatePicker.vue
@@ -8,7 +8,7 @@
     <!-- No Calendar Configured -->
     <div v-else-if="!calendarData || calendarData.months.length === 0" class="text-center pa-4">
       <v-icon size="48" color="warning" class="mb-2">mdi-calendar-alert</v-icon>
-      <p class="text-body-2 text-medium-emphasis">
+      <p class="text-body-medium text-medium-emphasis">
         {{ $t('calendar.noCalendarConfigured') }}
       </p>
     </div>
@@ -18,7 +18,7 @@
       <v-row dense>
         <!-- Day Selector -->
         <v-col cols="12" sm="3">
-          <v-label class="text-caption mb-1">{{ $t('calendar.day') }}</v-label>
+          <v-label class="text-body-small mb-1">{{ $t('calendar.day') }}</v-label>
           <v-select
             v-model="internalDay"
             :items="dayItems"
@@ -30,7 +30,7 @@
 
         <!-- Month Selector -->
         <v-col cols="12" sm="5">
-          <v-label class="text-caption mb-1">{{ $t('calendar.month') }}</v-label>
+          <v-label class="text-body-small mb-1">{{ $t('calendar.month') }}</v-label>
           <v-select
             v-model="internalMonth"
             :items="monthItems"
@@ -44,7 +44,7 @@
 
         <!-- Year Selector -->
         <v-col cols="12" sm="4">
-          <v-label class="text-caption mb-1">{{ $t('calendar.year') }}</v-label>
+          <v-label class="text-body-small mb-1">{{ $t('calendar.year') }}</v-label>
           <div class="d-flex align-center">
             <v-btn
               icon="mdi-minus"

--- a/packages/app/app/components/campaigns/CampaignExportDialog.vue
+++ b/packages/app/app/components/campaigns/CampaignExportDialog.vue
@@ -22,7 +22,7 @@
         <!-- Full Export Info -->
         <v-alert v-if="exportMode === 'full'" type="info" variant="tonal" class="mb-4">
           <div class="font-weight-medium">{{ $t('campaigns.export.fullExportInfo') }}</div>
-          <div class="text-body-2 mt-1">
+          <div class="text-body-medium mt-1">
             {{ $t('campaigns.export.fullExportDetails', {
               entities: entityStats.total,
               sessions: sessionCount,

--- a/packages/app/app/components/campaigns/CampaignImportDialog.vue
+++ b/packages/app/app/components/campaigns/CampaignImportDialog.vue
@@ -40,7 +40,7 @@
           <div v-else-if="preview">
             <v-alert type="success" variant="tonal" class="mb-4">
               <div class="font-weight-medium">{{ preview.campaignName }}</div>
-              <div v-if="preview.description" class="text-body-2 mt-1">
+              <div v-if="preview.description" class="text-body-medium mt-1">
                 {{ preview.description }}
               </div>
             </v-alert>
@@ -137,7 +137,7 @@
                 <template #label>
                   <div>
                     <div class="font-weight-medium">{{ $t('campaigns.import.modeNew') }}</div>
-                    <div class="text-caption text-medium-emphasis">
+                    <div class="text-body-small text-medium-emphasis">
                       {{ $t('campaigns.import.modeNewHint') }}
                     </div>
                   </div>
@@ -152,7 +152,7 @@
                         "{{ activeCampaign.name }}"
                       </span>
                     </div>
-                    <div class="text-caption text-medium-emphasis">
+                    <div class="text-body-small text-medium-emphasis">
                       {{ activeCampaign
                         ? $t('campaigns.import.modeMergeHint')
                         : $t('campaigns.import.modeMergeNoActive')
@@ -232,7 +232,7 @@
 
           <!-- Store Update: Show count -->
           <div v-if="conflictInfo?.isStoreUpdate" class="mb-4">
-            <p class="text-body-2 mb-2">
+            <p class="text-body-medium mb-2">
               {{ $t('campaigns.import.storeUpdateDetails') }}
             </p>
             <v-chip color="primary" variant="tonal">
@@ -242,7 +242,7 @@
 
           <!-- Duplicates: Show list -->
           <div v-else-if="conflictInfo?.duplicates.length" class="mb-4">
-            <p class="text-body-2 mb-2">
+            <p class="text-body-medium mb-2">
               {{ $t('campaigns.import.duplicateDetails') }}
             </p>
             <v-list density="compact" max-height="200" class="overflow-y-auto">
@@ -285,15 +285,15 @@
                 <!-- Show imported vs existing -->
                 <div v-if="!conflict.isStandard" class="d-flex flex-column flex-sm-row ga-2 mb-2">
                   <div class="flex-grow-1">
-                    <div class="text-caption text-medium-emphasis">{{ $t('campaigns.import.imported') }}</div>
-                    <div class="text-body-2">
+                    <div class="text-body-small text-medium-emphasis">{{ $t('campaigns.import.imported') }}</div>
+                    <div class="text-body-medium">
                       DE: {{ conflict.imported.name_de || '-' }}<br />
                       EN: {{ conflict.imported.name_en || '-' }}
                     </div>
                   </div>
                   <div class="flex-grow-1">
-                    <div class="text-caption text-medium-emphasis">{{ $t('campaigns.import.existing') }}</div>
-                    <div class="text-body-2">
+                    <div class="text-body-small text-medium-emphasis">{{ $t('campaigns.import.existing') }}</div>
+                    <div class="text-body-medium">
                       DE: {{ conflict.existing.name_de || '-' }}<br />
                       EN: {{ conflict.existing.name_en || '-' }}
                     </div>
@@ -310,18 +310,18 @@
                 >
                   <v-radio v-if="conflict.isStandard" value="skip">
                     <template #label>
-                      <span class="text-body-2">{{ $t('campaigns.import.skipStandard') }}</span>
+                      <span class="text-body-medium">{{ $t('campaigns.import.skipStandard') }}</span>
                     </template>
                   </v-radio>
                   <template v-else>
                     <v-radio value="keep">
                       <template #label>
-                        <span class="text-body-2">{{ $t('campaigns.import.keepExisting') }}</span>
+                        <span class="text-body-medium">{{ $t('campaigns.import.keepExisting') }}</span>
                       </template>
                     </v-radio>
                     <v-radio value="overwrite">
                       <template #label>
-                        <span class="text-body-2">{{ $t('campaigns.import.overwriteExisting') }}</span>
+                        <span class="text-body-medium">{{ $t('campaigns.import.overwriteExisting') }}</span>
                       </template>
                     </v-radio>
                   </template>
@@ -339,7 +339,7 @@
 
             <v-card variant="outlined">
               <v-card-text class="pa-3">
-                <div class="text-body-2 mb-3">
+                <div class="text-body-medium mb-3">
                   {{ $t('campaigns.import.calendarConflictDetails') }}
                 </div>
 
@@ -351,16 +351,16 @@
                   <v-radio value="keep">
                     <template #label>
                       <div>
-                        <span class="text-body-2 font-weight-medium">{{ $t('campaigns.import.keepExistingCalendar') }}</span>
-                        <div class="text-caption text-medium-emphasis">{{ $t('campaigns.import.keepExistingCalendarHint') }}</div>
+                        <span class="text-body-medium font-weight-medium">{{ $t('campaigns.import.keepExistingCalendar') }}</span>
+                        <div class="text-body-small text-medium-emphasis">{{ $t('campaigns.import.keepExistingCalendarHint') }}</div>
                       </div>
                     </template>
                   </v-radio>
                   <v-radio value="overwrite">
                     <template #label>
                       <div>
-                        <span class="text-body-2 font-weight-medium">{{ $t('campaigns.import.overwriteCalendar') }}</span>
-                        <div class="text-caption text-medium-emphasis">{{ $t('campaigns.import.overwriteCalendarHint') }}</div>
+                        <span class="text-body-medium font-weight-medium">{{ $t('campaigns.import.overwriteCalendar') }}</span>
+                        <div class="text-body-small text-medium-emphasis">{{ $t('campaigns.import.overwriteCalendarHint') }}</div>
                       </div>
                     </template>
                   </v-radio>
@@ -377,8 +377,8 @@
         <!-- Step 4: Importing -->
         <div v-else-if="step === 'importing'" class="text-center py-8">
           <v-progress-circular indeterminate size="64" class="mb-4" />
-          <div class="text-h6">{{ $t('campaigns.import.importing') }}</div>
-          <div class="text-body-2 text-medium-emphasis">
+          <div class="text-headline-small">{{ $t('campaigns.import.importing') }}</div>
+          <div class="text-body-medium text-medium-emphasis">
             {{ $t('campaigns.import.pleaseWait') }}
           </div>
         </div>
@@ -386,8 +386,8 @@
         <!-- Step 4: Success -->
         <div v-else-if="step === 'success'" class="text-center py-8">
           <v-icon size="64" color="success" class="mb-4">mdi-check-circle</v-icon>
-          <div class="text-h6">{{ $t('campaigns.import.success') }}</div>
-          <div class="text-body-2 text-medium-emphasis">
+          <div class="text-headline-small">{{ $t('campaigns.import.success') }}</div>
+          <div class="text-body-medium text-medium-emphasis">
             {{ $t('campaigns.import.successDetails', importResult?.stats || {}) }}
           </div>
         </div>

--- a/packages/app/app/components/campaigns/CurrencyManageDialog.vue
+++ b/packages/app/app/components/campaigns/CurrencyManageDialog.vue
@@ -17,7 +17,7 @@
           >
             <template #prepend>
               <v-avatar color="primary" size="40">
-                <span class="text-body-1 font-weight-bold">{{ currency.symbol }}</span>
+                <span class="text-body-large font-weight-bold">{{ currency.symbol }}</span>
               </v-avatar>
             </template>
 
@@ -48,7 +48,7 @@
         <div v-else class="text-center py-8 text-medium-emphasis">
           <v-icon icon="mdi-cash-remove" size="48" class="mb-2" />
           <p>{{ $t('campaigns.currencies.empty') }}</p>
-          <p class="text-body-2">{{ $t('campaigns.currencies.emptyText') }}</p>
+          <p class="text-body-medium">{{ $t('campaigns.currencies.emptyText') }}</p>
         </div>
       </v-card-text>
 

--- a/packages/app/app/components/chaos/ChaosEntityCard.vue
+++ b/packages/app/app/components/chaos/ChaosEntityCard.vue
@@ -47,7 +47,7 @@
     </div>
 
     <!-- Entity Name -->
-    <div class="chaos-entity-card__name" :class="{ 'text-body-1': isCenter, 'text-body-2': !isCenter }">
+    <div class="chaos-entity-card__name" :class="{ 'text-body-large': isCenter, 'text-body-medium': !isCenter }">
       {{ entity.name }}
     </div>
 

--- a/packages/app/app/components/dashboard/DashboardCalendarWidget.vue
+++ b/packages/app/app/components/dashboard/DashboardCalendarWidget.vue
@@ -9,7 +9,7 @@
       <div class="d-flex align-center justify-space-between mb-3">
         <div class="d-flex align-center">
           <v-icon icon="mdi-calendar" color="primary" size="24" class="mr-2" />
-          <span class="text-subtitle-1 font-weight-medium">{{ $t('dashboard.calendar.title') }}</span>
+          <span class="text-title-medium font-weight-medium">{{ $t('dashboard.calendar.title') }}</span>
         </div>
         <v-icon v-if="hasCalendar" icon="mdi-chevron-right" size="20" class="text-medium-emphasis" />
       </div>
@@ -21,18 +21,18 @@
       <div v-else-if="hasCalendar">
         <!-- Current Date -->
         <div class="current-date d-flex align-center ga-3 pa-3 rounded-lg mb-3">
-          <div class="date-day text-h4 font-weight-bold text-primary text-center">{{ currentDay }}.</div>
+          <div class="date-day text-headline-large font-weight-bold text-primary text-center">{{ currentDay }}.</div>
           <div class="flex-grow-1">
-            <div class="text-subtitle-1 font-weight-medium">{{ currentMonthName }}</div>
-            <div class="text-caption text-medium-emphasis">{{ currentMonth }}. {{ $t('dashboard.calendar.month') }}, {{ $t('dashboard.calendar.year') }} {{ currentYear }}</div>
-            <div v-if="eraName" class="text-caption text-medium-emphasis font-italic">{{ eraName }}</div>
+            <div class="text-title-medium font-weight-medium">{{ currentMonthName }}</div>
+            <div class="text-body-small text-medium-emphasis">{{ currentMonth }}. {{ $t('dashboard.calendar.month') }}, {{ $t('dashboard.calendar.year') }} {{ currentYear }}</div>
+            <div v-if="eraName" class="text-body-small text-medium-emphasis font-italic">{{ eraName }}</div>
           </div>
         </div>
 
         <!-- Days since first session -->
         <div v-if="daysSinceFirstSession !== null" class="dashboard-info-box d-flex align-center py-1 px-3 rounded mb-2">
           <v-icon icon="mdi-flag-checkered" size="16" class="mr-1" />
-          <span class="text-body-2">
+          <span class="text-body-medium">
             {{ $t('dashboard.calendar.daysSinceStart', { days: daysSinceFirstSession }) }}
           </span>
         </div>
@@ -40,8 +40,8 @@
         <!-- Weather (if available) -->
         <div v-if="weather" class="dashboard-info-box d-flex align-center py-2 px-3 rounded">
           <v-icon :icon="weatherIcon" size="18" class="mr-1" />
-          <span class="text-body-2">{{ weatherLabel }}</span>
-          <span v-if="weather.temperature" class="text-body-2 ml-2">
+          <span class="text-body-medium">{{ weatherLabel }}</span>
+          <span v-if="weather.temperature" class="text-body-medium ml-2">
             {{ weather.temperature }}°
           </span>
         </div>
@@ -49,7 +49,7 @@
 
       <div v-else class="d-flex flex-column align-center text-center py-4">
         <v-icon icon="mdi-calendar-plus" size="32" class="text-medium-emphasis mb-2" />
-        <p class="text-body-2 text-medium-emphasis mb-2">
+        <p class="text-body-medium text-medium-emphasis mb-2">
           {{ $t('dashboard.calendar.notConfigured') }}
         </p>
         <v-btn size="small" color="primary" variant="tonal" to="/calendar">

--- a/packages/app/app/components/dashboard/DashboardCategoryCard.vue
+++ b/packages/app/app/components/dashboard/DashboardCategoryCard.vue
@@ -6,13 +6,13 @@
           <v-icon :icon="icon" size="22" color="white" />
         </v-avatar>
         <div class="flex-grow-1">
-          <div class="text-subtitle-1 font-weight-medium">{{ title }}</div>
-          <div class="text-caption text-medium-emphasis">{{ count }} {{ $t('dashboard.category.entries') }}</div>
+          <div class="text-title-medium font-weight-medium">{{ title }}</div>
+          <div class="text-body-small text-medium-emphasis">{{ count }} {{ $t('dashboard.category.entries') }}</div>
         </div>
         <v-icon icon="mdi-chevron-right" size="20" class="text-medium-emphasis" />
       </div>
 
-      <p class="text-body-2 text-medium-emphasis mb-3">
+      <p class="text-body-medium text-medium-emphasis mb-3">
         {{ description }}
       </p>
 

--- a/packages/app/app/components/dashboard/DashboardMapsWidget.vue
+++ b/packages/app/app/components/dashboard/DashboardMapsWidget.vue
@@ -4,7 +4,7 @@
       <div class="d-flex align-center justify-space-between mb-3">
         <div class="d-flex align-center">
           <v-icon icon="mdi-map" color="primary" size="24" class="mr-2" />
-          <span class="text-subtitle-1 font-weight-medium">{{ $t('dashboard.maps.title') }}</span>
+          <span class="text-title-medium font-weight-medium">{{ $t('dashboard.maps.title') }}</span>
         </div>
         <v-icon icon="mdi-chevron-right" size="20" class="text-medium-emphasis" />
       </div>
@@ -19,7 +19,7 @@
             class="rounded"
           >
             <div class="map-overlay d-flex align-center justify-space-between py-2 px-3">
-              <span class="text-body-2 font-weight-medium text-white">{{ primaryMap.name }}</span>
+              <span class="text-body-medium font-weight-medium text-white">{{ primaryMap.name }}</span>
               <v-chip size="x-small" color="primary" variant="flat">
                 {{ primaryMap._markerCount || 0 }} {{ $t('dashboard.maps.markers') }}
               </v-chip>
@@ -28,11 +28,11 @@
         </div>
 
         <div class="dashboard-info-box d-flex justify-space-between py-2 px-3 rounded">
-          <div class="text-body-2">
+          <div class="text-body-medium">
             <v-icon icon="mdi-map" size="16" class="mr-1" />
             {{ maps.length }} {{ $t('dashboard.maps.count') }}
           </div>
-          <div class="text-body-2">
+          <div class="text-body-medium">
             <v-icon icon="mdi-map-marker" size="16" class="mr-1" />
             {{ totalMarkers }} {{ $t('dashboard.maps.totalMarkers') }}
           </div>
@@ -41,7 +41,7 @@
 
       <div v-else class="d-flex flex-column align-center text-center py-4">
         <v-icon icon="mdi-map-plus" size="32" class="text-medium-emphasis mb-2" />
-        <p class="text-body-2 text-medium-emphasis mb-2">
+        <p class="text-body-medium text-medium-emphasis mb-2">
           {{ $t('dashboard.maps.empty') }}
         </p>
         <v-btn size="small" color="primary" variant="tonal" to="/maps">

--- a/packages/app/app/components/dashboard/DashboardNotesWidget.vue
+++ b/packages/app/app/components/dashboard/DashboardNotesWidget.vue
@@ -4,7 +4,7 @@
       <div class="d-flex align-center justify-space-between mb-3">
         <div class="d-flex align-center">
           <v-icon icon="mdi-notebook-outline" color="primary" size="24" class="mr-2" />
-          <span class="text-subtitle-1 font-weight-medium">{{ $t('dashboard.notes.title') }}</span>
+          <span class="text-title-medium font-weight-medium">{{ $t('dashboard.notes.title') }}</span>
           <v-badge
             v-if="pendingCount > 0"
             :content="pendingCount"
@@ -28,18 +28,18 @@
             :color="note.completed ? 'success' : 'grey'"
             class="mr-2"
           />
-          <span class="note-text flex-grow-1 text-body-2 text-truncate" :class="{ 'text-decoration-line-through': note.completed }">
+          <span class="note-text flex-grow-1 text-body-medium text-truncate" :class="{ 'text-decoration-line-through': note.completed }">
             {{ note.content }}
           </span>
         </div>
-        <div v-if="pendingCount > 3" class="text-caption text-medium-emphasis mt-2">
+        <div v-if="pendingCount > 3" class="text-body-small text-medium-emphasis mt-2">
           {{ $t('dashboard.notes.more', { count: pendingCount - 3 }) }}
         </div>
       </div>
 
       <div v-else class="d-flex flex-column align-center text-center py-2">
         <v-icon icon="mdi-check-circle" size="32" color="success" class="mb-2" />
-        <p class="text-body-2 text-medium-emphasis">
+        <p class="text-body-medium text-medium-emphasis">
           {{ $t('dashboard.notes.allDone') }}
         </p>
       </div>

--- a/packages/app/app/components/dashboard/DashboardPinboardWidget.vue
+++ b/packages/app/app/components/dashboard/DashboardPinboardWidget.vue
@@ -4,7 +4,7 @@
       <div class="d-flex align-center justify-space-between mb-3">
         <div class="d-flex align-center">
           <v-icon icon="mdi-pin" color="primary" size="24" class="mr-2" />
-          <span class="text-subtitle-1 font-weight-medium">{{ $t('dashboard.pinboard.title') }}</span>
+          <span class="text-title-medium font-weight-medium">{{ $t('dashboard.pinboard.title') }}</span>
         </div>
       </div>
 
@@ -36,20 +36,20 @@
               </template>
             </div>
             <div class="flex-grow-1 overflow-hidden">
-              <div class="text-body-2 font-weight-medium text-truncate">{{ pin.name }}</div>
-              <div class="text-caption text-medium-emphasis">{{ getTypeLabel(pin.type) }}</div>
+              <div class="text-body-medium font-weight-medium text-truncate">{{ pin.name }}</div>
+              <div class="text-body-small text-medium-emphasis">{{ getTypeLabel(pin.type) }}</div>
             </div>
           </div>
         </div>
 
-        <div v-if="pins.length > 4" class="text-caption text-medium-emphasis mt-2 text-center">
+        <div v-if="pins.length > 4" class="text-body-small text-medium-emphasis mt-2 text-center">
           {{ $t('dashboard.pinboard.more', { count: pins.length - 4 }) }}
         </div>
       </div>
 
       <div v-else class="d-flex flex-column align-center text-center py-4">
         <v-icon icon="mdi-pin-off" size="32" class="text-medium-emphasis mb-2" />
-        <p class="text-body-2 text-medium-emphasis">
+        <p class="text-body-medium text-medium-emphasis">
           {{ $t('dashboard.pinboard.empty') }}
         </p>
       </div>

--- a/packages/app/app/components/dashboard/DashboardStatsCard.vue
+++ b/packages/app/app/components/dashboard/DashboardStatsCard.vue
@@ -3,7 +3,7 @@
     <v-card-text class="pa-4">
       <div class="d-flex align-center mb-3">
         <v-icon icon="mdi-chart-timeline-variant" color="primary" size="24" class="mr-2" />
-        <span class="text-subtitle-1 font-weight-medium">{{ $t('dashboard.stats.title') }}</span>
+        <span class="text-title-medium font-weight-medium">{{ $t('dashboard.stats.title') }}</span>
       </div>
 
       <div class="stats-grid">
@@ -11,8 +11,8 @@
         <div class="stat-item d-flex align-center ga-3 pa-3 rounded-lg">
           <v-icon icon="mdi-clock-outline" size="20" color="primary" style="opacity: 0.8" />
           <div class="flex-grow-1">
-            <div class="text-h6 font-weight-bold">{{ formattedPlaytime }}</div>
-            <div class="stat-label text-caption text-medium-emphasis text-uppercase">{{ $t('dashboard.stats.playtime') }}</div>
+            <div class="text-headline-small font-weight-bold">{{ formattedPlaytime }}</div>
+            <div class="stat-label text-body-small text-medium-emphasis text-uppercase">{{ $t('dashboard.stats.playtime') }}</div>
           </div>
         </div>
 
@@ -20,8 +20,8 @@
         <div class="stat-item d-flex align-center ga-3 pa-3 rounded-lg">
           <v-icon icon="mdi-book-open-page-variant" size="20" color="primary" style="opacity: 0.8" />
           <div class="flex-grow-1">
-            <div class="text-h6 font-weight-bold">{{ sessionCount }}</div>
-            <div class="stat-label text-caption text-medium-emphasis text-uppercase">{{ $t('dashboard.stats.sessions') }}</div>
+            <div class="text-headline-small font-weight-bold">{{ sessionCount }}</div>
+            <div class="stat-label text-body-small text-medium-emphasis text-uppercase">{{ $t('dashboard.stats.sessions') }}</div>
           </div>
         </div>
 
@@ -29,8 +29,8 @@
         <div class="stat-item d-flex align-center ga-3 pa-3 rounded-lg">
           <v-icon icon="mdi-database" size="20" color="primary" style="opacity: 0.8" />
           <div class="flex-grow-1">
-            <div class="text-h6 font-weight-bold">{{ totalEntities }}</div>
-            <div class="stat-label text-caption text-medium-emphasis text-uppercase">{{ $t('dashboard.stats.entities') }}</div>
+            <div class="text-headline-small font-weight-bold">{{ totalEntities }}</div>
+            <div class="stat-label text-body-small text-medium-emphasis text-uppercase">{{ $t('dashboard.stats.entities') }}</div>
           </div>
         </div>
 
@@ -38,8 +38,8 @@
         <div class="stat-item d-flex align-center ga-3 pa-3 rounded-lg">
           <v-icon icon="mdi-pin" size="20" color="primary" style="opacity: 0.8" />
           <div class="flex-grow-1">
-            <div class="text-h6 font-weight-bold">{{ pinnedCount }}</div>
-            <div class="stat-label text-caption text-medium-emphasis text-uppercase">{{ $t('dashboard.stats.pinned') }}</div>
+            <div class="text-headline-small font-weight-bold">{{ pinnedCount }}</div>
+            <div class="stat-label text-body-small text-medium-emphasis text-uppercase">{{ $t('dashboard.stats.pinned') }}</div>
           </div>
         </div>
       </div>

--- a/packages/app/app/components/encounters/EncounterAddParticipantDialog.vue
+++ b/packages/app/app/components/encounters/EncounterAddParticipantDialog.vue
@@ -114,7 +114,7 @@
 
         <div v-else class="text-center py-6 text-medium-emphasis">
           <div>{{ $t('common.noResults') }}</div>
-          <div class="text-body-2 mt-1">{{ $t('encounters.onlyWithStats') }}</div>
+          <div class="text-body-medium mt-1">{{ $t('encounters.onlyWithStats') }}</div>
         </div>
       </v-card-text>
     </v-card>

--- a/packages/app/app/components/encounters/EncounterCombatView.vue
+++ b/packages/app/app/components/encounters/EncounterCombatView.vue
@@ -43,7 +43,7 @@
             @click.stop="confirmRemove(participant)"
           />
         </div>
-        <div class="combat-tile__name text-caption text-center text-truncate mt-1">
+        <div class="combat-tile__name text-body-small text-center text-truncate mt-1">
           {{ participant.display_name }}
           <span v-if="participant.duplicate_index > 0">({{ participant.duplicate_index + 1 }})</span>
         </div>
@@ -71,7 +71,7 @@
             <v-icon v-else>{{ getEntityIcon(activeParticipant.entity_type) }}</v-icon>
           </v-avatar>
           <div>
-            <div class="text-h6">
+            <div class="text-headline-small">
               {{ activeParticipant.display_name }}
               <span v-if="activeParticipant.duplicate_index > 0" class="text-medium-emphasis">({{ activeParticipant.duplicate_index + 1 }})</span>
             </div>
@@ -97,7 +97,7 @@
               :label="$t('encounters.hp')"
               style="max-width: 90px;"
             />
-            <span class="text-h6">/</span>
+            <span class="text-headline-small">/</span>
             <v-text-field
               v-model.number="liveMaxHp"
               type="number"
@@ -107,7 +107,7 @@
               label="Max"
               style="max-width: 90px;"
             />
-            <span v-if="activeParticipant.temp_hp > 0" class="text-info text-body-2">(+{{ activeParticipant.temp_hp }} {{ $t('encounters.tempHp') }})</span>
+            <span v-if="activeParticipant.temp_hp > 0" class="text-info text-body-medium">(+{{ activeParticipant.temp_hp }} {{ $t('encounters.tempHp') }})</span>
           </div>
           <v-progress-linear
             :model-value="liveHpPct"
@@ -150,7 +150,7 @@
         <!-- Effects -->
         <div class="mb-3">
           <div class="d-flex align-center ga-2 mb-2">
-            <span class="text-body-2 font-weight-medium">{{ $t('encounters.effects') }}</span>
+            <span class="text-body-medium font-weight-medium">{{ $t('encounters.effects') }}</span>
             <v-spacer />
             <v-btn size="small" variant="tonal" prepend-icon="mdi-plus" @click="showEffectInput = !showEffectInput">
               {{ $t('encounters.addEffect') }}
@@ -205,7 +205,7 @@
               <span v-if="effect.duration_type === 'rounds'" class="ml-1">({{ effect.remaining_rounds }})</span>
             </v-chip>
           </div>
-          <div v-else class="text-caption text-medium-emphasis">{{ $t('encounters.noEffects') }}</div>
+          <div v-else class="text-body-small text-medium-emphasis">{{ $t('encounters.noEffects') }}</div>
         </div>
 
         <!-- Notes -->

--- a/packages/app/app/components/encounters/EncounterDetail.vue
+++ b/packages/app/app/components/encounters/EncounterDetail.vue
@@ -3,7 +3,7 @@
     <!-- Header -->
     <div class="d-flex align-center ga-2 mb-4">
       <v-btn icon="mdi-arrow-left" variant="text" @click="encounterStore.closeEncounter()" />
-      <span class="text-h5">{{ encounter.name }}</span>
+      <span class="text-headline-medium">{{ encounter.name }}</span>
       <v-chip size="small" :color="statusColor(encounter.status)" variant="tonal">
         {{ $t(`encounters.statuses.${encounter.status}`) }}
       </v-chip>

--- a/packages/app/app/components/encounters/EncounterDiceRoller.vue
+++ b/packages/app/app/components/encounters/EncounterDiceRoller.vue
@@ -28,7 +28,7 @@
         <v-btn icon size="x-small" variant="text" @click="modifier--">
           <v-icon size="16">mdi-minus</v-icon>
         </v-btn>
-        <span class="text-body-2 font-weight-bold" style="min-width: 32px; text-align: center;">
+        <span class="text-body-medium font-weight-bold" style="min-width: 32px; text-align: center;">
           {{ modifier >= 0 ? `+${modifier}` : modifier }}
         </span>
         <v-btn icon size="x-small" variant="text" @click="modifier++">
@@ -60,9 +60,9 @@
 
     <!-- Result -->
     <div v-if="lastResult" class="mt-2 d-flex align-center ga-2">
-      <span class="text-h6 font-weight-bold text-primary">{{ lastResult.total }}</span>
-      <span class="text-body-2 text-medium-emphasis">=</span>
-      <span class="text-body-2 text-medium-emphasis">{{ lastResult.breakdown }}</span>
+      <span class="text-headline-small font-weight-bold text-primary">{{ lastResult.total }}</span>
+      <span class="text-body-medium text-medium-emphasis">=</span>
+      <span class="text-body-medium text-medium-emphasis">{{ lastResult.breakdown }}</span>
     </div>
   </div>
 </template>

--- a/packages/app/app/components/encounters/EncounterSetupList.vue
+++ b/packages/app/app/components/encounters/EncounterSetupList.vue
@@ -44,7 +44,7 @@
     <div v-else class="text-center py-8 text-medium-emphasis">
       <v-icon icon="mdi-account-group-outline" size="48" class="mb-2" />
       <div>{{ $t('encounters.noParticipants') }}</div>
-      <div class="text-body-2">{{ $t('encounters.noParticipantsHint') }}</div>
+      <div class="text-body-medium">{{ $t('encounters.noParticipantsHint') }}</div>
     </div>
   </div>
 </template>

--- a/packages/app/app/components/entities/CopyToCampaignDialog.vue
+++ b/packages/app/app/components/entities/CopyToCampaignDialog.vue
@@ -152,13 +152,13 @@
               <template #prepend>
                 <v-icon size="small" class="mr-2">{{ getEntityIcon(dup.type_name) }}</v-icon>
               </template>
-              <v-list-item-title class="text-body-2">{{ dup.name }}</v-list-item-title>
+              <v-list-item-title class="text-body-medium">{{ dup.name }}</v-list-item-title>
             </v-list-item>
           </v-list>
 
           <!-- Mode Selection -->
           <div class="mt-3">
-            <div class="text-body-2 mb-2">{{ $t('entities.copyToCampaign.howToHandle') }}</div>
+            <div class="text-body-medium mb-2">{{ $t('entities.copyToCampaign.howToHandle') }}</div>
             <v-btn-toggle v-model="copyMode" mandatory color="primary" density="compact">
               <v-btn value="skip" size="small">
                 <v-icon start size="small">mdi-skip-next</v-icon>
@@ -184,7 +184,7 @@
           class="mt-4"
         >
           <div class="font-weight-medium">{{ $t('entities.copyToCampaign.success') }}</div>
-          <div class="text-body-2 mt-1">
+          <div class="text-body-medium mt-1">
             {{ $t('entities.copyToCampaign.successDetails', {
               copied: copyResult.stats.entitiesCopied,
               skipped: copyResult.stats.entitiesSkipped,

--- a/packages/app/app/components/factions/FactionCard.vue
+++ b/packages/app/app/components/factions/FactionCard.vue
@@ -34,7 +34,7 @@
 
       <!-- Name & Metadata -->
       <div class="flex-grow-1" style="min-width: 0">
-        <h3 class="text-h6 mb-2" style="line-height: 1.2">
+        <h3 class="text-headline-small mb-2" style="line-height: 1.2">
           {{ faction.name }}
           <v-chip v-if="faction.archived_at" size="x-small" color="warning" variant="tonal" class="ml-1">
             {{ $t('common.archived') }}
@@ -68,7 +68,7 @@
 
         <!-- Leader (always shown, takes same vertical space) -->
         <div
-          class="text-caption text-medium-emphasis"
+          class="text-body-small text-medium-emphasis"
           :style="{
             minHeight: faction.metadata?.type || faction.metadata?.alignment ? '20px' : '44px',
           }"
@@ -81,10 +81,10 @@
     <!-- Description (Fixed 3 lines) -->
     <v-card-text class="pt-0 pb-3" style="flex-grow: 0">
       <div class="faction-description">
-        <p v-if="faction.description" class="text-body-2 text-medium-emphasis mb-0">
+        <p v-if="faction.description" class="text-body-medium text-medium-emphasis mb-0">
           {{ faction.description }}
         </p>
-        <p v-else class="text-body-2 text-disabled mb-0 font-italic">
+        <p v-else class="text-body-medium text-disabled mb-0 font-italic">
           {{ $t('common.noDescription') }}
         </p>
       </div>

--- a/packages/app/app/components/factions/FactionDetailsForm.vue
+++ b/packages/app/app/components/factions/FactionDetailsForm.vue
@@ -98,7 +98,7 @@
             </v-btn>
 
             <!-- AI Hint -->
-            <div v-if="!hasApiKey" class="text-caption text-medium-emphasis mt-3">
+            <div v-if="!hasApiKey" class="text-body-small text-medium-emphasis mt-3">
               <v-icon size="small" class="mr-1">mdi-information-outline</v-icon>
               KI-Generierung: OpenAI API-Key in Einstellungen hinterlegen
             </div>

--- a/packages/app/app/components/factions/FactionLocationsTab.vue
+++ b/packages/app/app/components/factions/FactionLocationsTab.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <div class="text-h6 mb-4">
+    <div class="text-headline-small mb-4">
       {{ $t('factions.locationsList') }}
     </div>
 
@@ -73,7 +73,7 @@
 
     <v-divider class="my-4" />
 
-    <div class="text-h6 mb-4">
+    <div class="text-headline-small mb-4">
       {{ $t('factions.addLocation') }}
     </div>
 

--- a/packages/app/app/components/factions/FactionRelationsTab.vue
+++ b/packages/app/app/components/factions/FactionRelationsTab.vue
@@ -21,7 +21,7 @@
           <v-chip size="small" class="mr-1" color="primary" variant="tonal">
             {{ $t(`factions.factionRelationTypes.${relation.relation_type}`, relation.relation_type) }}
           </v-chip>
-          <span v-if="getNotesText(relation.notes)" class="text-caption">
+          <span v-if="getNotesText(relation.notes)" class="text-body-small">
             {{ getNotesText(relation.notes) }}
           </span>
         </v-list-item-subtitle>

--- a/packages/app/app/components/factions/FactionViewDialog.vue
+++ b/packages/app/app/components/factions/FactionViewDialog.vue
@@ -8,8 +8,8 @@
           <v-icon v-else icon="mdi-shield-account" size="32" />
         </v-avatar>
         <div class="flex-grow-1">
-          <h2 class="text-h5">{{ faction.name }}</h2>
-          <div v-if="faction.leader_name" class="text-body-2 text-medium-emphasis">
+          <h2 class="text-headline-medium">{{ faction.name }}</h2>
+          <div v-if="faction.leader_name" class="text-body-medium text-medium-emphasis">
             {{ $t('factions.leader') }}: {{ faction.leader_name }}
           </div>
         </div>
@@ -94,10 +94,10 @@
 
               <!-- Description -->
               <div v-if="faction.description" class="mb-6">
-                <h3 class="text-subtitle-1 font-weight-bold mb-2">
+                <h3 class="text-title-medium font-weight-bold mb-2">
                   {{ $t('factions.description') }}
                 </h3>
-                <p class="text-body-2" style="white-space: pre-wrap">{{ faction.description }}</p>
+                <p class="text-body-medium" style="white-space: pre-wrap">{{ faction.description }}</p>
               </div>
 
               <!-- Metadata Grid -->
@@ -107,7 +107,7 @@
                     <div class="d-flex align-center">
                       <v-icon class="mr-3" color="primary">mdi-home-city</v-icon>
                       <div>
-                        <div class="text-caption text-medium-emphasis">
+                        <div class="text-body-small text-medium-emphasis">
                           {{ $t('factions.headquarters') }}
                         </div>
                         <div class="font-weight-medium">{{ faction.metadata.headquarters }}</div>
@@ -120,7 +120,7 @@
                     <div class="d-flex align-start">
                       <v-icon class="mr-3 mt-1" color="secondary">mdi-target</v-icon>
                       <div>
-                        <div class="text-caption text-medium-emphasis">
+                        <div class="text-body-small text-medium-emphasis">
                           {{ $t('factions.goals') }}
                         </div>
                         <div class="font-weight-medium" style="white-space: pre-wrap">{{ faction.metadata.goals }}</div>
@@ -133,7 +133,7 @@
                     <div class="d-flex align-start">
                       <v-icon class="mr-3 mt-1">mdi-note-text</v-icon>
                       <div>
-                        <div class="text-caption text-medium-emphasis">
+                        <div class="text-body-small text-medium-emphasis">
                           {{ $t('factions.notes') }}
                         </div>
                         <div class="font-weight-medium" style="white-space: pre-wrap">{{ faction.metadata.notes }}</div>

--- a/packages/app/app/components/groups/GroupAddMemberMenu.vue
+++ b/packages/app/app/components/groups/GroupAddMemberMenu.vue
@@ -17,7 +17,7 @@
         <template #prepend>
           <v-icon :icon="entityType.icon" size="small" class="mr-2" />
         </template>
-        <v-list-item-title class="text-body-2">{{ entityType.title }}</v-list-item-title>
+        <v-list-item-title class="text-body-medium">{{ entityType.title }}</v-list-item-title>
       </v-list-item>
     </v-list>
   </v-menu>

--- a/packages/app/app/components/groups/GroupCard.vue
+++ b/packages/app/app/components/groups/GroupCard.vue
@@ -25,10 +25,10 @@
 
       <!-- Name & Description -->
       <div class="flex-grow-1" style="min-width: 0">
-        <h3 class="text-h6 mb-2" style="line-height: 1.2">{{ group.name }}</h3>
+        <h3 class="text-headline-small mb-2" style="line-height: 1.2">{{ group.name }}</h3>
 
         <!-- Member Count -->
-        <div class="text-caption text-medium-emphasis">
+        <div class="text-body-small text-medium-emphasis">
           <span v-if="totalMembers > 0">{{ $t('groups.memberCount', totalMembers) }}</span>
           <span v-else class="text-disabled">{{ $t('groups.noMembers') }}</span>
         </div>
@@ -38,10 +38,10 @@
     <!-- Description (Fixed 3 lines) -->
     <v-card-text class="pt-0 pb-3" style="flex-grow: 0">
       <div class="group-description">
-        <p v-if="group.description" class="text-body-2 text-medium-emphasis mb-0">
+        <p v-if="group.description" class="text-body-medium text-medium-emphasis mb-0">
           {{ group.description }}
         </p>
-        <p v-else class="text-body-2 text-disabled mb-0 font-italic">
+        <p v-else class="text-body-medium text-disabled mb-0 font-italic">
           {{ $t('common.noDescription') }}
         </p>
       </div>

--- a/packages/app/app/components/groups/GroupEditDialog.vue
+++ b/packages/app/app/components/groups/GroupEditDialog.vue
@@ -28,7 +28,7 @@
 
         <!-- Color Selection -->
         <div class="mb-4">
-          <label class="v-label text-caption mb-2 d-block">{{ $t('groups.color') }}</label>
+          <label class="v-label text-body-small mb-2 d-block">{{ $t('groups.color') }}</label>
           <div class="d-flex flex-wrap ga-2">
             <v-avatar
               v-for="color in GROUP_COLORS"

--- a/packages/app/app/components/groups/GroupEditDialog.vue
+++ b/packages/app/app/components/groups/GroupEditDialog.vue
@@ -93,10 +93,10 @@
           <template #prepend-inner>
             <v-icon v-if="displayIcon" :icon="displayIcon" />
           </template>
-          <template #item="{ item, props: itemProps }">
+          <template #item="{ internalItem, props: itemProps }">
             <v-list-item v-bind="itemProps">
               <template #prepend>
-                <v-icon :icon="item.value" class="mr-2" />
+                <v-icon :icon="internalItem.value" class="mr-2" />
               </template>
             </v-list-item>
           </template>

--- a/packages/app/app/components/groups/GroupPreviewDialog.vue
+++ b/packages/app/app/components/groups/GroupPreviewDialog.vue
@@ -7,8 +7,8 @@
           <v-icon :icon="group.icon || 'mdi-folder-multiple'" size="24" :color="getContrastColor(group.color)" />
         </v-avatar>
         <div class="flex-grow-1">
-          <h3 class="text-h6">{{ group.name }}</h3>
-          <div class="text-body-2 text-medium-emphasis">
+          <h3 class="text-headline-small">{{ group.name }}</h3>
+          <div class="text-body-medium text-medium-emphasis">
             {{ $t('groups.memberCount', totalMembers) }}
           </div>
         </div>
@@ -19,7 +19,7 @@
 
       <!-- Description (if exists) -->
       <v-card-text v-if="group.description" class="py-3">
-        <p class="text-body-2 mb-0">{{ group.description }}</p>
+        <p class="text-body-medium mb-0">{{ group.description }}</p>
       </v-card-text>
 
       <v-divider v-if="group.description" />
@@ -48,8 +48,8 @@
                 <v-icon v-else :icon="getTypeIcon(member.entity_type)" size="16" />
               </v-avatar>
             </template>
-            <v-list-item-title class="text-body-2">{{ member.entity_name }}</v-list-item-title>
-            <v-list-item-subtitle class="text-caption">
+            <v-list-item-title class="text-body-medium">{{ member.entity_name }}</v-list-item-title>
+            <v-list-item-subtitle class="text-body-small">
               {{ $t(`entityTypes.${member.entity_type}`) }}
             </v-list-item-subtitle>
             <template #append>

--- a/packages/app/app/components/groups/GroupViewDialog.vue
+++ b/packages/app/app/components/groups/GroupViewDialog.vue
@@ -7,8 +7,8 @@
           <v-icon :icon="group.icon || 'mdi-folder-multiple'" size="32" :color="getContrastColor(group.color)" />
         </v-avatar>
         <div class="flex-grow-1">
-          <h2 class="text-h5">{{ group.name }}</h2>
-          <div class="text-body-2 text-medium-emphasis">
+          <h2 class="text-headline-medium">{{ group.name }}</h2>
+          <div class="text-body-medium text-medium-emphasis">
             {{ $t('groups.memberCount', totalMembers) }}
           </div>
         </div>
@@ -18,7 +18,7 @@
 
       <!-- Description (if exists) -->
       <v-card-text v-if="group.description" class="py-3">
-        <p class="text-body-2 mb-0">{{ group.description }}</p>
+        <p class="text-body-medium mb-0">{{ group.description }}</p>
       </v-card-text>
 
       <v-divider v-if="group.description" />

--- a/packages/app/app/components/items/ItemCard.vue
+++ b/packages/app/app/components/items/ItemCard.vue
@@ -34,7 +34,7 @@
 
       <!-- Name & Metadata -->
       <div class="flex-grow-1" style="min-width: 0">
-        <h3 class="text-h6 mb-2" style="line-height: 1.2">
+        <h3 class="text-headline-small mb-2" style="line-height: 1.2">
           {{ item.name }}
           <v-chip v-if="item.archived_at" size="x-small" color="warning" variant="tonal" class="ml-1">
             {{ $t('common.archived') }}
@@ -64,7 +64,7 @@
 
         <!-- Value & Weight (always shown, takes same vertical space) -->
         <div
-          class="text-caption text-medium-emphasis"
+          class="text-body-small text-medium-emphasis"
           :style="{ minHeight: item.metadata?.type || item.metadata?.rarity ? '20px' : '44px' }"
         >
           <span v-if="item.metadata?.value">{{ item.metadata.value }}</span>
@@ -77,10 +77,10 @@
     <!-- Description (Fixed 3 lines) -->
     <v-card-text class="pt-0 pb-3" style="flex-grow: 0">
       <div class="item-description">
-        <p v-if="item.description" class="text-body-2 text-medium-emphasis mb-0">
+        <p v-if="item.description" class="text-body-medium text-medium-emphasis mb-0">
           {{ item.description }}
         </p>
-        <p v-else class="text-body-2 text-disabled mb-0 font-italic">
+        <p v-else class="text-body-medium text-disabled mb-0 font-italic">
           {{ $t('common.noDescription') }}
         </p>
       </div>

--- a/packages/app/app/components/items/ItemEditDialog.vue
+++ b/packages/app/app/components/items/ItemEditDialog.vue
@@ -126,10 +126,10 @@
                     variant="outlined"
                     clearable
                   >
-                    <template #item="{ props: itemProps, item: selectItem }">
+                    <template #item="{ props: itemProps, internalItem: selectItem }">
                       <v-list-item v-bind="itemProps" :title="$t(`items.types.${selectItem.value}`)" />
                     </template>
-                    <template #selection="{ item: selectItem }">
+                    <template #selection="{ internalItem: selectItem }">
                       {{ $t(`items.types.${selectItem.value}`) }}
                     </template>
                   </v-select>
@@ -142,10 +142,10 @@
                     variant="outlined"
                     clearable
                   >
-                    <template #item="{ props: itemProps, item: selectItem }">
+                    <template #item="{ props: itemProps, internalItem: selectItem }">
                       <v-list-item v-bind="itemProps" :title="$t(`items.rarities.${selectItem.value}`)" />
                     </template>
-                    <template #selection="{ item: selectItem }">
+                    <template #selection="{ internalItem: selectItem }">
                       {{ $t(`items.rarities.${selectItem.value}`) }}
                     </template>
                   </v-select>
@@ -189,14 +189,14 @@
                     item-value="id"
                     density="default"
                   >
-                    <template #item="{ props: itemProps, item: selectItem }">
+                    <template #item="{ props: itemProps, internalItem: selectItem }">
                       <v-list-item v-bind="itemProps">
                         <template #prepend>
                           <span class="font-weight-bold mr-2">{{ selectItem.raw.symbol }}</span>
                         </template>
                       </v-list-item>
                     </template>
-                    <template #selection="{ item: selectItem }">
+                    <template #selection="{ internalItem: selectItem }">
                       {{ selectItem.raw.symbol }}
                     </template>
                   </v-select>
@@ -558,10 +558,10 @@
                   variant="outlined"
                   clearable
                 >
-                  <template #item="{ props: itemProps, item: selectItem }">
+                  <template #item="{ props: itemProps, internalItem: selectItem }">
                     <v-list-item v-bind="itemProps" :title="$t(`items.types.${selectItem.value}`)" />
                   </template>
-                  <template #selection="{ item: selectItem }">
+                  <template #selection="{ internalItem: selectItem }">
                     {{ $t(`items.types.${selectItem.value}`) }}
                   </template>
                 </v-select>
@@ -574,10 +574,10 @@
                   variant="outlined"
                   clearable
                 >
-                  <template #item="{ props: itemProps, item: selectItem }">
+                  <template #item="{ props: itemProps, internalItem: selectItem }">
                     <v-list-item v-bind="itemProps" :title="$t(`items.rarities.${selectItem.value}`)" />
                   </template>
-                  <template #selection="{ item: selectItem }">
+                  <template #selection="{ internalItem: selectItem }">
                     {{ $t(`items.rarities.${selectItem.value}`) }}
                   </template>
                 </v-select>

--- a/packages/app/app/components/items/ItemEditDialog.vue
+++ b/packages/app/app/components/items/ItemEditDialog.vue
@@ -115,7 +115,7 @@
 
               <v-divider class="my-4" />
 
-              <div class="text-h6 mb-4">{{ $t('items.metadata') }}</div>
+              <div class="text-headline-small mb-4">{{ $t('items.metadata') }}</div>
 
               <v-row>
                 <v-col cols="12" md="6">

--- a/packages/app/app/components/items/ItemViewDialog.vue
+++ b/packages/app/app/components/items/ItemViewDialog.vue
@@ -7,8 +7,8 @@
           <v-icon v-else icon="mdi-treasure-chest" size="32" />
         </v-avatar>
         <div class="flex-grow-1">
-          <h2 class="text-h5">{{ item.name }}</h2>
-          <div v-if="item.metadata?.type || item.metadata?.rarity" class="text-body-2">
+          <h2 class="text-headline-medium">{{ item.name }}</h2>
+          <div v-if="item.metadata?.type || item.metadata?.rarity" class="text-body-medium">
             <v-chip
               v-if="item.metadata?.rarity"
               :color="getRarityColor(item.metadata.rarity)"
@@ -90,10 +90,10 @@
 
               <!-- Description -->
               <div v-if="item.description" class="mb-4">
-                <h3 class="text-h6 mb-2">
+                <h3 class="text-headline-small mb-2">
                   {{ $t('items.description') }}
                 </h3>
-                <p class="text-body-1" style="white-space: pre-wrap">
+                <p class="text-body-large" style="white-space: pre-wrap">
                   {{ item.description }}
                 </p>
               </div>
@@ -105,7 +105,7 @@
                     <div class="d-flex align-center">
                       <v-icon class="mr-3" color="amber">mdi-currency-usd</v-icon>
                       <div>
-                        <div class="text-caption text-medium-emphasis">{{ $t('items.value') }}</div>
+                        <div class="text-body-small text-medium-emphasis">{{ $t('items.value') }}</div>
                         <div class="font-weight-medium">{{ item.metadata.value }}</div>
                       </div>
                     </div>
@@ -116,7 +116,7 @@
                     <div class="d-flex align-center">
                       <v-icon class="mr-3" color="grey">mdi-weight</v-icon>
                       <div>
-                        <div class="text-caption text-medium-emphasis">{{ $t('items.weight') }}</div>
+                        <div class="text-body-small text-medium-emphasis">{{ $t('items.weight') }}</div>
                         <div class="font-weight-medium">{{ item.metadata.weight }}</div>
                       </div>
                     </div>
@@ -127,7 +127,7 @@
                     <div class="d-flex align-center">
                       <v-icon class="mr-3" color="blue">mdi-lightning-bolt</v-icon>
                       <div>
-                        <div class="text-caption text-medium-emphasis">{{ $t('items.charges') }}</div>
+                        <div class="text-body-small text-medium-emphasis">{{ $t('items.charges') }}</div>
                         <div class="font-weight-medium">{{ item.metadata.charges }}</div>
                       </div>
                     </div>
@@ -138,7 +138,7 @@
                     <div class="d-flex align-center">
                       <v-icon class="mr-3" color="primary">mdi-star</v-icon>
                       <div>
-                        <div class="text-caption text-medium-emphasis">{{ $t('items.properties') }}</div>
+                        <div class="text-body-small text-medium-emphasis">{{ $t('items.properties') }}</div>
                         <div class="font-weight-medium">{{ item.metadata.properties }}</div>
                       </div>
                     </div>

--- a/packages/app/app/components/layout/GlobalSearch.vue
+++ b/packages/app/app/components/layout/GlobalSearch.vue
@@ -31,7 +31,7 @@
       </v-card-title>
       <v-divider />
       <v-card-text style="max-height: 500px; overflow-y: auto">
-        <div v-if="searchQuery" class="text-caption text-disabled mb-2">
+        <div v-if="searchQuery" class="text-body-small text-disabled mb-2">
           {{ $t('search.searching', { query: searchQuery }) }}
         </div>
         <v-list v-if="searchResults.length > 0">

--- a/packages/app/app/components/layout/NavigationDrawer.vue
+++ b/packages/app/app/components/layout/NavigationDrawer.vue
@@ -6,34 +6,38 @@
     @click="$emit('update:rail', false)"
     @update:model-value="$emit('update:model-value', $event)"
   >
-    <v-list-item
-      :prepend-icon="rail ? 'mdi-dice-d20' : 'mdi-dice-d20'"
-      :title="rail ? '' : 'DM Hero'"
-      nav
-    >
-      <template #append>
-        <v-btn
-          :icon="rail ? 'mdi-chevron-right' : 'mdi-chevron-left'"
-          variant="text"
-          @click.stop="$emit('update:rail', !rail)"
-        />
-      </template>
-    </v-list-item>
+    <!-- Fixed top: app title + active campaign -->
+    <template #prepend>
+      <v-list-item
+        :prepend-icon="rail ? 'mdi-dice-d20' : 'mdi-dice-d20'"
+        :title="rail ? '' : 'DM Hero'"
+        nav
+      >
+        <template #append>
+          <v-btn
+            :icon="rail ? 'mdi-chevron-right' : 'mdi-chevron-left'"
+            variant="text"
+            @click.stop="$emit('update:rail', !rail)"
+          />
+        </template>
+      </v-list-item>
 
-    <v-divider />
+      <v-divider />
 
-    <!-- Active Campaign Display -->
-    <v-list-item
-      v-if="activeCampaignName && !rail"
-      prepend-icon="mdi-sword-cross"
-      :title="activeCampaignName || ''"
-      :subtitle="$t('nav.activeCampaign')"
-      class="mb-2"
-      @click="router.push('/campaigns')"
-    />
+      <!-- Active Campaign Display -->
+      <v-list-item
+        v-if="activeCampaignName && !rail"
+        prepend-icon="mdi-sword-cross"
+        :title="activeCampaignName || ''"
+        :subtitle="$t('nav.activeCampaign')"
+        class="mb-2"
+        @click="router.push('/campaigns')"
+      />
 
-    <v-divider v-if="activeCampaignName && !rail" />
+      <v-divider v-if="activeCampaignName && !rail" />
+    </template>
 
+    <!-- Scrollable middle: nav items -->
     <v-list density="compact" nav>
       <v-list-item
         prepend-icon="mdi-view-dashboard"

--- a/packages/app/app/components/layout/NavigationDrawer.vue
+++ b/packages/app/app/components/layout/NavigationDrawer.vue
@@ -142,11 +142,7 @@
           :title="rail ? '' : $t('nav.settings')"
           to="/settings"
         />
-        <v-list-item
-          :prepend-icon="isDark ? 'mdi-weather-night' : 'mdi-weather-sunny'"
-          :title="rail ? '' : $t('nav.theme')"
-          @click="$emit('toggle-theme')"
-        />
+        <LayoutThemeSwitcher :rail="rail" />
       </v-list>
     </template>
   </v-navigation-drawer>
@@ -166,7 +162,6 @@ interface Props {
   rail: boolean
   hasActiveCampaign: boolean
   activeCampaignName?: string | null
-  isDark: boolean
   isSearchActive: boolean
 }
 
@@ -176,7 +171,6 @@ defineEmits<{
   'update:model-value': [value: boolean]
   'update:rail': [value: boolean]
   'search-click': []
-  'toggle-theme': []
 }>()
 </script>
 

--- a/packages/app/app/components/layout/ThemeSwitcher.vue
+++ b/packages/app/app/components/layout/ThemeSwitcher.vue
@@ -1,0 +1,102 @@
+<template>
+  <FeatureTooltip
+    feature-key="theme-switcher-v1"
+    :text="$t('featureTooltips.themeSwitcher')"
+    location="end"
+  >
+    <v-list-item
+      :id="ACTIVATOR_ID"
+      prepend-icon="mdi-palette"
+      :title="rail ? '' : $t('nav.theme')"
+    >
+      <template v-if="!rail" #append>
+        <div class="d-flex align-center ga-1">
+          <span
+            class="swatch swatch--primary"
+            :style="{ background: swatch.primary }"
+          />
+          <span
+            class="swatch swatch--bg"
+            :style="{ background: swatch.background }"
+          />
+        </div>
+      </template>
+    </v-list-item>
+
+    <v-menu
+      :activator="`#${ACTIVATOR_ID}`"
+      :close-on-content-click="false"
+      location="end"
+      offset="8"
+    >
+      <v-card min-width="220">
+        <v-list density="compact" nav>
+          <v-list-subheader>{{ $t('nav.themePickerTitle') }}</v-list-subheader>
+          <v-list-item
+            v-for="name in available"
+            :key="name"
+            :active="current === name"
+            @click="setTheme(name)"
+          >
+            <template #prepend>
+              <div class="d-flex align-center ga-1 mr-2">
+                <span
+                  class="swatch swatch--primary"
+                  :style="{ background: swatches[name].primary }"
+                />
+                <span
+                  class="swatch swatch--bg"
+                  :style="{ background: swatches[name].background }"
+                />
+              </div>
+            </template>
+            <v-list-item-title>{{ $t(`themes.${name}`) }}</v-list-item-title>
+          </v-list-item>
+          <v-divider class="my-1" />
+          <v-list-item
+            prepend-icon="mdi-restore"
+            :disabled="current === defaultTheme"
+            @click="reset"
+          >
+            <v-list-item-title>{{ $t('common.reset') }}</v-list-item-title>
+          </v-list-item>
+        </v-list>
+      </v-card>
+    </v-menu>
+  </FeatureTooltip>
+</template>
+
+<script setup lang="ts">
+import FeatureTooltip from '~/components/shared/FeatureTooltip.vue'
+import { useThemePreference } from '~/composables/useThemePreference'
+import { getThemeSwatch, THEME_NAMES, type ThemeName } from '~/composables/themes'
+
+defineProps<{ rail: boolean }>()
+
+const ACTIVATOR_ID = 'theme-switcher-activator'
+
+const { current, setTheme, reset, available, defaultTheme } = useThemePreference()
+
+const swatches = Object.fromEntries(
+  THEME_NAMES.map(name => [name, getThemeSwatch(name)]),
+) as Record<ThemeName, { primary: string, background: string }>
+
+const swatch = computed(() => swatches[current.value])
+</script>
+
+<style scoped>
+.swatch {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border-radius: 3px;
+  border: 1px solid rgba(0, 0, 0, 0.2);
+}
+.swatch--primary {
+  border-radius: 3px 0 0 3px;
+}
+.swatch--bg {
+  border-radius: 0 3px 3px 0;
+  margin-inline-start: -1px;
+}
+</style>

--- a/packages/app/app/components/layout/UpdateBanner.vue
+++ b/packages/app/app/components/layout/UpdateBanner.vue
@@ -11,13 +11,13 @@
         <!-- Header -->
         <div class="d-flex align-center mb-2">
           <v-icon :icon="headerIcon" class="mr-2" />
-          <span class="text-body-2 font-weight-medium">
+          <span class="text-body-medium font-weight-medium">
             {{ headerText }}
           </span>
         </div>
 
         <!-- Version info -->
-        <div v-if="updateInfo" class="text-caption mb-2">
+        <div v-if="updateInfo" class="text-body-small mb-2">
           {{ updateInfo.latestVersion }}
           <v-chip
             v-if="updateInfo.isDevMode"
@@ -37,7 +37,7 @@
             height="8"
             rounded
           />
-          <div class="text-caption mt-1 d-flex justify-space-between">
+          <div class="text-body-small mt-1 d-flex justify-space-between">
             <span>{{ Math.round(downloadProgress.percent) }}%</span>
             <span>{{ formatSpeed(downloadProgress.bytesPerSecond) }}</span>
           </div>
@@ -121,7 +121,7 @@
         <!-- Linux hint for the manual install step (outside flex row so it wraps normally) -->
         <p
           v-if="isReadyToInstall && isLinux"
-          class="text-caption mt-2 mb-0"
+          class="text-body-small mt-2 mb-0"
         >
           {{ $t('update.linuxInstallHint') }}
         </p>

--- a/packages/app/app/components/locations/LocationViewDialog.vue
+++ b/packages/app/app/components/locations/LocationViewDialog.vue
@@ -7,8 +7,8 @@
           <v-icon v-else icon="mdi-map-marker" size="32" />
         </v-avatar>
         <div class="flex-grow-1">
-          <h2 class="text-h5">{{ location.name }}</h2>
-          <div v-if="location.metadata?.type" class="text-body-2 text-medium-emphasis">
+          <h2 class="text-headline-medium">{{ location.name }}</h2>
+          <div v-if="location.metadata?.type" class="text-body-medium text-medium-emphasis">
             {{ $t(`locations.types.${location.metadata.type}`, location.metadata.type) }}
           </div>
         </div>
@@ -76,10 +76,10 @@
               />
 
               <div v-if="location.description" class="mb-4">
-                <h3 class="text-h6 mb-2">
+                <h3 class="text-headline-small mb-2">
                   {{ $t('locations.description') }}
                 </h3>
-                <p class="text-body-1" style="white-space: pre-wrap">
+                <p class="text-body-large" style="white-space: pre-wrap">
                   {{ location.description }}
                 </p>
               </div>
@@ -91,7 +91,7 @@
                     <div class="d-flex align-center">
                       <v-icon class="mr-3" color="primary">mdi-shape</v-icon>
                       <div>
-                        <div class="text-caption text-medium-emphasis">{{ $t('locations.type') }}</div>
+                        <div class="text-body-small text-medium-emphasis">{{ $t('locations.type') }}</div>
                         <div class="font-weight-medium">{{ $t(`locations.types.${location.metadata.type}`, location.metadata.type) }}</div>
                       </div>
                     </div>
@@ -102,7 +102,7 @@
                     <div class="d-flex align-center">
                       <v-icon class="mr-3" color="secondary">mdi-map</v-icon>
                       <div>
-                        <div class="text-caption text-medium-emphasis">{{ $t('locations.region') }}</div>
+                        <div class="text-body-small text-medium-emphasis">{{ $t('locations.region') }}</div>
                         <div class="font-weight-medium">{{ location.metadata.region }}</div>
                       </div>
                     </div>
@@ -113,7 +113,7 @@
                     <div class="d-flex align-start">
                       <v-icon class="mr-3 mt-1">mdi-note-text</v-icon>
                       <div>
-                        <div class="text-caption text-medium-emphasis">{{ $t('locations.notes') }}</div>
+                        <div class="text-body-small text-medium-emphasis">{{ $t('locations.notes') }}</div>
                         <div class="font-weight-medium" style="white-space: pre-wrap">{{ location.metadata.notes }}</div>
                       </div>
                     </div>

--- a/packages/app/app/components/lore/LoreCard.vue
+++ b/packages/app/app/components/lore/LoreCard.vue
@@ -34,7 +34,7 @@
 
       <!-- Name & Metadata -->
       <div class="flex-grow-1" style="min-width: 0">
-        <h3 class="text-h6 mb-2" style="line-height: 1.2">
+        <h3 class="text-headline-small mb-2" style="line-height: 1.2">
           {{ lore.name }}
           <v-chip v-if="lore.archived_at" size="x-small" color="warning" variant="tonal" class="ml-1">
             {{ $t('common.archived') }}
@@ -55,7 +55,7 @@
 
         <!-- Date (for events) - always shown, takes same vertical space -->
         <div
-          class="text-caption text-medium-emphasis"
+          class="text-body-small text-medium-emphasis"
           :style="{ minHeight: lore.metadata?.type ? '20px' : '44px' }"
         >
           <template v-if="lore.metadata?.date">
@@ -69,10 +69,10 @@
     <!-- Description (Fixed 3 lines) -->
     <v-card-text class="pt-0 pb-3" style="flex-grow: 0">
       <div class="lore-description">
-        <p v-if="lore.description" class="text-body-2 text-medium-emphasis mb-0">
+        <p v-if="lore.description" class="text-body-medium text-medium-emphasis mb-0">
           {{ lore.description }}
         </p>
-        <p v-else class="text-body-2 text-disabled mb-0 font-italic">
+        <p v-else class="text-body-medium text-disabled mb-0 font-italic">
           {{ $t('common.noDescription') }}
         </p>
       </div>

--- a/packages/app/app/components/lore/LoreEditDialog.vue
+++ b/packages/app/app/components/lore/LoreEditDialog.vue
@@ -135,7 +135,7 @@
 
             <!-- NPCs Tab -->
             <v-tabs-window-item value="npcs">
-              <div class="text-h6 mb-4">{{ $t('lore.linkedNpcs') }}</div>
+              <div class="text-headline-small mb-4">{{ $t('lore.linkedNpcs') }}</div>
 
               <v-list v-if="linkedNpcs.length > 0">
                 <v-list-item v-for="npc in linkedNpcs" :key="npc.id" class="mb-2" border>
@@ -170,7 +170,7 @@
 
               <v-divider class="my-4" />
 
-              <div class="text-h6 mb-4">{{ $t('lore.addNpc') }}</div>
+              <div class="text-headline-small mb-4">{{ $t('lore.addNpc') }}</div>
 
               <v-autocomplete
                 v-model="selectedNpcId"
@@ -201,7 +201,7 @@
 
             <!-- Factions Tab -->
             <v-tabs-window-item value="factions">
-              <div class="text-h6 mb-4">{{ $t('lore.linkedFactions') }}</div>
+              <div class="text-headline-small mb-4">{{ $t('lore.linkedFactions') }}</div>
 
               <v-list v-if="linkedFactions.length > 0">
                 <v-list-item v-for="faction in linkedFactions" :key="faction.id" class="mb-2" border>
@@ -230,7 +230,7 @@
 
               <v-divider class="my-4" />
 
-              <div class="text-h6 mb-4">{{ $t('lore.addFaction') }}</div>
+              <div class="text-headline-small mb-4">{{ $t('lore.addFaction') }}</div>
 
               <v-autocomplete
                 v-model="selectedFactionId"

--- a/packages/app/app/components/lore/LoreViewDialog.vue
+++ b/packages/app/app/components/lore/LoreViewDialog.vue
@@ -8,7 +8,7 @@
           <v-icon v-else icon="mdi-book-open-variant" size="32" />
         </v-avatar>
         <div class="flex-grow-1">
-          <div class="text-h5">{{ lore.name }}</div>
+          <div class="text-headline-medium">{{ lore.name }}</div>
           <div v-if="lore.metadata?.type" class="mt-1">
             <v-chip :color="getTypeColor(lore.metadata.type)" size="small">
               {{ $t(`lore.types.${lore.metadata.type}`) }}
@@ -74,7 +74,7 @@
               <!-- Date Card -->
               <v-card v-if="lore.metadata?.date" variant="tonal" class="mb-4">
                 <v-card-text>
-                  <div class="text-caption text-medium-emphasis mb-1">
+                  <div class="text-body-small text-medium-emphasis mb-1">
                     {{ $t('lore.date') }}
                   </div>
                   <div class="d-flex align-center">
@@ -87,10 +87,10 @@
               <!-- Description -->
               <v-card v-if="lore.description" variant="tonal">
                 <v-card-text>
-                  <div class="text-caption text-medium-emphasis mb-2">
+                  <div class="text-body-small text-medium-emphasis mb-2">
                     {{ $t('lore.description') }}
                   </div>
-                  <div class="text-body-1" style="white-space: pre-wrap">
+                  <div class="text-body-large" style="white-space: pre-wrap">
                     {{ lore.description }}
                   </div>
                 </v-card-text>

--- a/packages/app/app/components/maps/MapAreaEditDialog.vue
+++ b/packages/app/app/components/maps/MapAreaEditDialog.vue
@@ -52,7 +52,7 @@
           class="mb-3"
         >
           <template #append>
-            <span class="text-body-2">{{ form.radius }}%</span>
+            <span class="text-body-medium">{{ form.radius }}%</span>
           </template>
         </v-slider>
 

--- a/packages/app/app/components/maps/MapAreaEditDialog.vue
+++ b/packages/app/app/components/maps/MapAreaEditDialog.vue
@@ -29,11 +29,11 @@
           no-filter
           prepend-inner-icon="mdi-map-marker"
         >
-          <template #item="{ item, props: itemProps }">
+          <template #item="{ internalItem, props: itemProps }">
             <v-list-item v-bind="itemProps">
               <template #prepend>
                 <v-avatar size="32" color="#8B7355">
-                  <v-img v-if="item.raw.image_url" :src="`/uploads/${item.raw.image_url}`" />
+                  <v-img v-if="internalItem.raw.image_url" :src="`/uploads/${internalItem.raw.image_url}`" />
                   <v-icon v-else icon="mdi-map-marker" size="small" />
                 </v-avatar>
               </template>

--- a/packages/app/app/components/maps/MapMarkerEditDialog.vue
+++ b/packages/app/app/components/maps/MapMarkerEditDialog.vue
@@ -42,11 +42,11 @@
           no-filter
           :disabled="!form.entityType"
         >
-          <template #item="{ item, props: itemProps }">
+          <template #item="{ internalItem, props: itemProps }">
             <v-list-item v-bind="itemProps">
               <template #prepend>
                 <v-avatar size="32" :color="getEntityColor(form.entityType)">
-                  <v-img v-if="item.raw.image_url" :src="`/uploads/${item.raw.image_url}`" />
+                  <v-img v-if="internalItem.raw.image_url" :src="`/uploads/${internalItem.raw.image_url}`" />
                   <v-icon v-else :icon="getEntityIcon(form.entityType)" size="small" />
                 </v-avatar>
               </template>

--- a/packages/app/app/components/npcs/NpcCard.vue
+++ b/packages/app/app/components/npcs/NpcCard.vue
@@ -34,7 +34,7 @@
 
       <!-- Name & Metadata -->
       <div class="flex-grow-1" style="min-width: 0">
-        <h3 class="text-h6 mb-2" style="line-height: 1.2">
+        <h3 class="text-headline-small mb-2" style="line-height: 1.2">
           {{ npc.name }}
           <v-chip v-if="npc.archived_at" size="x-small" color="warning" variant="tonal" class="ml-1">
             {{ $t('common.archived') }}
@@ -66,7 +66,7 @@
 
         <!-- Race & Class (always shown, takes same vertical space) -->
         <div
-          class="text-caption text-medium-emphasis"
+          class="text-body-small text-medium-emphasis"
           :style="{ minHeight: toArray(npc.metadata?.type).length || npc.metadata?.status ? '20px' : '44px' }"
         >
           <span v-if="npc.metadata?.race">{{ getRaceDisplayName(npc.metadata.race) }}</span>
@@ -79,10 +79,10 @@
     <!-- Description (Fixed 3 lines) -->
     <v-card-text class="pt-0 pb-3" style="flex-grow: 0">
       <div class="npc-description">
-        <p v-if="npc.description" class="text-body-2 text-medium-emphasis mb-0">
+        <p v-if="npc.description" class="text-body-medium text-medium-emphasis mb-0">
           {{ npc.description }}
         </p>
-        <p v-else class="text-body-2 text-disabled mb-0 font-italic">
+        <p v-else class="text-body-medium text-disabled mb-0 font-italic">
           {{ $t('common.noDescription') }}
         </p>
       </div>

--- a/packages/app/app/components/npcs/NpcEditDialog.vue
+++ b/packages/app/app/components/npcs/NpcEditDialog.vue
@@ -204,19 +204,19 @@
                     multiple
                     chips
                   >
-                    <template #item="{ props: itemProps, item }">
+                    <template #item="{ props: itemProps, internalItem }">
                       <v-list-item v-bind="itemProps">
                         <template #prepend>
-                          <v-icon :icon="getNpcTypeIcon(item.value)" />
+                          <v-icon :icon="getNpcTypeIcon(internalItem.value)" />
                         </template>
                       </v-list-item>
                     </template>
-                    <template #selection="{ item }">
+                    <template #selection="{ internalItem }">
                       <v-chip>
                         <template #prepend>
-                          <v-icon :icon="getNpcTypeIcon(item.value)" size="small" class="mr-1" />
+                          <v-icon :icon="getNpcTypeIcon(internalItem.value)" size="small" class="mr-1" />
                         </template>
-                        {{ item.title }}
+                        {{ internalItem.title }}
                       </v-chip>
                     </template>
                   </v-select>
@@ -229,19 +229,19 @@
                     variant="outlined"
                     clearable
                   >
-                    <template #item="{ props: itemProps, item }">
+                    <template #item="{ props: itemProps, internalItem }">
                       <v-list-item v-bind="itemProps">
                         <template #prepend>
-                          <v-icon :icon="getNpcStatusIcon(item.value)" :color="getNpcStatusColor(item.value)" />
+                          <v-icon :icon="getNpcStatusIcon(internalItem.value)" :color="getNpcStatusColor(internalItem.value)" />
                         </template>
                       </v-list-item>
                     </template>
-                    <template #selection="{ item }">
-                      <v-chip :color="getNpcStatusColor(item.value)">
+                    <template #selection="{ internalItem }">
+                      <v-chip :color="getNpcStatusColor(internalItem.value)">
                         <template #prepend>
-                          <v-icon :icon="getNpcStatusIcon(item.value)" size="small" class="mr-1" />
+                          <v-icon :icon="getNpcStatusIcon(internalItem.value)" size="small" class="mr-1" />
                         </template>
-                        {{ item.title }}
+                        {{ internalItem.title }}
                       </v-chip>
                     </template>
                   </v-select>
@@ -457,19 +457,19 @@
                   multiple
                   chips
                 >
-                  <template #item="{ props: itemProps, item }">
+                  <template #item="{ props: itemProps, internalItem }">
                     <v-list-item v-bind="itemProps">
                       <template #prepend>
-                        <v-icon :icon="getNpcTypeIcon(item.value)" />
+                        <v-icon :icon="getNpcTypeIcon(internalItem.value)" />
                       </template>
                     </v-list-item>
                   </template>
-                  <template #selection="{ item }">
+                  <template #selection="{ internalItem }">
                     <v-chip>
                       <template #prepend>
-                        <v-icon :icon="getNpcTypeIcon(item.value)" size="small" class="mr-1" />
+                        <v-icon :icon="getNpcTypeIcon(internalItem.value)" size="small" class="mr-1" />
                       </template>
-                      {{ item.title }}
+                      {{ internalItem.title }}
                     </v-chip>
                   </template>
                 </v-select>
@@ -482,19 +482,19 @@
                   variant="outlined"
                   clearable
                 >
-                  <template #item="{ props: itemProps, item }">
+                  <template #item="{ props: itemProps, internalItem }">
                     <v-list-item v-bind="itemProps">
                       <template #prepend>
-                        <v-icon :icon="getNpcStatusIcon(item.value)" :color="getNpcStatusColor(item.value)" />
+                        <v-icon :icon="getNpcStatusIcon(internalItem.value)" :color="getNpcStatusColor(internalItem.value)" />
                       </template>
                     </v-list-item>
                   </template>
-                  <template #selection="{ item }">
-                    <v-chip :color="getNpcStatusColor(item.value)">
+                  <template #selection="{ internalItem }">
+                    <v-chip :color="getNpcStatusColor(internalItem.value)">
                       <template #prepend>
-                        <v-icon :icon="getNpcStatusIcon(item.value)" size="small" class="mr-1" />
+                        <v-icon :icon="getNpcStatusIcon(internalItem.value)" size="small" class="mr-1" />
                       </template>
-                      {{ item.title }}
+                      {{ internalItem.title }}
                     </v-chip>
                   </template>
                 </v-select>

--- a/packages/app/app/components/npcs/NpcMembershipsTab.vue
+++ b/packages/app/app/components/npcs/NpcMembershipsTab.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <div class="text-h6 mb-4">
+    <div class="text-headline-small mb-4">
       {{ $t('npcs.factionMemberships') }}
     </div>
 
@@ -18,7 +18,7 @@
           </v-chip>
           <span
             v-if="membership.notes && typeof membership.notes === 'object' && 'rank' in membership.notes"
-            class="text-caption"
+            class="text-body-small"
           >
             {{ $t('npcs.rank') }}: {{ membership.notes.rank }}
           </span>
@@ -50,7 +50,7 @@
 
     <v-divider class="my-4" />
 
-    <div class="text-h6 mb-4">
+    <div class="text-headline-small mb-4">
       {{ $t('npcs.addFactionMembership') }}
     </div>
 

--- a/packages/app/app/components/npcs/NpcNotesTab.vue
+++ b/packages/app/app/components/npcs/NpcNotesTab.vue
@@ -27,7 +27,7 @@
           <v-icon icon="mdi-note-text" color="primary" />
         </template>
         <v-list-item-title>
-          <span class="text-caption text-medium-emphasis mr-2">
+          <span class="text-body-small text-medium-emphasis mr-2">
             {{ formatDate(note.date || note.created_at) }}
           </span>
           <span v-if="note.title" class="font-weight-medium">

--- a/packages/app/app/components/npcs/NpcRelationsTab.vue
+++ b/packages/app/app/components/npcs/NpcRelationsTab.vue
@@ -27,7 +27,7 @@
           <v-chip size="small" class="mr-1" color="primary" variant="tonal">
             {{ $t(`npcs.npcRelationTypes.${relation.relation_type}`, relation.relation_type) }}
           </v-chip>
-          <span v-if="getNotesText(relation.notes)" class="text-caption">
+          <span v-if="getNotesText(relation.notes)" class="text-body-small">
             {{ getNotesText(relation.notes) }}
           </span>
         </v-list-item-subtitle>

--- a/packages/app/app/components/npcs/NpcViewDialog.vue
+++ b/packages/app/app/components/npcs/NpcViewDialog.vue
@@ -8,8 +8,8 @@
           <v-icon v-else icon="mdi-account" size="32" />
         </v-avatar>
         <div class="flex-grow-1">
-          <h2 class="text-h5">{{ npc.name }}</h2>
-          <div class="text-body-2 text-medium-emphasis">
+          <h2 class="text-headline-medium">{{ npc.name }}</h2>
+          <div class="text-body-medium text-medium-emphasis">
             <span v-if="npc.metadata?.race">{{ getRaceDisplayName(npc.metadata.race) }}</span>
             <span v-if="npc.metadata?.race && toArray(npc.metadata?.class).length"> • </span>
             <span v-if="toArray(npc.metadata?.class).length">{{ getClassesDisplay(npc.metadata?.class) }}</span>
@@ -104,14 +104,14 @@
 
               <!-- Description -->
               <div v-if="npc.description" class="mb-6">
-                <h3 class="text-subtitle-1 font-weight-bold mb-2">{{ $t('npcs.description') }}</h3>
-                <p class="text-body-2" style="white-space: pre-wrap">{{ npc.description }}</p>
+                <h3 class="text-title-medium font-weight-bold mb-2">{{ $t('npcs.description') }}</h3>
+                <p class="text-body-medium" style="white-space: pre-wrap">{{ npc.description }}</p>
               </div>
 
               <!-- Notes -->
               <div v-if="npc.metadata?.notes" class="mb-6">
-                <h3 class="text-subtitle-1 font-weight-bold mb-2">{{ $t('npcs.notes') }}</h3>
-                <p class="text-body-2" style="white-space: pre-wrap; max-height: 200px; overflow-y: auto">{{ npc.metadata.notes }}</p>
+                <h3 class="text-title-medium font-weight-bold mb-2">{{ $t('npcs.notes') }}</h3>
+                <p class="text-body-medium" style="white-space: pre-wrap; max-height: 200px; overflow-y: auto">{{ npc.metadata.notes }}</p>
               </div>
 
               <!-- Metadata Grid -->
@@ -121,7 +121,7 @@
                     <div class="d-flex align-center">
                       <v-icon class="mr-3" color="primary">mdi-map-marker</v-icon>
                       <div>
-                        <div class="text-caption text-medium-emphasis">{{ $t('npcs.location') }}</div>
+                        <div class="text-body-small text-medium-emphasis">{{ $t('npcs.location') }}</div>
                         <div class="font-weight-medium">{{ npc.metadata.location }}</div>
                       </div>
                     </div>
@@ -132,7 +132,7 @@
                     <div class="d-flex align-start">
                       <v-icon class="mr-3 mt-1" color="secondary">mdi-shield-account</v-icon>
                       <div class="flex-grow-1" style="min-width: 0">
-                        <div class="text-caption text-medium-emphasis mb-1">
+                        <div class="text-body-small text-medium-emphasis mb-1">
                           {{ $t('npcs.faction', counts.factions.length) }}
                         </div>
                         <div class="d-flex flex-wrap" style="gap: 6px">
@@ -144,7 +144,7 @@
                             color="secondary"
                           >
                             {{ faction.name }}
-                            <span class="text-caption ml-1 opacity-70">({{ translateMembershipType(faction.relationType) }})</span>
+                            <span class="text-body-small ml-1 opacity-70">({{ translateMembershipType(faction.relationType) }})</span>
                           </v-chip>
                         </div>
                       </div>
@@ -156,7 +156,7 @@
                     <div class="d-flex align-center">
                       <v-icon class="mr-3">mdi-calendar</v-icon>
                       <div>
-                        <div class="text-caption text-medium-emphasis">{{ $t('npcs.age') }}</div>
+                        <div class="text-body-small text-medium-emphasis">{{ $t('npcs.age') }}</div>
                         <div class="font-weight-medium">{{ npc.metadata.age }}</div>
                       </div>
                     </div>
@@ -167,7 +167,7 @@
                     <div class="d-flex align-center">
                       <v-icon class="mr-3">mdi-gender-male-female</v-icon>
                       <div>
-                        <div class="text-caption text-medium-emphasis">{{ $t('npcs.gender') }}</div>
+                        <div class="text-body-small text-medium-emphasis">{{ $t('npcs.gender') }}</div>
                         <div class="font-weight-medium">{{ $t(`npcs.genders.${npc.metadata.gender}`) }}</div>
                       </div>
                     </div>
@@ -208,7 +208,7 @@
                       <v-chip size="x-small" color="primary" variant="tonal">
                         {{ $t(`npcs.npcRelationTypes.${rel.relation_type}`, rel.relation_type) }}
                       </v-chip>
-                      <span v-if="getNotesText(rel.notes)" class="text-caption">{{ getNotesText(rel.notes) }}</span>
+                      <span v-if="getNotesText(rel.notes)" class="text-body-small">{{ getNotesText(rel.notes) }}</span>
                     </div>
                   </v-list-item-subtitle>
                 </v-list-item>

--- a/packages/app/app/components/players/PlayerCard.vue
+++ b/packages/app/app/components/players/PlayerCard.vue
@@ -34,7 +34,7 @@
 
       <!-- Name & Contact Info -->
       <div class="flex-grow-1" style="min-width: 0">
-        <h3 class="text-h6 mb-2" style="line-height: 1.2">
+        <h3 class="text-headline-small mb-2" style="line-height: 1.2">
           {{ player.name }}
           <v-chip v-if="player.archived_at" size="x-small" color="warning" variant="tonal" class="ml-1">
             {{ $t('common.archived') }}
@@ -43,15 +43,15 @@
 
         <!-- Contact Info -->
         <div class="d-flex flex-column" style="gap: 4px">
-          <div v-if="player.metadata?.discord" class="text-caption text-medium-emphasis d-flex align-center">
+          <div v-if="player.metadata?.discord" class="text-body-small text-medium-emphasis d-flex align-center">
             <v-icon size="14" class="mr-1">mdi-discord</v-icon>
             {{ player.metadata.discord }}
           </div>
-          <div v-if="player.metadata?.email" class="text-caption text-medium-emphasis d-flex align-center">
+          <div v-if="player.metadata?.email" class="text-body-small text-medium-emphasis d-flex align-center">
             <v-icon size="14" class="mr-1">mdi-email</v-icon>
             {{ player.metadata.email }}
           </div>
-          <div v-if="player.metadata?.phone" class="text-caption text-medium-emphasis d-flex align-center">
+          <div v-if="player.metadata?.phone" class="text-body-small text-medium-emphasis d-flex align-center">
             <v-icon size="14" class="mr-1">mdi-phone</v-icon>
             {{ player.metadata.phone }}
           </div>
@@ -62,10 +62,10 @@
     <!-- Description (Fixed 3 lines) -->
     <v-card-text class="pt-0 pb-3" style="flex-grow: 0">
       <div class="player-description">
-        <p v-if="player.description" class="text-body-2 text-medium-emphasis mb-0">
+        <p v-if="player.description" class="text-body-medium text-medium-emphasis mb-0">
           {{ player.description }}
         </p>
-        <p v-else class="text-body-2 text-disabled mb-0 font-italic">
+        <p v-else class="text-body-medium text-disabled mb-0 font-italic">
           {{ $t('common.noDescription') }}
         </p>
       </div>

--- a/packages/app/app/components/players/PlayerCharactersTab.vue
+++ b/packages/app/app/components/players/PlayerCharactersTab.vue
@@ -18,7 +18,7 @@
           <v-chip size="small" class="mr-1" color="primary" variant="tonal">
             {{ $t(`players.relationTypes.${npc.relation_type}`, npc.relation_type) }}
           </v-chip>
-          <span v-if="npc.notes" class="text-caption">
+          <span v-if="npc.notes" class="text-body-small">
             {{ npc.notes.substring(0, 80) }}{{ npc.notes.length > 80 ? '...' : '' }}
           </span>
         </v-list-item-subtitle>

--- a/packages/app/app/components/players/PlayerEditDialog.vue
+++ b/packages/app/app/components/players/PlayerEditDialog.vue
@@ -114,7 +114,7 @@
             <v-card variant="outlined" class="mb-3 pa-3">
               <div class="d-flex align-center mb-2">
                 <v-icon class="mr-2" color="primary">mdi-cake-variant</v-icon>
-                <span class="text-subtitle-2">{{ $t('players.characterBirthday') }}</span>
+                <span class="text-title-small">{{ $t('players.characterBirthday') }}</span>
                 <v-tooltip v-if="!hasCalendar" location="top">
                   <template #activator="{ props: tooltipProps }">
                     <v-icon v-bind="tooltipProps" class="ml-2" size="small" color="warning">
@@ -146,7 +146,7 @@
                   />
                 </div>
               </div>
-              <div v-else class="text-medium-emphasis text-body-2">
+              <div v-else class="text-medium-emphasis text-body-medium">
                 {{ $t('players.noCalendarForBirthday') }}
               </div>
             </v-card>
@@ -163,7 +163,7 @@
 
             <!-- Inspiration Counter -->
             <div class="d-flex align-center mb-3">
-              <span class="text-body-1 mr-4">{{ $t('players.inspiration') }}</span>
+              <span class="text-body-large mr-4">{{ $t('players.inspiration') }}</span>
               <v-btn
                 icon="mdi-minus"
                 size="small"
@@ -171,7 +171,7 @@
                 :disabled="(form.inspiration || 0) <= 0"
                 @click="form.inspiration = Math.max(0, (form.inspiration || 0) - 1)"
               />
-              <v-chip size="large" class="mx-2 text-h6" variant="tonal" color="primary">
+              <v-chip size="large" class="mx-2 text-headline-small" variant="tonal" color="primary">
                 {{ form.inspiration || 0 }}
               </v-chip>
               <v-btn
@@ -339,7 +339,7 @@
 
           <!-- Inspiration Counter -->
           <div class="d-flex align-center mb-3">
-            <span class="text-body-1 mr-4">{{ $t('players.inspiration') }}</span>
+            <span class="text-body-large mr-4">{{ $t('players.inspiration') }}</span>
             <v-btn
               icon="mdi-minus"
               size="small"
@@ -347,7 +347,7 @@
               :disabled="(form.inspiration || 0) <= 0"
               @click="form.inspiration = Math.max(0, (form.inspiration || 0) - 1)"
             />
-            <v-chip size="large" class="mx-2 text-h6" variant="tonal" color="primary">
+            <v-chip size="large" class="mx-2 text-headline-small" variant="tonal" color="primary">
               {{ form.inspiration || 0 }}
             </v-chip>
             <v-btn

--- a/packages/app/app/components/players/PlayerItemsTab.vue
+++ b/packages/app/app/components/players/PlayerItemsTab.vue
@@ -18,7 +18,7 @@
           <v-chip size="small" class="mr-1" color="primary" variant="tonal">
             {{ $t(`players.itemRelationTypes.${item.relation_type}`, item.relation_type) }}
           </v-chip>
-          <span v-if="item.notes" class="text-caption">
+          <span v-if="item.notes" class="text-body-small">
             {{ item.notes.substring(0, 80) }}{{ item.notes.length > 80 ? '...' : '' }}
           </span>
         </v-list-item-subtitle>

--- a/packages/app/app/components/players/PlayerLoreTab.vue
+++ b/packages/app/app/components/players/PlayerLoreTab.vue
@@ -18,7 +18,7 @@
           <v-chip size="small" class="mr-1" color="primary" variant="tonal">
             {{ $t(`players.loreRelationTypes.${lore.relation_type}`, lore.relation_type) }}
           </v-chip>
-          <span v-if="lore.notes" class="text-caption">
+          <span v-if="lore.notes" class="text-body-small">
             {{ lore.notes.substring(0, 80) }}{{ lore.notes.length > 80 ? '...' : '' }}
           </span>
         </v-list-item-subtitle>

--- a/packages/app/app/components/players/PlayerViewDialog.vue
+++ b/packages/app/app/components/players/PlayerViewDialog.vue
@@ -9,9 +9,9 @@
         </v-avatar>
         <div class="flex-grow-1">
           <!-- Player Name (human) is primary -->
-          <h2 class="text-h5">{{ player.metadata?.player_name || player.name }}</h2>
+          <h2 class="text-headline-medium">{{ player.metadata?.player_name || player.name }}</h2>
           <!-- Character name as subtitle if player_name exists -->
-          <div v-if="player.metadata?.player_name" class="text-body-2 text-medium-emphasis">
+          <div v-if="player.metadata?.player_name" class="text-body-medium text-medium-emphasis">
             <v-icon size="x-small" class="mr-1">mdi-sword-cross</v-icon>
             {{ player.name }}
           </div>
@@ -92,8 +92,8 @@
             <div class="pa-4">
               <!-- Description -->
               <div v-if="player.description" class="mb-6">
-                <h3 class="text-subtitle-1 font-weight-bold mb-2">{{ $t('players.description') }}</h3>
-                <p class="text-body-2" style="white-space: pre-wrap">{{ player.description }}</p>
+                <h3 class="text-title-medium font-weight-bold mb-2">{{ $t('players.description') }}</h3>
+                <p class="text-body-medium" style="white-space: pre-wrap">{{ player.description }}</p>
               </div>
 
               <!-- Contact Info -->
@@ -103,7 +103,7 @@
                     <div class="d-flex align-center">
                       <v-icon class="mr-3" color="primary">mdi-email</v-icon>
                       <div>
-                        <div class="text-caption text-medium-emphasis">{{ $t('players.email') }}</div>
+                        <div class="text-body-small text-medium-emphasis">{{ $t('players.email') }}</div>
                         <a :href="`mailto:${player.metadata.email}`" class="font-weight-medium text-decoration-none">
                           {{ player.metadata.email }}
                         </a>
@@ -116,7 +116,7 @@
                     <div class="d-flex align-center">
                       <v-icon class="mr-3" color="primary">mdi-discord</v-icon>
                       <div>
-                        <div class="text-caption text-medium-emphasis">{{ $t('players.discord') }}</div>
+                        <div class="text-body-small text-medium-emphasis">{{ $t('players.discord') }}</div>
                         <div class="font-weight-medium">{{ player.metadata.discord }}</div>
                       </div>
                     </div>
@@ -127,7 +127,7 @@
                     <div class="d-flex align-center">
                       <v-icon class="mr-3" color="primary">mdi-phone</v-icon>
                       <div>
-                        <div class="text-caption text-medium-emphasis">{{ $t('players.phone') }}</div>
+                        <div class="text-body-small text-medium-emphasis">{{ $t('players.phone') }}</div>
                         <a :href="`tel:${player.metadata.phone}`" class="font-weight-medium text-decoration-none">
                           {{ player.metadata.phone }}
                         </a>
@@ -139,9 +139,9 @@
 
               <!-- Notes -->
               <div v-if="player.metadata?.notes" class="mt-6">
-                <h3 class="text-subtitle-1 font-weight-bold mb-2">{{ $t('players.notes') }}</h3>
+                <h3 class="text-title-medium font-weight-bold mb-2">{{ $t('players.notes') }}</h3>
                 <v-card variant="outlined" class="pa-3">
-                  <p class="text-body-2" style="white-space: pre-wrap">{{ player.metadata.notes }}</p>
+                  <p class="text-body-medium" style="white-space: pre-wrap">{{ player.metadata.notes }}</p>
                 </v-card>
               </div>
             </div>

--- a/packages/app/app/components/sessions/SessionImageGallery.vue
+++ b/packages/app/app/components/sessions/SessionImageGallery.vue
@@ -30,7 +30,7 @@
       <!-- AI Image Generation Section -->
       <v-card variant="tonal" class="mb-4">
         <v-card-text>
-          <div class="text-subtitle-2 mb-2">
+          <div class="text-title-small mb-2">
             <v-icon size="small" class="mr-1">mdi-creation</v-icon>
             {{ $t('sessions.generateCoverImage') }}
           </div>
@@ -57,7 +57,7 @@
             >
               {{ $t('common.generateImage') }}
             </v-btn>
-            <span v-if="!hasApiKey" class="text-caption text-medium-emphasis">
+            <span v-if="!hasApiKey" class="text-body-small text-medium-emphasis">
               {{ $t('settings.noApiKey') }}
             </span>
           </div>
@@ -106,7 +106,7 @@
                 <v-icon start icon="mdi-star" />
                 {{ $t('common.primary') }}
               </v-chip>
-              <span class="text-caption text-medium-emphasis">
+              <span class="text-body-small text-medium-emphasis">
                 {{ new Date(image.createdAt).toLocaleDateString('de-DE') }}
               </span>
             </div>

--- a/packages/app/app/components/shared/AnnouncementDialog.vue
+++ b/packages/app/app/components/shared/AnnouncementDialog.vue
@@ -11,25 +11,25 @@
         <!-- HTML content (formatted announcements) -->
         <div
           v-if="currentAnnouncement?.html"
-          class="text-body-1 mb-4"
+          class="text-body-large mb-4"
           v-html="$t(currentAnnouncement?.contentKey || '')"
         />
         <!-- eslint-enable vue/no-v-html -->
         <!-- Plain text content (legacy) -->
-        <p v-else class="text-body-1 mb-4">
+        <p v-else class="text-body-large mb-4">
           {{ $t(currentAnnouncement?.contentKey || '') }}
         </p>
 
         <!-- OS-specific installer path -->
         <template v-if="currentAnnouncement?.showInstallerPath">
           <v-alert type="info" variant="tonal" class="mb-4">
-            <div class="text-subtitle-2 mb-1">
+            <div class="text-title-small mb-1">
               {{ $t('announcements.installerPath', { os: osName }) }}
             </div>
-            <code class="text-body-2">{{ installerPath }}</code>
+            <code class="text-body-medium">{{ installerPath }}</code>
           </v-alert>
 
-          <p class="text-body-2 text-medium-emphasis">
+          <p class="text-body-medium text-medium-emphasis">
             {{ $t('announcements.autoUpdateHint') }}
           </p>
         </template>

--- a/packages/app/app/components/shared/EntityDocuments.vue
+++ b/packages/app/app/components/shared/EntityDocuments.vue
@@ -158,7 +158,7 @@
         >
           <div class="text-center">
             <v-progress-circular indeterminate size="64" color="primary" />
-            <div class="text-h6 mt-4">{{ $t('common.uploading') }}</div>
+            <div class="text-headline-small mt-4">{{ $t('common.uploading') }}</div>
           </div>
         </v-overlay>
 

--- a/packages/app/app/components/shared/EntityFactionsTab.vue
+++ b/packages/app/app/components/shared/EntityFactionsTab.vue
@@ -26,7 +26,7 @@
           <v-chip v-if="relation.relation_type" size="small" class="mr-1">
             {{ $t(`${i18nPrefix}.${relation.relation_type}`, relation.relation_type) }}
           </v-chip>
-          <span v-if="relation.notes" class="text-caption">
+          <span v-if="relation.notes" class="text-body-small">
             {{ relation.notes }}
           </span>
         </v-list-item-subtitle>

--- a/packages/app/app/components/shared/EntityImageGallery.vue
+++ b/packages/app/app/components/shared/EntityImageGallery.vue
@@ -81,7 +81,7 @@
                 <v-icon start icon="mdi-star" />
                 {{ $t('common.primary') }}
               </v-chip>
-              <span class="text-caption text-medium-emphasis">
+              <span class="text-body-small text-medium-emphasis">
                 {{ new Date(image.created_at).toLocaleDateString('de-DE') }}
               </span>
             </div>

--- a/packages/app/app/components/shared/EntityImageUpload.vue
+++ b/packages/app/app/components/shared/EntityImageUpload.vue
@@ -107,7 +107,7 @@
           </v-btn>
 
           <!-- AI Hint -->
-          <div v-if="!hasApiKey" class="text-caption text-medium-emphasis mt-3">
+          <div v-if="!hasApiKey" class="text-body-small text-medium-emphasis mt-3">
             <v-icon size="small" class="mr-1">mdi-information-outline</v-icon>
             KI-Generierung: OpenAI API-Key in Einstellungen hinterlegen
           </div>

--- a/packages/app/app/components/shared/EntityItemsTab.vue
+++ b/packages/app/app/components/shared/EntityItemsTab.vue
@@ -93,10 +93,10 @@
           <v-chip v-if="showRelationType && item.relation_type" size="small" class="mr-1" color="primary" variant="tonal">
             {{ getRelationTypeLabel(item.relation_type) }}
           </v-chip>
-          <span v-if="showQuantity && item.quantity && item.quantity > 1" class="text-caption mr-2">
+          <span v-if="showQuantity && item.quantity && item.quantity > 1" class="text-body-small mr-2">
             {{ item.quantity }}x
           </span>
-          <span v-if="item.description" class="text-caption text-medium-emphasis">
+          <span v-if="item.description" class="text-body-small text-medium-emphasis">
             {{ item.description.substring(0, 100) }}{{ item.description.length > 100 ? '...' : '' }}
           </span>
         </v-list-item-subtitle>

--- a/packages/app/app/components/shared/EntityLocationsTab.vue
+++ b/packages/app/app/components/shared/EntityLocationsTab.vue
@@ -21,7 +21,7 @@
           <v-chip size="small" class="mr-1">
             {{ $t(`npcs.relationTypes.${relation.relation_type}`, relation.relation_type) }}
           </v-chip>
-          <span v-if="relation.notes" class="text-caption">
+          <span v-if="relation.notes" class="text-body-small">
             {{ relation.notes }}
           </span>
         </v-list-item-subtitle>

--- a/packages/app/app/components/shared/EntityMarkdownEditor.vue
+++ b/packages/app/app/components/shared/EntityMarkdownEditor.vue
@@ -114,7 +114,7 @@
           </NormalToolbar>
         </template>
       </MdEditor>
-      <div class="editor-hint text-caption text-medium-emphasis mt-1 d-flex align-center">
+      <div class="editor-hint text-body-small text-medium-emphasis mt-1 d-flex align-center">
         <v-hotkey keys="ctrl+shift+space" :platform="platform" class="mr-2" />
         <span>{{ $t('editor.quickSearchHintText') }}</span>
       </div>
@@ -131,7 +131,7 @@
       @update:model-value="onQuickSearchClose"
     >
       <v-card min-width="350" height="380" elevation="12" class="quick-search-card d-flex flex-column">
-        <v-card-title class="text-body-1 py-2 flex-grow-0 flex-shrink-0">
+        <v-card-title class="text-body-large py-2 flex-grow-0 flex-shrink-0">
           <v-icon start size="small">mdi-lightning-bolt</v-icon>
           {{ $t('editor.quickInsert') }}
         </v-card-title>

--- a/packages/app/app/components/shared/EntityNpcsTab.vue
+++ b/packages/app/app/components/shared/EntityNpcsTab.vue
@@ -73,10 +73,10 @@
           <v-chip v-if="showMembershipType && npc.relation_type" size="small" class="mr-1" color="primary" variant="tonal">
             {{ getMembershipTypeLabel(npc.relation_type) }}
           </v-chip>
-          <span v-if="showRank && npc.notes?.rank" class="text-caption mr-2">
+          <span v-if="showRank && npc.notes?.rank" class="text-body-small mr-2">
             {{ $t('common.rank') }}: {{ npc.notes.rank }}
           </span>
-          <span v-if="npc.description" class="text-caption text-medium-emphasis">
+          <span v-if="npc.description" class="text-body-small text-medium-emphasis">
             {{ npc.description.substring(0, 100) }}{{ npc.description.length > 100 ? '...' : '' }}
           </span>
         </v-list-item-subtitle>

--- a/packages/app/app/components/shared/EntityPlayersTab.vue
+++ b/packages/app/app/components/shared/EntityPlayersTab.vue
@@ -26,7 +26,7 @@
           <v-chip v-if="relation.relation_type" size="small" class="mr-1">
             {{ $t(`${i18nPrefix}.${relation.relation_type}`, relation.relation_type) }}
           </v-chip>
-          <span v-if="relation.notes" class="text-caption">
+          <span v-if="relation.notes" class="text-body-small">
             {{ relation.notes }}
           </span>
         </v-list-item-subtitle>

--- a/packages/app/app/components/shared/EntityPreviewDialog.vue
+++ b/packages/app/app/components/shared/EntityPreviewDialog.vue
@@ -5,7 +5,7 @@
         <v-icon :icon="entityIcon" :color="entityColor" class="mr-2" />
         {{ entity.name }}
         <template v-if="normalizedEntityType === 'player' && entity.player_name">
-          <span class="text-body-2 text-medium-emphasis ml-2">
+          <span class="text-body-medium text-medium-emphasis ml-2">
             ({{ entity.player_name }})
           </span>
         </template>
@@ -24,11 +24,11 @@
             class="mb-4 rounded"
             cover
           />
-          <div v-if="entity.description" class="text-body-1 mb-4" style="white-space: pre-wrap">
+          <div v-if="entity.description" class="text-body-large mb-4" style="white-space: pre-wrap">
             {{ entity.description }}
           </div>
           <v-divider class="my-4" />
-          <div class="text-body-2">
+          <div class="text-body-medium">
             <div v-if="entity.race" class="mb-2">
               <strong>{{ $t('npcs.race') }}:</strong> {{ entity.race }}
             </div>
@@ -41,7 +41,7 @@
           </div>
           <div v-if="entity.notes" class="mt-4">
             <strong>{{ $t('common.notes') }}:</strong>
-            <div class="text-body-2 mt-2" style="white-space: pre-wrap">{{ entity.notes }}</div>
+            <div class="text-body-medium mt-2" style="white-space: pre-wrap">{{ entity.notes }}</div>
           </div>
 
           <!-- Linked NPCs -->
@@ -97,11 +97,11 @@
             class="mb-4 rounded"
             cover
           />
-          <div v-if="entity.description" class="text-body-1 mb-4" style="white-space: pre-wrap">
+          <div v-if="entity.description" class="text-body-large mb-4" style="white-space: pre-wrap">
             {{ entity.description }}
           </div>
           <v-divider class="my-4" />
-          <div class="text-body-2">
+          <div class="text-body-medium">
             <div v-if="entity.type" class="mb-2">
               <strong>{{ $t('locations.type') }}:</strong> {{ entity.type }}
             </div>
@@ -111,7 +111,7 @@
           </div>
           <div v-if="entity.notes" class="mt-4">
             <strong>{{ $t('common.notes') }}:</strong>
-            <div class="text-body-2 mt-2" style="white-space: pre-wrap">{{ entity.notes }}</div>
+            <div class="text-body-medium mt-2" style="white-space: pre-wrap">{{ entity.notes }}</div>
           </div>
         </template>
 
@@ -135,7 +135,7 @@
               {{ $t(`items.rarities.${entity.rarity}`) }}
             </v-chip>
           </div>
-          <div v-if="entity.description" class="text-body-1 mb-4" style="white-space: pre-wrap">
+          <div v-if="entity.description" class="text-body-large mb-4" style="white-space: pre-wrap">
             {{ entity.description }}
           </div>
           <v-divider class="my-4" />
@@ -151,7 +151,7 @@
           </div>
           <div v-if="entity.notes" class="mt-4">
             <strong>{{ $t('common.notes') }}:</strong>
-            <div class="text-body-2 mt-2" style="white-space: pre-wrap">{{ entity.notes }}</div>
+            <div class="text-body-medium mt-2" style="white-space: pre-wrap">{{ entity.notes }}</div>
           </div>
         </template>
 
@@ -165,11 +165,11 @@
             class="mb-4 rounded"
             cover
           />
-          <div v-if="entity.description" class="text-body-1 mb-4" style="white-space: pre-wrap">
+          <div v-if="entity.description" class="text-body-large mb-4" style="white-space: pre-wrap">
             {{ entity.description }}
           </div>
           <v-divider class="my-4" />
-          <div class="text-body-2">
+          <div class="text-body-medium">
             <div v-if="entity.leader" class="mb-2">
               <strong>{{ $t('factions.leader') }}:</strong> {{ entity.leader }}
             </div>
@@ -179,11 +179,11 @@
           </div>
           <div v-if="entity.goals" class="mt-4">
             <strong>{{ $t('factions.goals') }}:</strong>
-            <div class="text-body-2 mt-2" style="white-space: pre-wrap">{{ entity.goals }}</div>
+            <div class="text-body-medium mt-2" style="white-space: pre-wrap">{{ entity.goals }}</div>
           </div>
           <div v-if="entity.notes" class="mt-4">
             <strong>{{ $t('common.notes') }}:</strong>
-            <div class="text-body-2 mt-2" style="white-space: pre-wrap">{{ entity.notes }}</div>
+            <div class="text-body-medium mt-2" style="white-space: pre-wrap">{{ entity.notes }}</div>
           </div>
         </template>
 
@@ -197,11 +197,11 @@
             class="mb-4 rounded"
             cover
           />
-          <div v-if="entity.description" class="text-body-1 mb-4" style="white-space: pre-wrap">
+          <div v-if="entity.description" class="text-body-large mb-4" style="white-space: pre-wrap">
             {{ entity.description }}
           </div>
           <v-divider class="my-4" />
-          <div class="text-body-2">
+          <div class="text-body-medium">
             <div v-if="entity.type" class="mb-2">
               <strong>{{ $t('lore.type') }}:</strong>
               {{ $t(`lore.types.${entity.type}`) }}
@@ -212,7 +212,7 @@
           </div>
           <div v-if="entity.notes" class="mt-4">
             <strong>{{ $t('common.notes') }}:</strong>
-            <div class="text-body-2 mt-2" style="white-space: pre-wrap">{{ entity.notes }}</div>
+            <div class="text-body-medium mt-2" style="white-space: pre-wrap">{{ entity.notes }}</div>
           </div>
         </template>
 
@@ -226,11 +226,11 @@
             class="mb-4 rounded"
             cover
           />
-          <div v-if="entity.description" class="text-body-1 mb-4" style="white-space: pre-wrap">
+          <div v-if="entity.description" class="text-body-large mb-4" style="white-space: pre-wrap">
             {{ entity.description }}
           </div>
           <v-divider class="my-4" />
-          <div class="text-body-2">
+          <div class="text-body-medium">
             <div v-if="entity.player_name" class="mb-2">
               <strong>{{ $t('players.playerName') }}:</strong> {{ entity.player_name }}
             </div>
@@ -243,7 +243,7 @@
           </div>
           <div v-if="entity.notes" class="mt-4">
             <strong>{{ $t('common.notes') }}:</strong>
-            <div class="text-body-2 mt-2" style="white-space: pre-wrap">{{ entity.notes }}</div>
+            <div class="text-body-medium mt-2" style="white-space: pre-wrap">{{ entity.notes }}</div>
           </div>
           <!-- Stats -->
           <SharedEntityPreviewStats v-if="entityId" :entity-id="entityId" />

--- a/packages/app/app/components/shared/EntityPreviewStats.vue
+++ b/packages/app/app/components/shared/EntityPreviewStats.vue
@@ -3,23 +3,23 @@
     <v-divider class="mb-3" />
     <div class="d-flex align-center ga-2 mb-2">
       <v-icon icon="mdi-clipboard-list-outline" size="small" />
-      <span class="text-subtitle-2 font-weight-medium">{{ template.name }}</span>
+      <span class="text-title-small font-weight-medium">{{ template.name }}</span>
     </div>
 
     <div v-for="group in template.groups" :key="group.id" class="mb-3">
-      <div class="text-caption text-medium-emphasis mb-1">{{ resolveLabel(group.name) }}</div>
+      <div class="text-body-small text-medium-emphasis mb-1">{{ resolveLabel(group.name) }}</div>
 
       <!-- Attributes: compact grid -->
       <v-row v-if="group.group_type === 'attributes'" dense>
         <v-col v-for="f in group.fields" :key="f.id" cols="4" sm="3" md="2">
           <div class="text-center pa-1 rounded stat-cell">
-            <div class="text-caption text-medium-emphasis stat-label" :title="resolveLabel(f.label)">{{ resolveLabel(f.label) }}</div>
+            <div class="text-body-small text-medium-emphasis stat-label" :title="resolveLabel(f.label)">{{ resolveLabel(f.label) }}</div>
             <template v-if="f.field_type === 'number'">
-              <div class="text-body-1 font-weight-bold">{{ getNumber(f.name) }}</div>
+              <div class="text-body-large font-weight-bold">{{ getNumber(f.name) }}</div>
               <v-chip v-if="f.has_modifier" size="x-small" variant="tonal">{{ formatMod(getModifier(f.name)) }}</v-chip>
             </template>
             <template v-else-if="f.field_type === 'resource'">
-              <div class="text-body-2 font-weight-bold">{{ getResource(f.name).current }}/{{ getResource(f.name).max }}</div>
+              <div class="text-body-medium font-weight-bold">{{ getResource(f.name).current }}/{{ getResource(f.name).max }}</div>
               <v-progress-linear
                 v-if="getResource(f.name).max"
                 :model-value="(getResource(f.name).current / getResource(f.name).max) * 100"
@@ -32,7 +32,7 @@
             <template v-else-if="f.field_type === 'boolean'">
               <v-icon :icon="values[f.name] ? 'mdi-check' : 'mdi-close'" :color="values[f.name] ? 'success' : 'grey'" size="small" />
             </template>
-            <div v-else class="text-body-2">{{ values[f.name] || '—' }}</div>
+            <div v-else class="text-body-medium">{{ values[f.name] || '—' }}</div>
           </div>
         </v-col>
       </v-row>
@@ -41,9 +41,9 @@
       <v-row v-else-if="group.group_type === 'resources'" dense>
         <v-col v-for="f in group.fields" :key="f.id" cols="6" sm="4">
           <div class="pa-2 rounded stat-cell">
-            <div class="text-caption text-medium-emphasis stat-label" :title="resolveLabel(f.label)">{{ resolveLabel(f.label) }}</div>
+            <div class="text-body-small text-medium-emphasis stat-label" :title="resolveLabel(f.label)">{{ resolveLabel(f.label) }}</div>
             <template v-if="f.field_type === 'resource'">
-              <div class="text-body-2 font-weight-bold">{{ getResource(f.name).current }} / {{ getResource(f.name).max }}</div>
+              <div class="text-body-medium font-weight-bold">{{ getResource(f.name).current }} / {{ getResource(f.name).max }}</div>
               <v-progress-linear
                 v-if="getResource(f.name).max"
                 :model-value="(getResource(f.name).current / getResource(f.name).max) * 100"
@@ -53,7 +53,7 @@
                 class="mt-1"
               />
             </template>
-            <div v-else class="text-body-2 font-weight-bold">{{ values[f.name] || '—' }}</div>
+            <div v-else class="text-body-medium font-weight-bold">{{ values[f.name] || '—' }}</div>
           </div>
         </v-col>
       </v-row>
@@ -61,18 +61,18 @@
       <!-- Other groups: compact rows -->
       <div v-else>
         <div v-for="f in group.fields" :key="f.id" class="d-flex align-center ga-2 py-1">
-          <span class="text-caption text-medium-emphasis" style="min-width: 100px;">{{ resolveLabel(f.label) }}</span>
+          <span class="text-body-small text-medium-emphasis" style="min-width: 100px;">{{ resolveLabel(f.label) }}</span>
           <template v-if="f.field_type === 'number'">
-            <span class="text-body-2 font-weight-bold">{{ getNumber(f.name) }}</span>
+            <span class="text-body-medium font-weight-bold">{{ getNumber(f.name) }}</span>
             <v-chip v-if="f.has_modifier" size="x-small" variant="tonal">{{ formatMod(getModifier(f.name)) }}</v-chip>
           </template>
           <template v-else-if="f.field_type === 'resource'">
-            <span class="text-body-2 font-weight-bold">{{ getResource(f.name).current }}/{{ getResource(f.name).max }}</span>
+            <span class="text-body-medium font-weight-bold">{{ getResource(f.name).current }}/{{ getResource(f.name).max }}</span>
           </template>
           <template v-else-if="f.field_type === 'boolean'">
             <v-icon :icon="values[f.name] ? 'mdi-check' : 'mdi-close'" :color="values[f.name] ? 'success' : 'grey'" size="small" />
           </template>
-          <span v-else class="text-body-2">{{ values[f.name] || '—' }}</span>
+          <span v-else class="text-body-medium">{{ values[f.name] || '—' }}</span>
         </div>
       </div>
     </div>

--- a/packages/app/app/components/shared/EntityRelationsEditTab.vue
+++ b/packages/app/app/components/shared/EntityRelationsEditTab.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <!-- Title -->
-    <div class="text-h6 mb-4">
+    <div class="text-headline-small mb-4">
       {{ title }}
     </div>
 

--- a/packages/app/app/components/shared/EntityRelationsList.vue
+++ b/packages/app/app/components/shared/EntityRelationsList.vue
@@ -60,7 +60,7 @@
             </v-chip>
 
             <!-- Description -->
-            <span v-if="entity.description" class="text-caption text-medium-emphasis">
+            <span v-if="entity.description" class="text-body-small text-medium-emphasis">
               {{ entity.description }}
             </span>
           </div>

--- a/packages/app/app/components/shared/EntityStatsTab.vue
+++ b/packages/app/app/components/shared/EntityStatsTab.vue
@@ -5,10 +5,10 @@
     <!-- No template assigned -->
     <div v-else-if="!store.template" class="text-center py-8">
       <v-icon icon="mdi-clipboard-list-outline" size="48" color="grey" class="mb-4" />
-      <p class="text-body-1 text-medium-emphasis mb-2">{{ $t('entityStats.noTemplate') }}</p>
+      <p class="text-body-large text-medium-emphasis mb-2">{{ $t('entityStats.noTemplate') }}</p>
 
       <template v-if="!readonly">
-        <p class="text-body-2 text-medium-emphasis mb-6">{{ $t('entityStats.noTemplateHint') }}</p>
+        <p class="text-body-medium text-medium-emphasis mb-6">{{ $t('entityStats.noTemplateHint') }}</p>
 
         <div class="d-flex justify-center align-center ga-3 mb-4">
           <v-select
@@ -30,7 +30,7 @@
           </v-btn>
         </div>
 
-        <NuxtLink to="/reference-data" class="text-caption text-medium-emphasis">
+        <NuxtLink to="/reference-data" class="text-body-small text-medium-emphasis">
           {{ $t('entityStats.createTemplateLink') }}
         </NuxtLink>
       </template>
@@ -41,7 +41,7 @@
       <!-- Header -->
       <div class="d-flex align-center ga-2 mb-4">
         <v-icon icon="mdi-clipboard-list-outline" size="small" />
-        <span class="text-subtitle-1 font-weight-medium">{{ store.template.name }}</span>
+        <span class="text-title-medium font-weight-medium">{{ store.template.name }}</span>
         <v-chip v-if="store.template.system_key" size="x-small" variant="tonal" color="primary">
           {{ store.template.system_key }}
         </v-chip>
@@ -72,7 +72,7 @@
       <!-- Groups -->
       <div v-for="group in store.template.groups" :key="group.id" class="mb-4">
         <v-card variant="outlined">
-          <v-card-title class="text-subtitle-2 py-2 px-4">
+          <v-card-title class="text-title-small py-2 px-4">
             {{ resolveLabel(group.name) }}
             <v-chip size="x-small" variant="tonal" class="ml-2">
               {{ $t(`statTemplates.groups.types.${group.group_type}`, group.group_type) }}
@@ -91,11 +91,11 @@
                 :lg="f.field_type === 'textarea' ? 12 : 2"
               >
                 <div class="text-center pa-2 rounded stat-cell">
-                  <div class="text-caption text-medium-emphasis mb-1">{{ resolveLabel(f.label) }}</div>
+                  <div class="text-body-small text-medium-emphasis mb-1">{{ resolveLabel(f.label) }}</div>
                   <!-- Number -->
                   <template v-if="f.field_type === 'number'">
                     <template v-if="readonly">
-                      <div class="text-h5 font-weight-bold">{{ getNumberParsed(f.name).value || '—' }}</div>
+                      <div class="text-headline-medium font-weight-bold">{{ getNumberParsed(f.name).value || '—' }}</div>
                       <div v-if="f.has_modifier" class="d-flex justify-center mt-1">
                         <v-chip size="small" variant="tonal">{{ formatModifier(getNumberParsed(f.name).modifier) }}</v-chip>
                       </div>
@@ -125,7 +125,7 @@
                   </template>
                   <!-- String -->
                   <template v-else-if="f.field_type === 'string'">
-                    <div v-if="readonly" class="text-body-1">{{ store.localValues[f.name] || '—' }}</div>
+                    <div v-if="readonly" class="text-body-large">{{ store.localValues[f.name] || '—' }}</div>
                     <v-text-field
                       v-else
                       :model-value="String(store.localValues[f.name] ?? '')"
@@ -137,7 +137,7 @@
                   </template>
                   <!-- Textarea -->
                   <template v-else-if="f.field_type === 'textarea'">
-                    <div v-if="readonly" class="text-body-2" style="white-space: pre-wrap; max-height: 200px; overflow-y: auto">{{ store.localValues[f.name] || '—' }}</div>
+                    <div v-if="readonly" class="text-body-medium" style="white-space: pre-wrap; max-height: 200px; overflow-y: auto">{{ store.localValues[f.name] || '—' }}</div>
                     <v-textarea
                       v-else
                       :model-value="String(store.localValues[f.name] ?? '')"
@@ -174,7 +174,7 @@
                           style="max-width: 70px;"
                           @update:model-value="(v: string) => onResourceCurrentChange(f.name, Number(v) || 0)"
                         />
-                        <span class="text-body-2 text-medium-emphasis">/ {{ getResource(f.name).max }}</span>
+                        <span class="text-body-medium text-medium-emphasis">/ {{ getResource(f.name).max }}</span>
                       </div>
                     </template>
                     <template v-else>
@@ -222,7 +222,7 @@
                 :md="f.field_type === 'textarea' ? 12 : 4"
               >
                 <div class="pa-3 rounded stat-cell">
-                  <div class="text-caption text-medium-emphasis mb-1">{{ resolveLabel(f.label) }}</div>
+                  <div class="text-body-small text-medium-emphasis mb-1">{{ resolveLabel(f.label) }}</div>
                   <!-- Resource -->
                   <template v-if="f.field_type === 'resource'">
                     <template v-if="readonly">
@@ -237,7 +237,7 @@
                           style="max-width: 100px;"
                           @update:model-value="(v: string) => onResourceCurrentChange(f.name, Number(v) || 0)"
                         />
-                        <span class="text-body-2 text-medium-emphasis">/ {{ getResource(f.name).max }}</span>
+                        <span class="text-body-medium text-medium-emphasis">/ {{ getResource(f.name).max }}</span>
                       </div>
                     </template>
                     <template v-else>
@@ -274,7 +274,7 @@
                   <!-- Number -->
                   <template v-else-if="f.field_type === 'number'">
                     <template v-if="readonly">
-                      <div class="text-h6 font-weight-bold">{{ getNumberParsed(f.name).value || '—' }}</div>
+                      <div class="text-headline-small font-weight-bold">{{ getNumberParsed(f.name).value || '—' }}</div>
                       <div v-if="f.has_modifier" class="mt-1">
                         <v-chip size="small" variant="tonal">{{ formatModifier(getNumberParsed(f.name).modifier) }}</v-chip>
                       </div>
@@ -313,7 +313,7 @@
                   </template>
                   <!-- String -->
                   <template v-else-if="f.field_type === 'string'">
-                    <div v-if="readonly" class="text-body-1">{{ store.localValues[f.name] || '—' }}</div>
+                    <div v-if="readonly" class="text-body-large">{{ store.localValues[f.name] || '—' }}</div>
                     <v-text-field
                       v-else
                       :model-value="String(store.localValues[f.name] ?? '')"
@@ -325,7 +325,7 @@
                   </template>
                   <!-- Textarea -->
                   <template v-else-if="f.field_type === 'textarea'">
-                    <div v-if="readonly" class="text-body-2" style="white-space: pre-wrap; max-height: 200px; overflow-y: auto">{{ store.localValues[f.name] || '—' }}</div>
+                    <div v-if="readonly" class="text-body-medium" style="white-space: pre-wrap; max-height: 200px; overflow-y: auto">{{ store.localValues[f.name] || '—' }}</div>
                     <v-textarea
                       v-else
                       :model-value="String(store.localValues[f.name] ?? '')"
@@ -349,13 +349,13 @@
                 :key="f.id"
                 class="d-flex align-center ga-3 py-2 px-2 rounded field-row"
               >
-                <span class="text-body-2 font-weight-medium" style="min-width: 140px;">
+                <span class="text-body-medium font-weight-medium" style="min-width: 140px;">
                   {{ resolveLabel(f.label) }}
                 </span>
                 <!-- Number -->
                 <template v-if="f.field_type === 'number'">
                   <template v-if="readonly">
-                    <span class="text-body-1 font-weight-bold">{{ getNumberParsed(f.name).value || '—' }}</span>
+                    <span class="text-body-large font-weight-bold">{{ getNumberParsed(f.name).value || '—' }}</span>
                     <v-chip v-if="f.has_modifier" size="small" variant="tonal">
                       {{ formatModifier(getNumberParsed(f.name).modifier) }}
                     </v-chip>
@@ -387,7 +387,7 @@
                 </template>
                 <!-- String -->
                 <template v-else-if="f.field_type === 'string'">
-                  <span v-if="readonly" class="text-body-2">{{ store.localValues[f.name] || '—' }}</span>
+                  <span v-if="readonly" class="text-body-medium">{{ store.localValues[f.name] || '—' }}</span>
                   <v-text-field
                     v-else
                     :model-value="String(store.localValues[f.name] ?? '')"
@@ -400,7 +400,7 @@
                 </template>
                 <!-- Textarea -->
                 <template v-else-if="f.field_type === 'textarea'">
-                  <div v-if="readonly" class="text-body-2 flex-grow-1" style="white-space: pre-wrap; max-height: 200px; overflow-y: auto">{{ store.localValues[f.name] || '—' }}</div>
+                  <div v-if="readonly" class="text-body-medium flex-grow-1" style="white-space: pre-wrap; max-height: 200px; overflow-y: auto">{{ store.localValues[f.name] || '—' }}</div>
                   <v-textarea
                     v-else
                     :model-value="String(store.localValues[f.name] ?? '')"
@@ -437,7 +437,7 @@
                         style="max-width: 80px;"
                         @update:model-value="(v: string) => onResourceCurrentChange(f.name, Number(v) || 0)"
                       />
-                      <span class="text-body-2 text-medium-emphasis">/ {{ getResource(f.name).max }}</span>
+                      <span class="text-body-medium text-medium-emphasis">/ {{ getResource(f.name).max }}</span>
                     </div>
                   </template>
                   <template v-else>
@@ -473,7 +473,7 @@
       <v-divider class="my-4" />
       <div class="d-flex align-center ga-2 mb-3">
         <v-icon icon="mdi-file-pdf-box" size="small" />
-        <span class="text-subtitle-2">{{ $t('entityStats.characterSheet') }}</span>
+        <span class="text-title-small">{{ $t('entityStats.characterSheet') }}</span>
         <v-spacer />
         <template v-if="!readonly">
           <v-btn
@@ -497,7 +497,7 @@
 
       <template v-if="store.characterSheets.length > 0">
         <v-card v-for="sheet in store.characterSheets" :key="sheet.id" variant="outlined" class="mb-3">
-          <v-card-title class="d-flex align-center text-subtitle-2 py-2 px-4">
+          <v-card-title class="d-flex align-center text-title-small py-2 px-4">
             <v-icon icon="mdi-file-pdf-box" color="error" class="mr-2" size="small" />
             {{ sheet.title }}
             <v-spacer />

--- a/packages/app/app/components/shared/FeatureTooltip.vue
+++ b/packages/app/app/components/shared/FeatureTooltip.vue
@@ -1,0 +1,296 @@
+<template>
+  <div ref="wrapper" class="feature-bubble-wrapper" @click.capture="onWrapperClick">
+    <slot />
+
+    <ClientOnly>
+      <Teleport to="body">
+        <Transition name="bubble-fade">
+          <div
+            v-if="shouldShow && anchor"
+            ref="bubbleEl"
+            class="feature-bubble"
+            :class="`feature-bubble--${effectiveLocation}`"
+            :style="bubbleStyle"
+            role="status"
+            @click.stop="onBubbleClick"
+          >
+            <div class="feature-bubble__arrow" :style="arrowStyle" />
+            <div class="feature-bubble__header">
+              <i class="mdi mdi-sparkles feature-bubble__icon" aria-hidden="true" />
+              <span class="feature-bubble__title">
+                {{ $t('featureTooltips.newBadge') }}
+              </span>
+            </div>
+            <div class="feature-bubble__text">
+              {{ text }}
+            </div>
+            <v-checkbox
+              v-model="dontShowAgain"
+              :label="$t('featureTooltips.dontShowAgain')"
+              density="compact"
+              hide-details
+              color="on-primary"
+              class="feature-bubble__checkbox"
+              @click.stop
+            />
+          </div>
+        </Transition>
+      </Teleport>
+    </ClientOnly>
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { CSSProperties } from 'vue'
+import { useFeatureTooltip } from '~/composables/useFeatureTooltips'
+
+type Location = 'top' | 'bottom' | 'start' | 'end'
+
+const props = withDefaults(defineProps<{
+  featureKey: string
+  text: string
+  /** Preferred side; will flip automatically if there's no room. */
+  location?: Location
+}>(), {
+  location: 'end',
+})
+
+const { shouldShow, dismissForSession, dismissPermanent } = useFeatureTooltip(props.featureKey)
+
+const wrapper = ref<HTMLElement | null>(null)
+const bubbleEl = ref<HTMLElement | null>(null)
+
+const dontShowAgain = ref(false)
+const anchor = ref<DOMRect | null>(null)
+const bubbleSize = ref<{ w: number, h: number }>({ w: 0, h: 0 })
+const effectiveLocation = ref<Location>(props.location)
+
+const GAP = 14
+const VIEWPORT_MARGIN = 12 // keep bubble at least this far from edges
+
+/** Side preference may flip when there's no room. */
+function pickEffectiveLocation(rect: DOMRect, bw: number, bh: number): Location {
+  const vw = window.innerWidth
+  const vh = window.innerHeight
+  const preferred = props.location
+
+  // Fits in preferred direction?
+  const fits = {
+    end: rect.right + GAP + bw <= vw - VIEWPORT_MARGIN,
+    start: rect.left - GAP - bw >= VIEWPORT_MARGIN,
+    bottom: rect.bottom + GAP + bh <= vh - VIEWPORT_MARGIN,
+    top: rect.top - GAP - bh >= VIEWPORT_MARGIN,
+  }
+  if (fits[preferred]) return preferred
+
+  // Try opposite axis first, then the orthogonal sides.
+  const order: Record<Location, Location[]> = {
+    end: ['start', 'bottom', 'top'],
+    start: ['end', 'bottom', 'top'],
+    bottom: ['top', 'end', 'start'],
+    top: ['bottom', 'end', 'start'],
+  }
+  for (const candidate of order[preferred]) {
+    if (fits[candidate]) return candidate
+  }
+  return preferred
+}
+
+const bubbleStyle = computed<CSSProperties>(() => {
+  const rect = anchor.value
+  if (!rect) return {}
+  const { w: bw, h: bh } = bubbleSize.value
+  const vw = window.innerWidth
+  const vh = window.innerHeight
+
+  const loc = effectiveLocation.value
+  let top: number
+  let left: number
+
+  if (loc === 'end' || loc === 'start') {
+    const idealTop = rect.top + rect.height / 2 - bh / 2
+    top = clamp(idealTop, VIEWPORT_MARGIN, vh - bh - VIEWPORT_MARGIN)
+    left = loc === 'end' ? rect.right + GAP : rect.left - GAP - bw
+  }
+  else {
+    const idealLeft = rect.left + rect.width / 2 - bw / 2
+    left = clamp(idealLeft, VIEWPORT_MARGIN, vw - bw - VIEWPORT_MARGIN)
+    top = loc === 'bottom' ? rect.bottom + GAP : rect.top - GAP - bh
+  }
+  return { top: `${top}px`, left: `${left}px` }
+})
+
+const arrowStyle = computed<CSSProperties>(() => {
+  const rect = anchor.value
+  if (!rect) return {}
+  const styleObj = bubbleStyle.value
+  const bubbleTop = parseFloat(String(styleObj.top ?? '0'))
+  const bubbleLeft = parseFloat(String(styleObj.left ?? '0'))
+
+  const loc = effectiveLocation.value
+  if (loc === 'end' || loc === 'start') {
+    // Pin arrow vertically at anchor center
+    const arrowTop = rect.top + rect.height / 2 - bubbleTop
+    return { top: `${arrowTop}px` }
+  }
+  // top/bottom — pin horizontally at anchor center
+  const arrowLeft = rect.left + rect.width / 2 - bubbleLeft
+  return { left: `${arrowLeft}px` }
+})
+
+function clamp(v: number, min: number, max: number) {
+  return Math.max(min, Math.min(max, v))
+}
+
+function measure() {
+  if (!wrapper.value) return
+  // Anchor on the first child (= the wrapped target), so the arrow points at it.
+  const el = (wrapper.value.firstElementChild as HTMLElement) ?? wrapper.value
+  const rect = el.getBoundingClientRect()
+  if (rect.width === 0 && rect.height === 0) {
+    anchor.value = null
+    return
+  }
+  anchor.value = rect
+
+  // Measure bubble size if mounted, then pick best side.
+  nextTick(() => {
+    if (bubbleEl.value) {
+      const br = bubbleEl.value.getBoundingClientRect()
+      bubbleSize.value = { w: br.width, h: br.height }
+    }
+    effectiveLocation.value = pickEffectiveLocation(
+      rect,
+      bubbleSize.value.w || 260,
+      bubbleSize.value.h || 140,
+    )
+  })
+}
+
+/** rAF-throttled measure so we don't getBoundingClientRect on every scroll pixel */
+let rafId: number | null = null
+function scheduleMeasure() {
+  if (rafId !== null) return
+  rafId = requestAnimationFrame(() => {
+    rafId = null
+    measure()
+  })
+}
+
+function close() {
+  if (dontShowAgain.value) dismissPermanent()
+  else dismissForSession()
+}
+
+function onBubbleClick() {
+  close()
+}
+
+function onWrapperClick(e: MouseEvent) {
+  if (!shouldShow.value || !wrapper.value) return
+  const target = e.target as HTMLElement | null
+  if (target && wrapper.value.contains(target)) close()
+}
+
+onMounted(() => {
+  nextTick(measure)
+  window.addEventListener('resize', scheduleMeasure)
+  window.addEventListener('scroll', scheduleMeasure, true)
+})
+onBeforeUnmount(() => {
+  window.removeEventListener('resize', scheduleMeasure)
+  window.removeEventListener('scroll', scheduleMeasure, true)
+  if (rafId !== null) cancelAnimationFrame(rafId)
+})
+watch(shouldShow, (v) => {
+  if (v) nextTick(measure)
+})
+</script>
+
+<script lang="ts">
+export default { name: 'FeatureTooltip' }
+</script>
+
+<style scoped>
+.feature-bubble-wrapper {
+  position: relative;
+}
+</style>
+
+<!-- Global because the bubble is teleported to <body> and would lose scoped styles -->
+<style>
+.feature-bubble {
+  position: fixed;
+  z-index: 2400;
+  min-width: 240px;
+  max-width: 320px;
+  padding: 12px 14px;
+  background: rgb(var(--v-theme-primary));
+  color: rgb(var(--v-theme-on-primary));
+  border-radius: 10px;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.3);
+  cursor: pointer;
+  user-select: none;
+  font-family: inherit;
+}
+
+.feature-bubble__arrow {
+  position: absolute;
+  width: 12px;
+  height: 12px;
+  background: rgb(var(--v-theme-primary));
+}
+
+/* arrow sits on the side facing the anchor */
+.feature-bubble--end .feature-bubble__arrow {
+  inset-inline-start: -6px;
+  transform: translateY(-50%) rotate(45deg);
+}
+.feature-bubble--start .feature-bubble__arrow {
+  inset-inline-end: -6px;
+  transform: translateY(-50%) rotate(45deg);
+}
+.feature-bubble--bottom .feature-bubble__arrow {
+  top: -6px;
+  transform: translateX(-50%) rotate(45deg);
+}
+.feature-bubble--top .feature-bubble__arrow {
+  bottom: -6px;
+  transform: translateX(-50%) rotate(45deg);
+}
+
+.feature-bubble__header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 6px;
+}
+.feature-bubble__icon {
+  font-size: 18px;
+  line-height: 1;
+}
+.feature-bubble__title {
+  font-weight: 700;
+  font-size: 0.875rem;
+  letter-spacing: 0.02em;
+}
+.feature-bubble__text {
+  font-size: 0.85rem;
+  line-height: 1.4;
+  margin-bottom: 8px;
+}
+.feature-bubble__checkbox .v-label {
+  font-size: 0.75rem;
+  opacity: 0.9;
+  color: rgb(var(--v-theme-on-primary));
+}
+
+.bubble-fade-enter-active,
+.bubble-fade-leave-active {
+  transition: opacity 0.2s ease;
+}
+.bubble-fade-enter-from,
+.bubble-fade-leave-to {
+  opacity: 0;
+}
+</style>

--- a/packages/app/app/components/shared/ImagePreviewDialog.vue
+++ b/packages/app/app/components/shared/ImagePreviewDialog.vue
@@ -8,7 +8,7 @@
       <v-card-title class="d-flex justify-space-between align-center">
         <div class="d-flex flex-column flex-grow-1">
           <span>{{ title }}</span>
-          <span v-if="subtitle" class="text-caption text-medium-emphasis">{{ subtitle }}</span>
+          <span v-if="subtitle" class="text-body-small text-medium-emphasis">{{ subtitle }}</span>
         </div>
         <v-btn icon="mdi-close" variant="text" @click="$emit('update:model-value', false)" />
       </v-card-title>

--- a/packages/app/app/components/shared/LocationSelectWithMap.vue
+++ b/packages/app/app/components/shared/LocationSelectWithMap.vue
@@ -18,17 +18,17 @@
       persistent-hint
       @update:model-value="onLocationChange"
     >
-      <template #item="{ item, props: itemProps }">
+      <template #item="{ internalItem, props: itemProps }">
         <v-list-item v-bind="itemProps">
           <template #prepend>
             <v-avatar size="32" color="#8B7355">
-              <v-img v-if="item.raw.image_url" :src="`/uploads/${item.raw.image_url}`" />
+              <v-img v-if="internalItem.raw.image_url" :src="`/uploads/${internalItem.raw.image_url}`" />
               <v-icon v-else icon="mdi-map-marker" size="small" />
             </v-avatar>
           </template>
           <template #subtitle>
-            <span v-if="item.raw.description" class="text-truncate">
-              {{ item.raw.description?.substring(0, 50) }}{{ item.raw.description?.length > 50 ? '...' : '' }}
+            <span v-if="internalItem.raw.description" class="text-truncate">
+              {{ internalItem.raw.description?.substring(0, 50) }}{{ internalItem.raw.description?.length > 50 ? '...' : '' }}
             </span>
           </template>
         </v-list-item>
@@ -63,9 +63,9 @@
             :hint="$t('entities.selectMapsHint')"
             persistent-hint
           >
-            <template #chip="{ item, props: chipProps }">
+            <template #chip="{ internalItem, props: chipProps }">
               <v-chip v-bind="chipProps" size="small">
-                {{ item.title }}
+                {{ internalItem.title }}
               </v-chip>
             </template>
           </v-select>

--- a/packages/app/app/components/shared/Pinboard.vue
+++ b/packages/app/app/components/shared/Pinboard.vue
@@ -165,8 +165,8 @@ defineExpose({
 
           <div v-else-if="localPins.length === 0" class="text-center py-4 text-medium-emphasis">
             <v-icon size="48" class="mb-2" color="grey">mdi-pin-off</v-icon>
-            <div class="text-body-2">{{ t('pinboard.empty') }}</div>
-            <div class="text-caption">{{ t('pinboard.emptyHint') }}</div>
+            <div class="text-body-medium">{{ t('pinboard.empty') }}</div>
+            <div class="text-body-small">{{ t('pinboard.emptyHint') }}</div>
           </div>
 
           <draggable

--- a/packages/app/app/components/shared/QuickLinkContextMenu.vue
+++ b/packages/app/app/components/shared/QuickLinkContextMenu.vue
@@ -18,7 +18,7 @@
           <template #prepend>
             <v-icon :icon="config.icon" size="small" class="mr-2" />
           </template>
-          <v-list-item-title class="text-body-2">
+          <v-list-item-title class="text-body-medium">
             {{ $t(config.labelKey) }}
           </v-list-item-title>
         </v-list-item>
@@ -28,7 +28,7 @@
           <template #prepend>
             <v-icon :icon="config.icon" size="small" class="mr-2" />
           </template>
-          <v-list-item-title class="text-body-2">
+          <v-list-item-title class="text-body-medium">
             {{ $t(config.labelKey) }}
           </v-list-item-title>
           <template #append>
@@ -50,7 +50,7 @@
                 class="px-3"
                 @click="handleSelect(config.targetType, relationType)"
               >
-                <v-list-item-title class="text-body-2">
+                <v-list-item-title class="text-body-medium">
                   {{ $t(`${config.i18nPrefix}.${relationType}`, relationType) }}
                 </v-list-item-title>
               </v-list-item>
@@ -67,7 +67,7 @@
         <template #prepend>
           <v-icon icon="mdi-folder-plus" size="small" class="mr-2" />
         </template>
-        <v-list-item-title class="text-body-2">
+        <v-list-item-title class="text-body-medium">
           {{ $t('quickLink.addToGroup') }}
         </v-list-item-title>
         <template #append>
@@ -95,7 +95,7 @@
                   <v-icon :icon="group.icon || 'mdi-folder'" size="small" />
                 </v-avatar>
               </template>
-              <v-list-item-title class="text-body-2">
+              <v-list-item-title class="text-body-medium">
                 {{ group.name }}
               </v-list-item-title>
               <template v-if="isInGroup(group.id)" #append>
@@ -109,7 +109,7 @@
               <template #prepend>
                 <v-icon icon="mdi-plus" size="small" class="mr-2" />
               </template>
-              <v-list-item-title class="text-body-2">
+              <v-list-item-title class="text-body-medium">
                 {{ $t('quickLink.createGroup') }}
               </v-list-item-title>
             </v-list-item>

--- a/packages/app/app/components/stat-templates/Editor.vue
+++ b/packages/app/app/components/stat-templates/Editor.vue
@@ -94,8 +94,8 @@
     <!-- No template selected -->
     <div v-if="!currentTemplate" class="text-center py-8">
       <v-icon icon="mdi-clipboard-list-outline" size="48" color="grey" class="mb-4" />
-      <p class="text-body-1 text-medium-emphasis">{{ $t('statTemplates.noTemplates') }}</p>
-      <p class="text-body-2 text-medium-emphasis">{{ $t('statTemplates.noTemplatesHint') }}</p>
+      <p class="text-body-large text-medium-emphasis">{{ $t('statTemplates.noTemplates') }}</p>
+      <p class="text-body-medium text-medium-emphasis">{{ $t('statTemplates.noTemplatesHint') }}</p>
     </div>
 
     <!-- Template editor: name + description + groups -->
@@ -130,7 +130,7 @@
             </v-chip>
           </template>
           <v-card min-width="280" max-width="400">
-            <v-card-title class="text-subtitle-2 py-2">
+            <v-card-title class="text-title-small py-2">
               {{ $t('statTemplates.usedBy') }}
             </v-card-title>
             <v-divider />

--- a/packages/app/app/components/stat-templates/Editor.vue
+++ b/packages/app/app/components/stat-templates/Editor.vue
@@ -13,14 +13,14 @@
         style="max-width: 500px;"
         :disabled="isDirty"
       >
-        <template #item="{ item, props: itemProps }">
+        <template #item="{ internalItem, props: itemProps }">
           <v-list-item v-bind="itemProps">
-            <template v-if="item.raw.systemKey || item.raw.isImported" #append>
-              <v-chip v-if="item.raw.isImported" size="x-small" variant="tonal" color="info" class="mr-1">
+            <template v-if="internalItem.raw.systemKey || internalItem.raw.isImported" #append>
+              <v-chip v-if="internalItem.raw.isImported" size="x-small" variant="tonal" color="info" class="mr-1">
                 {{ $t('statTemplates.importedBadge') }}
               </v-chip>
-              <v-chip v-if="item.raw.systemKey" size="x-small" variant="tonal" color="primary">
-                {{ $t(`statPresets.${item.raw.systemKey}.name`, item.raw.systemKey) }}
+              <v-chip v-if="internalItem.raw.systemKey" size="x-small" variant="tonal" color="primary">
+                {{ $t(`statPresets.${internalItem.raw.systemKey}.name`, internalItem.raw.systemKey) }}
               </v-chip>
             </template>
           </v-list-item>

--- a/packages/app/app/components/stat-templates/FieldRow.vue
+++ b/packages/app/app/components/stat-templates/FieldRow.vue
@@ -8,7 +8,7 @@
     <!-- Display mode -->
     <template v-if="!editing">
       <div class="flex-grow-1 d-flex align-center ga-2">
-        <span class="text-body-2 font-weight-medium">{{ displayLabel }}</span>
+        <span class="text-body-medium font-weight-medium">{{ displayLabel }}</span>
         <v-chip size="x-small" variant="tonal" :color="fieldTypeColor">
           {{ $t(`statTemplates.fields.types.${field.field_type}`) }}
         </v-chip>

--- a/packages/app/app/components/stat-templates/GroupEditor.vue
+++ b/packages/app/app/components/stat-templates/GroupEditor.vue
@@ -5,7 +5,7 @@
         mdi-drag-horizontal
       </v-icon>
 
-      <span class="text-subtitle-1 font-weight-medium flex-grow-1">
+      <span class="text-title-medium font-weight-medium flex-grow-1">
         {{ displayName }}
       </span>
 

--- a/packages/app/app/components/ui/PageHeader.vue
+++ b/packages/app/app/components/ui/PageHeader.vue
@@ -1,10 +1,10 @@
 <template>
   <div class="d-flex justify-space-between align-center mb-6">
     <div>
-      <h1 class="text-h3 mb-2">
+      <h1 class="text-display-small mb-2">
         {{ title }}
       </h1>
-      <p class="text-body-1 text-medium-emphasis">
+      <p class="text-body-large text-medium-emphasis">
         {{ subtitle }}
       </p>
     </div>

--- a/packages/app/app/composables/themes.ts
+++ b/packages/app/app/composables/themes.ts
@@ -1,0 +1,276 @@
+import type { ThemeDefinition } from 'vuetify'
+
+/**
+ * DM Hero themes — 7 total: dark (default), hell, and 5 colored.
+ * Each defines vuetify palette + md-editor-v3 css vars.
+ */
+
+// "Midnight Tavern" — default
+const dark: ThemeDefinition = {
+  dark: true,
+  colors: {
+    'background': '#1A1D29',
+    'surface': '#232632',
+    'surface-variant': '#2D3142',
+    'on-surface-variant': '#C5B8A0',
+    'primary': '#D4A574',
+    'primary-darken-1': '#B8935F',
+    'secondary': '#8B7355',
+    'secondary-darken-1': '#6B5742',
+    'accent': '#CC8844',
+    'error': '#D32F2F',
+    'info': '#7B92AB',
+    'success': '#689F38',
+    'warning': '#F9A825',
+    'on-background': '#E8DCC4',
+    'on-surface': '#E8DCC4',
+    'on-primary': '#1A1D29',
+    'on-secondary': '#E8DCC4',
+  },
+  variables: {
+    'md-bg': '#1A1D29',
+    'md-surface': '#232632',
+    'md-text': '#E8DCC4',
+    'md-muted': '#C5B8A0',
+    'md-border': '#2D3142',
+    'md-primary': '#D4A574',
+    'md-code-bg': '#11151F',
+    'md-quote-bg': '#202534',
+    'md-table-stripe': '#1F2330',
+  },
+}
+
+// "Aged Parchment" — light
+const hell: ThemeDefinition = {
+  dark: false,
+  colors: {
+    'background': '#F5F1E8',
+    'surface': '#FFFFFF',
+    'surface-variant': '#E8DCC4',
+    'on-surface-variant': '#4A4035',
+    'primary': '#8B4513',
+    'primary-darken-1': '#654321',
+    'secondary': '#B8860B',
+    'secondary-darken-1': '#996515',
+    'accent': '#8B0000',
+    'error': '#C62828',
+    'info': '#5B7C99',
+    'success': '#558B2F',
+    'warning': '#F57C00',
+    'on-background': '#2C1810',
+    'on-surface': '#2C1810',
+    'on-primary': '#FFFFFF',
+    'on-secondary': '#2C1810',
+  },
+  variables: {
+    'md-bg': '#FFFFFF',
+    'md-surface': '#F5F1E8',
+    'md-text': '#2C1810',
+    'md-muted': '#4A4035',
+    'md-border': '#E8DCC4',
+    'md-primary': '#8B4513',
+    'md-code-bg': '#FAF6EE',
+    'md-quote-bg': '#FFF9F0',
+    'md-table-stripe': '#FAF2E3',
+  },
+}
+
+// "Ubuntu" — pink/violet, warm dark base
+const linux: ThemeDefinition = {
+  dark: true,
+  colors: {
+    'background': '#2C001E',
+    'surface': '#3D0B2C',
+    'surface-variant': '#4B1639',
+    'on-surface-variant': '#E8B8D8',
+    'primary': '#E95420',
+    'primary-darken-1': '#C44520',
+    'secondary': '#AEA79F',
+    'secondary-darken-1': '#7D7A78',
+    'accent': '#DD4814',
+    'error': '#DF382C',
+    'info': '#19B6EE',
+    'success': '#38B44A',
+    'warning': '#EFB73E',
+    'on-background': '#F7E8F0',
+    'on-surface': '#F7E8F0',
+    'on-primary': '#FFFFFF',
+    'on-secondary': '#2C001E',
+  },
+  variables: {
+    'md-bg': '#2C001E',
+    'md-surface': '#3D0B2C',
+    'md-text': '#F7E8F0',
+    'md-muted': '#E8B8D8',
+    'md-border': '#4B1639',
+    'md-primary': '#E95420',
+    'md-code-bg': '#1F0014',
+    'md-quote-bg': '#350B26',
+    'md-table-stripe': '#330620',
+  },
+}
+
+// "Forest" — mint/green
+const green: ThemeDefinition = {
+  dark: true,
+  colors: {
+    'background': '#0F1F1A',
+    'surface': '#172D26',
+    'surface-variant': '#1F3D33',
+    'on-surface-variant': '#B8D8C5',
+    'primary': '#4CAF7C',
+    'primary-darken-1': '#388E5B',
+    'secondary': '#7CB89A',
+    'secondary-darken-1': '#5A9577',
+    'accent': '#FFCA28',
+    'error': '#E57373',
+    'info': '#64B5F6',
+    'success': '#66BB6A',
+    'warning': '#FFA726',
+    'on-background': '#E0F2E9',
+    'on-surface': '#E0F2E9',
+    'on-primary': '#0F1F1A',
+    'on-secondary': '#0F1F1A',
+  },
+  variables: {
+    'md-bg': '#0F1F1A',
+    'md-surface': '#172D26',
+    'md-text': '#E0F2E9',
+    'md-muted': '#B8D8C5',
+    'md-border': '#1F3D33',
+    'md-primary': '#4CAF7C',
+    'md-code-bg': '#0A1612',
+    'md-quote-bg': '#142822',
+    'md-table-stripe': '#142823',
+  },
+}
+
+// "Ocean" — cool blue
+const blue: ThemeDefinition = {
+  dark: true,
+  colors: {
+    'background': '#0D1B2A',
+    'surface': '#16263A',
+    'surface-variant': '#1E3149',
+    'on-surface-variant': '#B0CCE0',
+    'primary': '#4FC3F7',
+    'primary-darken-1': '#0288D1',
+    'secondary': '#5F8FB5',
+    'secondary-darken-1': '#3D6B8C',
+    'accent': '#FF9100',
+    'error': '#EF5350',
+    'info': '#42A5F5',
+    'success': '#66BB6A',
+    'warning': '#FFA726',
+    'on-background': '#E1F0FA',
+    'on-surface': '#E1F0FA',
+    'on-primary': '#0D1B2A',
+    'on-secondary': '#0D1B2A',
+  },
+  variables: {
+    'md-bg': '#0D1B2A',
+    'md-surface': '#16263A',
+    'md-text': '#E1F0FA',
+    'md-muted': '#B0CCE0',
+    'md-border': '#1E3149',
+    'md-primary': '#4FC3F7',
+    'md-code-bg': '#0A1420',
+    'md-quote-bg': '#142235',
+    'md-table-stripe': '#142133',
+  },
+}
+
+// "Arcane" — purple/mystic
+const purple: ThemeDefinition = {
+  dark: true,
+  colors: {
+    'background': '#1A0F2E',
+    'surface': '#261943',
+    'surface-variant': '#322355',
+    'on-surface-variant': '#D0B8E8',
+    'primary': '#B388FF',
+    'primary-darken-1': '#7C4DFF',
+    'secondary': '#9575CD',
+    'secondary-darken-1': '#673AB7',
+    'accent': '#FFD740',
+    'error': '#FF5252',
+    'info': '#7986CB',
+    'success': '#69F0AE',
+    'warning': '#FFAB40',
+    'on-background': '#EDE0FA',
+    'on-surface': '#EDE0FA',
+    'on-primary': '#1A0F2E',
+    'on-secondary': '#1A0F2E',
+  },
+  variables: {
+    'md-bg': '#1A0F2E',
+    'md-surface': '#261943',
+    'md-text': '#EDE0FA',
+    'md-muted': '#D0B8E8',
+    'md-border': '#322355',
+    'md-primary': '#B388FF',
+    'md-code-bg': '#120A20',
+    'md-quote-bg': '#22153D',
+    'md-table-stripe': '#22153D',
+  },
+}
+
+// "Ember" — warm orange, like a campfire
+const orange: ThemeDefinition = {
+  dark: true,
+  colors: {
+    'background': '#1F1410',
+    'surface': '#2E1F18',
+    'surface-variant': '#3E2A21',
+    'on-surface-variant': '#E8C5B0',
+    'primary': '#FF7043',
+    'primary-darken-1': '#E64A19',
+    'secondary': '#BCAAA4',
+    'secondary-darken-1': '#8D6E63',
+    'accent': '#FFCA28',
+    'error': '#E53935',
+    'info': '#5C6BC0',
+    'success': '#66BB6A',
+    'warning': '#FFB300',
+    'on-background': '#FAE8DD',
+    'on-surface': '#FAE8DD',
+    'on-primary': '#1F1410',
+    'on-secondary': '#1F1410',
+  },
+  variables: {
+    'md-bg': '#1F1410',
+    'md-surface': '#2E1F18',
+    'md-text': '#FAE8DD',
+    'md-muted': '#E8C5B0',
+    'md-border': '#3E2A21',
+    'md-primary': '#FF7043',
+    'md-code-bg': '#170D0A',
+    'md-quote-bg': '#2A1A13',
+    'md-table-stripe': '#2A1A13',
+  },
+}
+
+export const themes = {
+  dark,
+  hell,
+  linux,
+  green,
+  blue,
+  purple,
+  orange,
+} as const
+
+export type ThemeName = keyof typeof themes
+
+export const THEME_NAMES: ThemeName[] = ['dark', 'hell', 'linux', 'green', 'blue', 'purple', 'orange']
+
+export const DEFAULT_THEME: ThemeName = 'dark'
+
+/** Preview swatch picked from each theme's primary + background for the switcher UI */
+export function getThemeSwatch(name: ThemeName): { primary: string, background: string } {
+  const t = themes[name]
+  return {
+    primary: (t.colors?.primary as string) ?? '#D4A574',
+    background: (t.colors?.background as string) ?? '#1A1D29',
+  }
+}

--- a/packages/app/app/composables/useFeatureTooltips.ts
+++ b/packages/app/app/composables/useFeatureTooltips.ts
@@ -1,0 +1,110 @@
+/**
+ * Per-feature "new feature" hint state, with two dismissal modes:
+ *
+ * - **Session dismiss** — user clicked the bubble (or the wrapped element) once.
+ *   Stored in-memory only, so the hint reappears on the next app start.
+ * - **Permanent dismiss** — user checked "Don't show again" before closing.
+ *   Persisted in localStorage `dm-hero-feature-tips-dismissed`.
+ *
+ * A global on/off switch (`dm-hero-feature-tips-disabled`) suppresses all
+ * hints — toggled from the Settings page.
+ */
+
+const GLOBAL_KEY = 'dm-hero-feature-tips-disabled'
+const DISMISSED_KEY = 'dm-hero-feature-tips-dismissed'
+
+// Module-level reactive state — shared across all composable callers.
+const permanentDismissed = ref<Set<string>>(new Set())
+const sessionDismissed = ref<Set<string>>(new Set())
+const globallyEnabled = ref(true)
+let hydrated = false
+
+function hydrate() {
+  if (hydrated || typeof localStorage === 'undefined') return
+  hydrated = true
+  try {
+    const raw = localStorage.getItem(DISMISSED_KEY)
+    if (raw) permanentDismissed.value = new Set(raw.split(',').filter(Boolean))
+    globallyEnabled.value = localStorage.getItem(GLOBAL_KEY) !== '1'
+  }
+  catch {
+    // ignore
+  }
+}
+
+function persistPermanent() {
+  if (typeof localStorage === 'undefined') return
+  try {
+    localStorage.setItem(DISMISSED_KEY, [...permanentDismissed.value].join(','))
+  }
+  catch {
+    // ignore
+  }
+}
+
+function persistGlobal() {
+  if (typeof localStorage === 'undefined') return
+  try {
+    if (globallyEnabled.value) localStorage.removeItem(GLOBAL_KEY)
+    else localStorage.setItem(GLOBAL_KEY, '1')
+  }
+  catch {
+    // ignore
+  }
+}
+
+/**
+ * Returns reactive show state + dismiss helpers for one specific feature key.
+ */
+export function useFeatureTooltip(key: string) {
+  hydrate()
+
+  const shouldShow = computed(() =>
+    globallyEnabled.value
+    && !permanentDismissed.value.has(key)
+    && !sessionDismissed.value.has(key),
+  )
+
+  /** Hide for this session — comes back on next app start. */
+  function dismissForSession() {
+    if (sessionDismissed.value.has(key)) return
+    const next = new Set(sessionDismissed.value)
+    next.add(key)
+    sessionDismissed.value = next
+  }
+
+  /** Hide forever (until the user resets in settings). */
+  function dismissPermanent() {
+    if (permanentDismissed.value.has(key)) return
+    const next = new Set(permanentDismissed.value)
+    next.add(key)
+    permanentDismissed.value = next
+    persistPermanent()
+  }
+
+  return { shouldShow, dismissForSession, dismissPermanent }
+}
+
+/**
+ * Settings-level controls: global on/off + reset all permanent dismissals.
+ */
+export function useFeatureTooltipSettings() {
+  hydrate()
+
+  function setGloballyEnabled(value: boolean) {
+    globallyEnabled.value = value
+    persistGlobal()
+  }
+
+  function resetAllDismissed() {
+    permanentDismissed.value = new Set()
+    sessionDismissed.value = new Set()
+    persistPermanent()
+  }
+
+  return {
+    globallyEnabled,
+    setGloballyEnabled,
+    resetAllDismissed,
+  }
+}

--- a/packages/app/app/composables/useThemePreference.ts
+++ b/packages/app/app/composables/useThemePreference.ts
@@ -1,0 +1,51 @@
+import { useTheme } from 'vuetify'
+import { THEME_NAMES, DEFAULT_THEME, type ThemeName } from './themes'
+
+export const THEME_COOKIE = 'dm-hero-theme'
+
+export function isThemeName(value: string | null | undefined): value is ThemeName {
+  return !!value && (THEME_NAMES as readonly string[]).includes(value)
+}
+
+/**
+ * Theme preference persisted via Nuxt cookie — so the server can read it on
+ * the first request and Vuetify boots straight into the right theme (no flash
+ * of dark mode before hydration).
+ */
+export function useThemePreference() {
+  const theme = useTheme()
+  // 1y cookie, SameSite=Lax so cookie is sent on normal navigations
+  const cookie = useCookie<ThemeName>(THEME_COOKIE, {
+    default: () => DEFAULT_THEME,
+    maxAge: 60 * 60 * 24 * 365,
+    sameSite: 'lax',
+  })
+
+  // Sync vuetify ↔ cookie if they diverge on first access (e.g. cookie set on
+  // the server, vuetify still on its plugin default).
+  if (isThemeName(cookie.value) && theme.global.name.value !== cookie.value) {
+    theme.global.name.value = cookie.value
+  }
+
+  const current = computed<ThemeName>(() => {
+    const name = theme.global.name.value
+    return isThemeName(name) ? name : DEFAULT_THEME
+  })
+
+  function setTheme(name: ThemeName) {
+    theme.global.name.value = name
+    cookie.value = name
+  }
+
+  function reset() {
+    setTheme(DEFAULT_THEME)
+  }
+
+  return {
+    current,
+    setTheme,
+    reset,
+    available: THEME_NAMES,
+    defaultTheme: DEFAULT_THEME,
+  }
+}

--- a/packages/app/app/pages/calendar/index.vue
+++ b/packages/app/app/pages/calendar/index.vue
@@ -3,7 +3,7 @@
     <!-- Header -->
     <div class="d-flex justify-space-between align-center mb-4">
       <div>
-        <h1 class="text-h4">{{ $t('calendar.title') }}</h1>
+        <h1 class="text-headline-large">{{ $t('calendar.title') }}</h1>
         <p class="text-medium-emphasis">{{ $t('calendar.subtitle') }}</p>
       </div>
       <div class="d-flex ga-2 align-center">
@@ -43,7 +43,7 @@
     <!-- Calendar not configured -->
     <v-card v-if="!isConfigured" class="pa-8 text-center">
       <v-icon size="64" color="grey">mdi-calendar-blank</v-icon>
-      <h2 class="text-h5 mt-4">{{ $t('calendar.notConfigured') }}</h2>
+      <h2 class="text-headline-medium mt-4">{{ $t('calendar.notConfigured') }}</h2>
       <p class="text-medium-emphasis mt-2">{{ $t('calendar.notConfiguredHint') }}</p>
       <v-btn color="primary" class="mt-4" @click="openSettingsDialog">
         {{ $t('calendar.setup') }}
@@ -62,7 +62,7 @@
             </v-chip>
             <div v-for="moonPhase in currentMoonPhases" :key="moonPhase.name" class="d-flex align-center ga-2">
               <v-icon :color="getMoonColor(moonPhase.name)">{{ getMoonIconForPhase(moonPhase.phaseIndex) }}</v-icon>
-              <span class="text-body-2">{{ moonPhase.name }}: {{ moonPhase.phase }}</span>
+              <span class="text-body-medium">{{ moonPhase.name }}: {{ moonPhase.phase }}</span>
             </div>
           </div>
           <v-btn
@@ -88,10 +88,10 @@
         <v-card-title class="d-flex align-center justify-space-between">
           <v-btn icon="mdi-chevron-left" variant="text" @click="prevMonth" />
           <div class="text-center">
-            <span class="text-h5">{{ currentMonthName }}</span>
+            <span class="text-headline-medium">{{ currentMonthName }}</span>
             <div class="d-flex align-center justify-center ga-2 mt-1">
               <v-btn icon="mdi-chevron-left" size="x-small" variant="text" @click="prevYear" />
-              <span class="text-body-1">
+              <span class="text-body-large">
                 {{ $t('calendar.year') }} {{ viewYear }}
                 <span v-if="calendarConfig.config.era_name">{{ calendarConfig.config.era_name }}</span>
               </span>
@@ -110,7 +110,7 @@
             <div
               v-for="weekday in calendarConfig.weekdays"
               :key="weekday.id"
-              class="calendar-header text-center text-caption font-weight-bold py-2"
+              class="calendar-header text-center text-body-small font-weight-bold py-2"
             >
               {{ weekday.name }}
             </div>
@@ -209,10 +209,10 @@
                       </v-chip>
                       <strong>{{ session.title }}</strong>
                     </div>
-                    <div v-if="session.summary" class="text-caption mb-1">
+                    <div v-if="session.summary" class="text-body-small mb-1">
                       {{ session.summary.slice(0, 150) }}{{ session.summary.length > 150 ? '...' : '' }}
                     </div>
-                    <div class="d-flex ga-2 text-caption">
+                    <div class="d-flex ga-2 text-body-small">
                       <span v-if="session.attendance_count > 0">
                         <v-icon size="12">mdi-account-group</v-icon> {{ session.attendance_count }}
                       </span>
@@ -223,14 +223,14 @@
                         <v-icon size="12">mdi-calendar</v-icon> {{ session.date }}
                       </span>
                     </div>
-                    <div v-if="!session.isStart && !session.isEnd" class="text-caption mt-1 text-warning">
+                    <div v-if="!session.isStart && !session.isEnd" class="text-body-small mt-1 text-warning">
                       {{ $t('calendar.multiDaySession') }}
                     </div>
                   </div>
                 </v-tooltip>
                 <div
                   v-if="getSessionsForDay(day).length > 2"
-                  class="session-more text-caption text-medium-emphasis"
+                  class="session-more text-body-small text-medium-emphasis"
                 >
                   +{{ getSessionsForDay(day).length - 2 }} {{ $t('calendar.sessions').toLowerCase() }}
                 </div>
@@ -256,13 +256,13 @@
                   </template>
                   <div>
                     <strong>{{ event.title }}</strong>
-                    <div class="text-caption">{{ $t('calendar.eventTypes.' + event.event_type) }}</div>
-                    <div v-if="event.entity_name" class="text-caption">{{ event.entity_name }}</div>
+                    <div class="text-body-small">{{ $t('calendar.eventTypes.' + event.event_type) }}</div>
+                    <div v-if="event.entity_name" class="text-body-small">{{ event.entity_name }}</div>
                   </div>
                 </v-tooltip>
                 <div
                   v-if="getEventsForDay(day).length > 3"
-                  class="event-more text-caption text-medium-emphasis"
+                  class="event-more text-body-small text-medium-emphasis"
                 >
                   +{{ getEventsForDay(day).length - 3 }} {{ $t('calendar.events').toLowerCase() }}
                 </div>
@@ -346,7 +346,7 @@
         <v-card-text>
           <!-- Sessions for selected day -->
           <div v-if="selectedDaySessions.length > 0" class="mb-4">
-            <div class="text-overline text-medium-emphasis mb-2">
+            <div class="text-label-small text-medium-emphasis mb-2">
               <v-icon size="16" class="mr-1">mdi-book-open-page-variant</v-icon>
               {{ $t('calendar.sessions') }} ({{ selectedDaySessions.length }})
             </div>
@@ -394,7 +394,7 @@
 
           <!-- Events for selected day -->
           <div v-if="selectedDayEvents.length > 0">
-            <div class="text-overline text-medium-emphasis mb-2">
+            <div class="text-label-small text-medium-emphasis mb-2">
               <v-icon size="16" class="mr-1">mdi-calendar</v-icon>
               {{ $t('calendar.events') }} ({{ selectedDayEvents.length }})
             </div>
@@ -482,7 +482,7 @@
               </v-avatar>
               <div>
                 <div class="font-weight-medium">{{ eventToDelete.title }}</div>
-                <div class="text-caption text-medium-emphasis">
+                <div class="text-body-small text-medium-emphasis">
                   {{ eventToDelete.day }}. {{ calendarConfig.months[eventToDelete.month - 1]?.name }}
                   <span v-if="!eventToDelete.is_recurring"> {{ eventToDelete.year }}</span>
                   <v-chip v-if="eventToDelete.is_recurring" size="x-small" class="ml-1">
@@ -517,7 +517,7 @@
 
           <!-- Affected Events -->
           <div v-if="validationResult?.affectedEvents.length" class="mb-4">
-            <div class="text-subtitle-2 mb-2">
+            <div class="text-title-small mb-2">
               <v-icon size="18" class="mr-1">mdi-calendar</v-icon>
               {{ $t('calendar.affectedEvents', { count: validationResult.affectedEvents.length }) }}
             </div>
@@ -538,14 +538,14 @@
                 </v-list-item-title>
               </v-list-item>
             </v-list>
-            <div class="text-caption text-medium-emphasis mt-1">
+            <div class="text-body-small text-medium-emphasis mt-1">
               {{ $t('calendar.eventsWillBeMoved') }}
             </div>
           </div>
 
           <!-- Affected Sessions -->
           <div v-if="validationResult?.affectedSessions.length">
-            <div class="text-subtitle-2 mb-2">
+            <div class="text-title-small mb-2">
               <v-icon size="18" class="mr-1">mdi-book-open-page-variant</v-icon>
               {{ $t('calendar.affectedSessions', { count: validationResult.affectedSessions.length }) }}
             </div>
@@ -565,7 +565,7 @@
                 </v-list-item-title>
               </v-list-item>
             </v-list>
-            <div class="text-caption text-medium-emphasis mt-1">
+            <div class="text-body-small text-medium-emphasis mt-1">
               {{ $t('calendar.sessionsWillBeReset') }}
             </div>
           </div>

--- a/packages/app/app/pages/campaigns.vue
+++ b/packages/app/app/pages/campaigns.vue
@@ -27,13 +27,13 @@
             {{ campaign.name }}
           </v-card-title>
           <v-card-text class="flex-grow-1">
-            <div v-if="campaign.description" class="text-body-2 mb-4">
+            <div v-if="campaign.description" class="text-body-medium mb-4">
               {{ campaign.description }}
             </div>
-            <div v-else class="text-body-2 text-disabled mb-4">
+            <div v-else class="text-body-medium text-disabled mb-4">
               {{ $t('campaigns.noDescription') }}
             </div>
-            <div class="text-caption text-medium-emphasis">
+            <div class="text-body-small text-medium-emphasis">
               {{ $t('campaigns.created') }}: {{ formatDate(campaign.created_at) }}
             </div>
           </v-card-text>
@@ -70,8 +70,8 @@
       <template #fallback>
         <v-container class="text-center py-16">
           <v-icon icon="mdi-sword-cross" size="64" color="grey" class="mb-4" />
-          <h2 class="text-h5 mb-2">{{ $t('campaigns.empty') }}</h2>
-          <p class="text-body-1 text-medium-emphasis mb-4">{{ $t('campaigns.emptyText') }}</p>
+          <h2 class="text-headline-medium mb-2">{{ $t('campaigns.empty') }}</h2>
+          <p class="text-body-large text-medium-emphasis mb-4">{{ $t('campaigns.emptyText') }}</p>
           <v-btn color="primary" prepend-icon="mdi-plus" @click="showCreateDialog = true">
             {{ $t('campaigns.create') }}
           </v-btn>

--- a/packages/app/app/pages/chaos/[id].vue
+++ b/packages/app/app/pages/chaos/[id].vue
@@ -6,8 +6,8 @@
         <v-icon>mdi-arrow-left</v-icon>
       </v-btn>
       <div class="chaos-title">
-        <h1 class="text-h5">{{ $t('chaos.title') }}</h1>
-        <span v-if="entity" class="text-body-2 text-medium-emphasis">
+        <h1 class="text-headline-medium">{{ $t('chaos.title') }}</h1>
+        <span v-if="entity" class="text-body-medium text-medium-emphasis">
           {{ entity.name }} · {{ filteredConnections.length }} {{ $t('chaos.connections') }}
           <span v-if="activeFilters.length > 0" class="text-disabled">
             ({{ connections.length }} {{ $t('chaos.total') }})
@@ -35,13 +35,13 @@
     <!-- Loading State -->
     <div v-if="loading" class="chaos-loading">
       <v-progress-circular indeterminate size="64" color="primary" />
-      <p class="mt-4 text-body-1">{{ $t('common.loading') }}</p>
+      <p class="mt-4 text-body-large">{{ $t('common.loading') }}</p>
     </div>
 
     <!-- Error State -->
     <div v-else-if="error" class="chaos-error">
       <v-icon size="64" color="error">mdi-alert-circle</v-icon>
-      <p class="mt-4 text-body-1">{{ error }}</p>
+      <p class="mt-4 text-body-large">{{ error }}</p>
       <v-btn color="primary" class="mt-4" @click="goBack">
         {{ $t('common.back') }}
       </v-btn>
@@ -142,8 +142,8 @@
 
       <!-- No Connections Message -->
       <div v-else class="chaos-no-connections">
-        <p class="text-body-1 text-medium-emphasis">{{ $t('chaos.noConnections') }}</p>
-        <p class="text-body-2 text-disabled">{{ $t('chaos.noConnectionsText') }}</p>
+        <p class="text-body-large text-medium-emphasis">{{ $t('chaos.noConnections') }}</p>
+        <p class="text-body-medium text-disabled">{{ $t('chaos.noConnectionsText') }}</p>
       </div>
     </div>
 

--- a/packages/app/app/pages/encounters/index.vue
+++ b/packages/app/app/pages/encounters/index.vue
@@ -67,7 +67,7 @@
               </v-chip>
             </div>
 
-            <div class="text-caption text-medium-emphasis mt-2">
+            <div class="text-body-small text-medium-emphasis mt-2">
               {{ formatDate(encounter.created_at) }}
             </div>
           </v-card-text>
@@ -96,8 +96,8 @@
       <template #fallback>
         <v-container class="text-center py-16">
           <v-icon icon="mdi-sword-cross" size="64" color="grey" class="mb-4" />
-          <h2 class="text-h5 mb-2">{{ $t('encounters.empty') }}</h2>
-          <p class="text-body-1 text-medium-emphasis mb-4">{{ $t('encounters.emptyText') }}</p>
+          <h2 class="text-headline-medium mb-2">{{ $t('encounters.empty') }}</h2>
+          <p class="text-body-large text-medium-emphasis mb-4">{{ $t('encounters.emptyText') }}</p>
           <v-btn color="primary" prepend-icon="mdi-plus" @click="showCreateDialog = true">
             {{ $t('encounters.create') }}
           </v-btn>

--- a/packages/app/app/pages/factions/index.vue
+++ b/packages/app/app/pages/factions/index.vue
@@ -51,7 +51,7 @@
       >
         <div class="text-center">
           <v-progress-circular indeterminate size="64" color="primary" class="mb-4" />
-          <div class="text-h6">{{ $t('common.searching') }}</div>
+          <div class="text-headline-small">{{ $t('common.searching') }}</div>
         </div>
       </v-overlay>
 
@@ -86,8 +86,8 @@
       <template #fallback>
         <v-container class="text-center py-16">
           <v-icon icon="mdi-shield-account-outline" size="64" color="grey" class="mb-4" />
-          <h2 class="text-h5 mb-2">{{ $t('factions.empty') }}</h2>
-          <p class="text-body-1 text-medium-emphasis mb-4">{{ $t('factions.emptyText') }}</p>
+          <h2 class="text-headline-medium mb-2">{{ $t('factions.empty') }}</h2>
+          <p class="text-body-large text-medium-emphasis mb-4">{{ $t('factions.emptyText') }}</p>
           <v-btn color="primary" prepend-icon="mdi-plus" @click="openCreateDialog">
             {{ $t('factions.create') }}
           </v-btn>

--- a/packages/app/app/pages/groups/index.vue
+++ b/packages/app/app/pages/groups/index.vue
@@ -39,7 +39,7 @@
       >
         <div class="text-center">
           <v-progress-circular indeterminate size="64" color="primary" class="mb-4" />
-          <div class="text-h6">{{ $t('common.searching') }}</div>
+          <div class="text-headline-small">{{ $t('common.searching') }}</div>
         </div>
       </v-overlay>
 
@@ -72,8 +72,8 @@
       <template #fallback>
         <v-container class="text-center py-16">
           <v-icon icon="mdi-folder-multiple-outline" size="64" color="grey" class="mb-4" />
-          <h2 class="text-h5 mb-2">{{ $t('groups.empty') }}</h2>
-          <p class="text-body-1 text-medium-emphasis mb-4">{{ $t('groups.emptyText') }}</p>
+          <h2 class="text-headline-medium mb-2">{{ $t('groups.empty') }}</h2>
+          <p class="text-body-large text-medium-emphasis mb-4">{{ $t('groups.emptyText') }}</p>
           <v-btn color="primary" prepend-icon="mdi-plus" @click="openCreateDialog">
             {{ $t('groups.create') }}
           </v-btn>

--- a/packages/app/app/pages/index.vue
+++ b/packages/app/app/pages/index.vue
@@ -3,10 +3,10 @@
     <!-- Redirect to campaigns if no campaign selected -->
     <div v-if="!activeCampaignId" class="text-center py-16">
       <v-icon icon="mdi-sword-cross" size="64" class="mb-4" color="primary" />
-      <h2 class="text-h4 mb-4">
+      <h2 class="text-headline-large mb-4">
         {{ $t('dashboard.noCampaign.title') }}
       </h2>
-      <p class="text-body-1 text-medium-emphasis mb-6">
+      <p class="text-body-large text-medium-emphasis mb-6">
         {{ $t('dashboard.noCampaign.description') }}
       </p>
       <v-btn color="primary" size="large" to="/campaigns" prepend-icon="mdi-arrow-right">
@@ -25,10 +25,10 @@
             </ClientOnly>
             <!-- Title with left margin to make room for dice -->
             <div style="margin-left: 230px;" class="mb-6 mt-4">
-              <div class="text-h3 font-weight-bold mb-1">
+              <div class="text-display-small font-weight-bold mb-1">
                 {{ $t('app.welcome') }}
               </div>
-              <p class="text-body-1 text-medium-emphasis">
+              <p class="text-body-large text-medium-emphasis">
                 {{ $t('app.subtitle') }}
               </p>
             </div>
@@ -102,7 +102,7 @@
       <!-- Category Cards -->
       <v-row class="mb-4">
         <v-col cols="12">
-          <div class="text-h6 font-weight-medium">
+          <div class="text-headline-small font-weight-medium">
             {{ $t('dashboard.categories.title') }}
           </div>
         </v-col>
@@ -126,7 +126,7 @@
       <v-row class="mb-4 mt-6">
         <v-col cols="12">
           <div class="d-flex align-center flex-wrap ga-2 mb-2">
-            <div class="text-h6 font-weight-medium">
+            <div class="text-headline-small font-weight-medium">
               {{ $t('dashboard.dataManagement') }}
             </div>
             <v-chip color="warning" size="small">Beta</v-chip>
@@ -155,8 +155,8 @@
               <div class="d-flex align-center">
                 <v-icon icon="mdi-export" size="28" color="primary" class="mr-3" />
                 <div>
-                  <div class="text-subtitle-1 font-weight-medium">{{ $t('campaigns.export.title') }}</div>
-                  <div class="text-body-2 text-medium-emphasis">
+                  <div class="text-title-medium font-weight-medium">{{ $t('campaigns.export.title') }}</div>
+                  <div class="text-body-medium text-medium-emphasis">
                     {{ $t('dashboard.exportHint') }}
                   </div>
                 </div>
@@ -170,8 +170,8 @@
               <div class="d-flex align-center">
                 <v-icon icon="mdi-import" size="28" color="secondary" class="mr-3" />
                 <div>
-                  <div class="text-subtitle-1 font-weight-medium">{{ $t('campaigns.import.title') }}</div>
-                  <div class="text-body-2 text-medium-emphasis">
+                  <div class="text-title-medium font-weight-medium">{{ $t('campaigns.import.title') }}</div>
+                  <div class="text-body-medium text-medium-emphasis">
                     {{ $t('dashboard.importHint') }}
                   </div>
                 </div>
@@ -185,8 +185,8 @@
               <div class="d-flex align-center">
                 <v-icon icon="mdi-content-copy" size="28" color="info" class="mr-3" />
                 <div>
-                  <div class="text-subtitle-1 font-weight-medium">{{ $t('entities.copyToCampaign.title') }}</div>
-                  <div class="text-body-2 text-medium-emphasis">
+                  <div class="text-title-medium font-weight-medium">{{ $t('entities.copyToCampaign.title') }}</div>
+                  <div class="text-body-medium text-medium-emphasis">
                     {{ $t('dashboard.copyHint') }}
                   </div>
                 </div>

--- a/packages/app/app/pages/items/index.vue
+++ b/packages/app/app/pages/items/index.vue
@@ -51,7 +51,7 @@
       >
         <div class="text-center">
           <v-progress-circular indeterminate size="64" color="primary" class="mb-4" />
-          <div class="text-h6">{{ $t('common.searching') }}</div>
+          <div class="text-headline-small">{{ $t('common.searching') }}</div>
         </div>
       </v-overlay>
 
@@ -86,8 +86,8 @@
       <template #fallback>
         <v-container class="text-center py-16">
           <v-icon icon="mdi-sword" size="64" color="grey" class="mb-4" />
-          <h2 class="text-h5 mb-2">{{ $t('items.empty') }}</h2>
-          <p class="text-body-1 text-medium-emphasis mb-4">{{ $t('items.emptyText') }}</p>
+          <h2 class="text-headline-medium mb-2">{{ $t('items.empty') }}</h2>
+          <p class="text-body-large text-medium-emphasis mb-4">{{ $t('items.emptyText') }}</p>
           <v-btn color="primary" prepend-icon="mdi-plus" @click="openCreateDialog">
             {{ $t('items.create') }}
           </v-btn>

--- a/packages/app/app/pages/locations/index.vue
+++ b/packages/app/app/pages/locations/index.vue
@@ -47,7 +47,7 @@
     <!-- Search Loading Indicator (shown immediately when typing starts) -->
     <div v-else-if="searching && (!searchResults || searchResults.length === 0)" class="text-center py-16">
       <v-progress-circular indeterminate size="64" color="primary" class="mb-4" />
-      <div class="text-h6">
+      <div class="text-headline-small">
         {{ $t('common.searching') }}
       </div>
     </div>
@@ -65,7 +65,7 @@
       >
         <div class="text-center">
           <v-progress-circular indeterminate size="64" color="primary" class="mb-4" />
-          <div class="text-h6">
+          <div class="text-headline-small">
             {{ $t('common.searching') }}
           </div>
         </div>
@@ -199,8 +199,8 @@
       <template #fallback>
         <v-container class="text-center py-16">
           <v-icon icon="mdi-map-marker-multiple" size="64" color="grey" class="mb-4" />
-          <h2 class="text-h5 mb-2">{{ $t('locations.empty') }}</h2>
-          <p class="text-body-1 text-medium-emphasis mb-4">{{ $t('locations.emptyText') }}</p>
+          <h2 class="text-headline-medium mb-2">{{ $t('locations.empty') }}</h2>
+          <p class="text-body-large text-medium-emphasis mb-4">{{ $t('locations.emptyText') }}</p>
           <v-btn color="primary" prepend-icon="mdi-plus" @click="showCreateDialog = true">
             {{ $t('locations.create') }}
           </v-btn>

--- a/packages/app/app/pages/locations/index.vue
+++ b/packages/app/app/pages/locations/index.vue
@@ -80,31 +80,16 @@
           item-value="id"
           item-title="title"
           density="comfortable"
-          expand-icon=""
-          collapse-icon=""
         >
-          <!-- Custom prepend slot for expand button + icon -->
+          <!-- Location type icon (expand/collapse is handled by v-treeview default) -->
           <template #prepend="{ internalItem }">
-            <div
-              :class="{
-                'highlight-blink-prepend': highlightedId === internalItem.raw.id,
-              }"
-              style="display: flex; align-items: center; gap: 4px; margin-left: -8px"
+            <v-icon
+              :class="{ 'highlight-blink-prepend': highlightedId === internalItem.raw.id }"
+              :color="getNodeColor(internalItem.raw)"
+              size="small"
             >
-              <!-- Expand/Collapse icon only if has children -->
-              <v-icon
-                v-if="internalItem.children && internalItem.children.length > 0"
-                :icon="openedNodes.includes(internalItem.value) ? 'mdi-chevron-down' : 'mdi-chevron-right'"
-                size="small"
-                style="width: 20px"
-              />
-              <div v-else style="width: 20px" />
-
-              <!-- Location type icon -->
-              <v-icon :color="getNodeColor(internalItem.raw)" size="small">
-                {{ getNodeIcon(internalItem.raw) }}
-              </v-icon>
-            </div>
+              {{ getNodeIcon(internalItem.raw) }}
+            </v-icon>
           </template>
 
           <!-- Custom title to highlight search results -->
@@ -549,13 +534,15 @@ const filteredLocations = computed(() => {
   return [...(locations.value || [])].sort((a, b) => a.name.localeCompare(b.name))
 })
 
-// Build tree structure from flat location list
-interface TreeNode {
-  id: number
+// Build tree structure from flat location list.
+// TreeNode extends Location so that all original fields (metadata, archived_at, …)
+// are directly accessible on the node — Vuetify 4's v-treeview slot prop is
+// `internalItem.raw = TreeNode`, so anything we want in the template must live
+// at the TreeNode level, not nested under another `.raw`.
+interface TreeNode extends Location {
   title: string
   children?: TreeNode[]
-  raw: Location
-  isSearchResult?: boolean // Mark if this is an actual search result
+  isSearchResult?: boolean
 }
 
 // Helper: Get all parent IDs for a location
@@ -610,13 +597,12 @@ const treeItems = computed(() => {
   const locationMap = new Map<number, TreeNode>()
   const rootNodes: TreeNode[] = []
 
-  // First pass: create all nodes
+  // First pass: create all nodes — spread Location so node has all its fields directly
   locationsToShow.forEach((location) => {
     locationMap.set(location.id, {
-      id: location.id,
+      ...location,
       title: location.name,
       children: [],
-      raw: location,
       isSearchResult: searchResultIds.has(location.id),
     })
   })
@@ -655,6 +641,20 @@ const treeItems = computed(() => {
 
   // Sort root nodes and all children
   sortNodes(rootNodes)
+
+  // v-treeview 4 treats any non-undefined children (even []) as expandable.
+  // Strip empty arrays so leaf nodes don't get an expand arrow.
+  const stripEmptyChildren = (nodes: TreeNode[]) => {
+    nodes.forEach((node) => {
+      if (node.children && node.children.length > 0) {
+        stripEmptyChildren(node.children)
+      }
+      else {
+        node.children = undefined
+      }
+    })
+  }
+  stripEmptyChildren(rootNodes)
 
   return rootNodes
 })
@@ -699,12 +699,12 @@ watch(
 
 // Get icon based on location type (uses composable)
 function getNodeIcon(item: TreeNode) {
-  return getLocationTypeIcon(item.raw?.metadata?.type)
+  return getLocationTypeIcon(item.metadata?.type)
 }
 
 // Get color based on location type (uses composable)
 function getNodeColor(item: TreeNode) {
-  return getLocationTypeColor(item.raw?.metadata?.type)
+  return getLocationTypeColor(item.metadata?.type)
 }
 
 // Form state
@@ -1001,9 +1001,11 @@ function handleLinked() {
   transform: scale(1.1);
 }
 
-/* Add consistent padding to all treeview items */
+/* Add consistent padding to all treeview items.
+ * NOTE: Only set padding-block — `padding` shorthand would kill the
+ * padding-inline-start that v-treeview uses for child indentation. */
 :deep(.v-treeview-item) {
-  padding: 4px 8px;
+  padding-block: 4px;
   margin: 2px 0;
   border-radius: 4px;
 }

--- a/packages/app/app/pages/locations/index.vue
+++ b/packages/app/app/pages/locations/index.vue
@@ -84,59 +84,59 @@
           collapse-icon=""
         >
           <!-- Custom prepend slot for expand button + icon -->
-          <template #prepend="{ item }">
+          <template #prepend="{ internalItem }">
             <div
               :class="{
-                'highlight-blink-prepend': highlightedId === item.raw.id,
+                'highlight-blink-prepend': highlightedId === internalItem.raw.id,
               }"
               style="display: flex; align-items: center; gap: 4px; margin-left: -8px"
             >
               <!-- Expand/Collapse icon only if has children -->
               <v-icon
-                v-if="item.children && item.children.length > 0"
-                :icon="openedNodes.includes(item.id) ? 'mdi-chevron-down' : 'mdi-chevron-right'"
+                v-if="internalItem.children && internalItem.children.length > 0"
+                :icon="openedNodes.includes(internalItem.value) ? 'mdi-chevron-down' : 'mdi-chevron-right'"
                 size="small"
                 style="width: 20px"
               />
               <div v-else style="width: 20px" />
 
               <!-- Location type icon -->
-              <v-icon :color="getNodeColor(item)" size="small">
-                {{ getNodeIcon(item) }}
+              <v-icon :color="getNodeColor(internalItem.raw)" size="small">
+                {{ getNodeIcon(internalItem.raw) }}
               </v-icon>
             </div>
           </template>
 
           <!-- Custom title to highlight search results -->
-          <template #title="{ item }">
+          <template #title="{ internalItem }">
             <div
-              :id="`location-${item.raw.id}`"
-              :key="`location-title-${item.raw.id}-${animationKey}`"
+              :id="`location-${internalItem.raw.id}`"
+              :key="`location-title-${internalItem.raw.id}-${animationKey}`"
               :class="{
-                'highlight-blink-title': highlightedId === item.raw.id,
+                'highlight-blink-title': highlightedId === internalItem.raw.id,
               }"
-              @contextmenu.prevent="openQuickLinkMenu($event, item.raw)"
+              @contextmenu.prevent="openQuickLinkMenu($event, internalItem.raw)"
             >
-              <span :class="{ 'text-primary font-weight-bold': item.isSearchResult }" :style="{ opacity: item.raw.archived_at ? 0.5 : 1 }">
-                {{ item.title }}
-                <v-chip v-if="item.raw.archived_at" size="x-small" color="warning" variant="tonal" class="ml-1">
+              <span :class="{ 'text-primary font-weight-bold': internalItem.raw.isSearchResult }" :style="{ opacity: internalItem.raw.archived_at ? 0.5 : 1 }">
+                {{ internalItem.title }}
+                <v-chip v-if="internalItem.raw.archived_at" size="x-small" color="warning" variant="tonal" class="ml-1">
                   {{ $t('common.archived') }}
                 </v-chip>
               </span>
             </div>
           </template>
 
-          <template #append="{ item }">
+          <template #append="{ internalItem }">
             <div class="d-flex align-center ga-1">
               <!-- Type chip -->
               <v-chip
-                v-if="item.raw.metadata?.type"
+                v-if="internalItem.raw.metadata?.type"
                 size="x-small"
                 color="primary"
                 variant="tonal"
                 class="mr-2"
               >
-                {{ $t(`locations.types.${item.raw.metadata.type}`, item.raw.metadata.type) }}
+                {{ $t(`locations.types.${internalItem.raw.metadata.type}`, internalItem.raw.metadata.type) }}
               </v-chip>
 
               <!-- Actions -->
@@ -144,31 +144,31 @@
                 icon="mdi-eye"
                 size="x-small"
                 variant="text"
-                @click.stop="viewLocation(item.raw)"
+                @click.stop="viewLocation(internalItem.raw)"
               />
               <v-btn
                 icon="mdi-pencil"
                 size="x-small"
                 variant="text"
-                @click.stop="editLocation(item.raw)"
+                @click.stop="editLocation(internalItem.raw)"
               />
               <v-btn
                 icon="mdi-graph"
                 size="x-small"
                 variant="text"
                 color="primary"
-                @click.stop="openChaosGraph(item.raw)"
+                @click.stop="openChaosGraph(internalItem.raw)"
               />
               <v-btn
-                :icon="item.raw.archived_at ? 'mdi-package-up' : 'mdi-archive-arrow-down'"
+                :icon="internalItem.raw.archived_at ? 'mdi-package-up' : 'mdi-archive-arrow-down'"
                 size="x-small"
                 variant="text"
-                :color="item.raw.archived_at ? 'success' : 'warning'"
-                @click.stop="archiveLocation(item.raw)"
+                :color="internalItem.raw.archived_at ? 'success' : 'warning'"
+                @click.stop="archiveLocation(internalItem.raw)"
               >
-                <v-icon>{{ item.raw.archived_at ? 'mdi-package-up' : 'mdi-archive-arrow-down' }}</v-icon>
+                <v-icon>{{ internalItem.raw.archived_at ? 'mdi-package-up' : 'mdi-archive-arrow-down' }}</v-icon>
                 <v-tooltip activator="parent" location="bottom">
-                  {{ item.raw.archived_at ? $t('common.unarchive') : $t('common.archive') }}
+                  {{ internalItem.raw.archived_at ? $t('common.unarchive') : $t('common.archive') }}
                 </v-tooltip>
               </v-btn>
               <v-btn
@@ -176,7 +176,7 @@
                 size="x-small"
                 variant="text"
                 color="error"
-                @click.stop="deleteLocation(item.raw)"
+                @click.stop="deleteLocation(internalItem.raw)"
               />
             </div>
           </template>

--- a/packages/app/app/pages/lore/index.vue
+++ b/packages/app/app/pages/lore/index.vue
@@ -50,7 +50,7 @@
       >
         <div class="text-center">
           <v-progress-circular indeterminate size="64" color="primary" class="mb-4" />
-          <div class="text-h6">
+          <div class="text-headline-small">
             {{ $t('common.searching') }}
           </div>
         </div>
@@ -80,10 +80,10 @@
     <v-card v-else>
       <v-card-text class="text-center pa-8">
         <v-icon icon="mdi-book-open-variant" size="64" color="grey" class="mb-4" />
-        <div class="text-h6 mb-2">
+        <div class="text-headline-small mb-2">
           {{ $t('lore.empty') }}
         </div>
-        <div class="text-body-2 text-medium-emphasis mb-4">
+        <div class="text-body-medium text-medium-emphasis mb-4">
           {{ $t('lore.emptyText') }}
         </div>
         <v-btn color="primary" prepend-icon="mdi-plus" @click="openCreateDialog">

--- a/packages/app/app/pages/maps/index.vue
+++ b/packages/app/app/pages/maps/index.vue
@@ -280,7 +280,7 @@
             class="mb-3"
           />
           <v-divider class="my-4" />
-          <div class="text-subtitle-2 mb-2">{{ $t('maps.scale') }}</div>
+          <div class="text-title-small mb-2">{{ $t('maps.scale') }}</div>
           <v-row dense>
             <v-col cols="6">
               <v-text-field
@@ -304,7 +304,7 @@
               />
             </v-col>
           </v-row>
-          <div class="text-caption text-medium-emphasis mb-3">
+          <div class="text-body-small text-medium-emphasis mb-3">
             {{ $t('maps.scaleHint') }}
           </div>
 

--- a/packages/app/app/pages/notes.vue
+++ b/packages/app/app/pages/notes.vue
@@ -3,10 +3,10 @@
     <!-- Redirect to campaigns if no campaign selected -->
     <div v-if="!campaignId" class="text-center py-16">
       <v-icon icon="mdi-notebook" size="64" class="mb-4" color="primary" />
-      <h2 class="text-h4 mb-4">
+      <h2 class="text-headline-large mb-4">
         {{ $t('notes.noCampaign.title') }}
       </h2>
-      <p class="text-body-1 text-medium-emphasis mb-6">
+      <p class="text-body-large text-medium-emphasis mb-6">
         {{ $t('notes.noCampaign.description') }}
       </p>
       <v-btn color="primary" size="large" to="/campaigns" prepend-icon="mdi-arrow-right">
@@ -20,11 +20,11 @@
         <v-col cols="12">
           <div class="d-flex align-center justify-space-between mb-4">
             <div>
-              <div class="text-h4 mb-2">
+              <div class="text-headline-large mb-2">
                 <v-icon icon="mdi-notebook-outline" size="36" class="mr-2" />
                 {{ $t('notes.title') }}
               </div>
-              <p class="text-body-1 text-medium-emphasis">
+              <p class="text-body-large text-medium-emphasis">
                 {{ $t('notes.subtitle') }}
               </p>
             </div>
@@ -76,10 +76,10 @@
 
             <v-card-text v-else-if="notesStore.noteCount === 0" class="text-center py-8">
               <v-icon icon="mdi-notebook-check-outline" size="64" class="mb-4" color="grey" />
-              <div class="text-h6 text-medium-emphasis mb-2">
+              <div class="text-headline-small text-medium-emphasis mb-2">
                 {{ $t('notes.empty') }}
               </div>
-              <div class="text-body-2 text-medium-emphasis">
+              <div class="text-body-medium text-medium-emphasis">
                 {{ $t('notes.emptyHint') }}
               </div>
             </v-card-text>
@@ -164,7 +164,7 @@
       <v-row v-if="notesStore.completedCount > 0" class="mt-4">
         <v-col cols="12">
           <div class="d-flex align-center justify-space-between">
-            <span class="text-body-2 text-medium-emphasis">
+            <span class="text-body-medium text-medium-emphasis">
               {{ notesStore.completedCount }} {{ $t('notes.completed') }}
             </span>
             <v-btn

--- a/packages/app/app/pages/npcs/index.vue
+++ b/packages/app/app/pages/npcs/index.vue
@@ -45,7 +45,7 @@
     <!-- Search Loading State (when searching with no previous results) -->
     <div v-else-if="searching && filteredNpcs.length === 0" class="text-center py-16">
       <v-progress-circular indeterminate size="64" color="primary" class="mb-4" />
-      <div class="text-h6">{{ $t('common.searching') }}</div>
+      <div class="text-headline-small">{{ $t('common.searching') }}</div>
     </div>
 
     <!-- NPC Cards with Search Overlay -->
@@ -61,7 +61,7 @@
       >
         <div class="text-center">
           <v-progress-circular indeterminate size="64" color="primary" class="mb-4" />
-          <div class="text-h6">
+          <div class="text-headline-small">
             {{ $t('common.searching') }}
           </div>
         </div>
@@ -104,8 +104,8 @@
         <template #fallback>
           <v-container class="text-center py-16">
             <v-icon icon="mdi-account-group" size="64" color="grey" class="mb-4" />
-            <h2 class="text-h5 mb-2">{{ $t('npcs.empty') }}</h2>
-            <p class="text-body-1 text-medium-emphasis mb-4">{{ $t('npcs.emptyText') }}</p>
+            <h2 class="text-headline-medium mb-2">{{ $t('npcs.empty') }}</h2>
+            <p class="text-body-large text-medium-emphasis mb-4">{{ $t('npcs.emptyText') }}</p>
             <v-btn color="primary" prepend-icon="mdi-plus" @click="openCreateDialog">
               {{ $t('npcs.create') }}
             </v-btn>

--- a/packages/app/app/pages/players/index.vue
+++ b/packages/app/app/pages/players/index.vue
@@ -51,7 +51,7 @@
       >
         <div class="text-center">
           <v-progress-circular indeterminate size="64" color="primary" class="mb-4" />
-          <div class="text-h6">
+          <div class="text-headline-small">
             {{ $t('common.searching') }}
           </div>
         </div>

--- a/packages/app/app/pages/reference-data.vue
+++ b/packages/app/app/pages/reference-data.vue
@@ -26,7 +26,7 @@
       <v-tabs-window-item value="currencies">
         <div v-if="!activeCampaignId" class="text-center py-8">
           <v-icon icon="mdi-alert-circle-outline" size="48" color="warning" class="mb-4" />
-          <p class="text-body-1">{{ $t('referenceData.noCampaignSelected') }}</p>
+          <p class="text-body-large">{{ $t('referenceData.noCampaignSelected') }}</p>
         </div>
         <div v-else>
           <div class="d-flex justify-end mb-4">
@@ -238,7 +238,7 @@
           />
 
           <v-divider class="my-4" />
-          <div class="text-subtitle-2 mb-2">
+          <div class="text-title-small mb-2">
             {{ $t('referenceData.translations') }}
           </div>
 
@@ -300,7 +300,7 @@
           />
 
           <v-divider class="my-4" />
-          <div class="text-subtitle-2 mb-2">
+          <div class="text-title-small mb-2">
             {{ $t('referenceData.translations') }}
           </div>
 

--- a/packages/app/app/pages/sessions/index.vue
+++ b/packages/app/app/pages/sessions/index.vue
@@ -35,11 +35,11 @@
         <template #opposite>
           <div class="timeline-date-section text-right">
             <!-- Real Date -->
-            <div class="text-body-2 font-weight-medium">
+            <div class="text-body-medium font-weight-medium">
               {{ formatRealDate(session.date) }}
             </div>
             <!-- In-Game Date -->
-            <div v-if="session.in_game_year_start" class="text-caption text-primary mt-1">
+            <div v-if="session.in_game_year_start" class="text-body-small text-primary mt-1">
               <v-icon size="x-small" class="mr-1">mdi-sword-cross</v-icon>
               {{ formatSessionDate(session) }}
               <span v-if="session.in_game_year_end && hasDateRange(session)">
@@ -77,10 +77,10 @@
 
           <v-card-text class="pt-2">
             <!-- Summary -->
-            <div v-if="session.summary" class="text-body-2 mb-3">
+            <div v-if="session.summary" class="text-body-medium mb-3">
               {{ truncateText(session.summary, 200) }}
             </div>
-            <div v-else class="text-body-2 text-disabled mb-3">
+            <div v-else class="text-body-medium text-disabled mb-3">
               {{ $t('sessions.noSummary') }}
             </div>
 
@@ -234,14 +234,14 @@
                 </v-card-title>
                 <v-card-text v-if="!hasCalendar" class="text-center py-4">
                   <v-icon size="48" color="warning" class="mb-2">mdi-calendar-alert</v-icon>
-                  <p class="text-body-2 text-medium-emphasis">
+                  <p class="text-body-medium text-medium-emphasis">
                     {{ $t('calendar.noCalendarConfigured') }}
                   </p>
                 </v-card-text>
                 <v-card-text v-else-if="useInGameDate" class="pt-0">
                   <v-row>
                     <v-col cols="12" md="6">
-                      <v-label class="text-subtitle-2 mb-2">{{ $t('sessions.inGameDateStart') }}</v-label>
+                      <v-label class="text-title-small mb-2">{{ $t('sessions.inGameDateStart') }}</v-label>
                       <CalendarInGameDatePicker
                         v-model="inGameDateStart"
                         :calendar-data="calendarData"
@@ -250,7 +250,7 @@
                       />
                     </v-col>
                     <v-col cols="12" md="6">
-                      <v-label class="text-subtitle-2 mb-2">{{ $t('sessions.inGameDateEnd') }}</v-label>
+                      <v-label class="text-title-small mb-2">{{ $t('sessions.inGameDateEnd') }}</v-label>
                       <CalendarInGameDatePicker
                         v-model="inGameDateEnd"
                         :calendar-data="calendarData"
@@ -273,7 +273,7 @@
               />
 
               <div class="d-flex align-center mb-4">
-                <div class="text-h6">
+                <div class="text-headline-small">
                   {{ $t('sessions.notes') }}
                 </div>
                 <v-spacer />
@@ -302,7 +302,7 @@
                 >
                   <div class="text-center">
                     <v-progress-circular indeterminate size="64" color="primary" />
-                    <div class="text-h6 mt-4">{{ smoothingText ? $t('sessions.smoothingText') : $t('common.uploading') }}</div>
+                    <div class="text-headline-small mt-4">{{ smoothingText ? $t('sessions.smoothingText') : $t('common.uploading') }}</div>
                   </div>
                 </v-overlay>
 
@@ -343,7 +343,7 @@
 
             <!-- Attendance Tab -->
             <v-tabs-window-item value="attendance">
-              <div class="text-h6 mb-4">
+              <div class="text-headline-small mb-4">
                 {{ $t('sessions.playerAttendance') }}
               </div>
 
@@ -351,7 +351,7 @@
                 <v-progress-circular indeterminate />
               </div>
 
-              <div v-else-if="allPlayers.length === 0" class="text-body-2 text-disabled">
+              <div v-else-if="allPlayers.length === 0" class="text-body-medium text-disabled">
                 {{ $t('sessions.noPlayers') }}
               </div>
 
@@ -393,7 +393,7 @@
 
             <!-- Mentions Tab -->
             <v-tabs-window-item value="mentions">
-              <div class="text-h6 mb-4">
+              <div class="text-headline-small mb-4">
                 {{ $t('sessions.linkedEntities') }}
               </div>
 
@@ -411,7 +411,7 @@
                   {{ mention.name }}
                 </v-chip>
               </div>
-              <div v-else class="text-body-2 text-disabled">
+              <div v-else class="text-body-medium text-disabled">
                 {{ $t('sessions.noMentions') }}
               </div>
             </v-tabs-window-item>
@@ -484,14 +484,14 @@
               </v-card-title>
               <v-card-text v-if="!hasCalendar" class="text-center py-4">
                 <v-icon size="48" color="warning" class="mb-2">mdi-calendar-alert</v-icon>
-                <p class="text-body-2 text-medium-emphasis">
+                <p class="text-body-medium text-medium-emphasis">
                   {{ $t('calendar.noCalendarConfigured') }}
                 </p>
               </v-card-text>
               <v-card-text v-else-if="useInGameDate" class="pt-0">
                 <v-row>
                   <v-col cols="12" md="6">
-                    <v-label class="text-subtitle-2 mb-2">{{ $t('sessions.inGameDateStart') }}</v-label>
+                    <v-label class="text-title-small mb-2">{{ $t('sessions.inGameDateStart') }}</v-label>
                     <CalendarInGameDatePicker
                       v-model="inGameDateStart"
                       :calendar-data="calendarData"
@@ -500,7 +500,7 @@
                     />
                   </v-col>
                   <v-col cols="12" md="6">
-                    <v-label class="text-subtitle-2 mb-2">{{ $t('sessions.inGameDateEnd') }}</v-label>
+                    <v-label class="text-title-small mb-2">{{ $t('sessions.inGameDateEnd') }}</v-label>
                     <CalendarInGameDatePicker
                       v-model="inGameDateEnd"
                       :calendar-data="calendarData"
@@ -523,7 +523,7 @@
             />
 
             <div class="d-flex align-center mb-4">
-              <div class="text-h6">
+              <div class="text-headline-small">
                 {{ $t('sessions.notes') }}
               </div>
               <v-spacer />
@@ -552,7 +552,7 @@
               >
                 <div class="text-center">
                   <v-progress-circular indeterminate size="64" color="primary" />
-                  <div class="text-h6 mt-4">{{ smoothingText ? $t('sessions.smoothingText') : $t('common.uploading') }}</div>
+                  <div class="text-headline-small mt-4">{{ smoothingText ? $t('sessions.smoothingText') : $t('common.uploading') }}</div>
                 </div>
               </v-overlay>
 
@@ -603,7 +603,7 @@
         </v-card-subtitle>
 
         <v-card-text style="max-height: 70vh">
-          <div v-if="viewingSession.summary" class="text-body-1 mb-4">
+          <div v-if="viewingSession.summary" class="text-body-large mb-4">
             {{ viewingSession.summary }}
           </div>
 

--- a/packages/app/app/pages/settings.vue
+++ b/packages/app/app/pages/settings.vue
@@ -282,6 +282,40 @@
       </v-card-text>
     </v-card>
 
+    <!-- Feature Tooltips Section -->
+    <v-card class="mt-6">
+      <v-card-text>
+        <div class="mb-4">
+          <h2 class="text-headline-small mb-2">
+            {{ $t('featureTooltips.settings.title') }}
+          </h2>
+          <p class="text-medium-emphasis text-body-medium mb-0">
+            {{ $t('featureTooltips.settings.description') }}
+          </p>
+        </div>
+
+        <v-switch
+          :model-value="featureTooltipsEnabled"
+          :label="$t('featureTooltips.settings.showToggle')"
+          color="primary"
+          hide-details
+          inset
+          density="comfortable"
+          @update:model-value="setFeatureTooltipsEnabled"
+        />
+
+        <v-btn
+          variant="outlined"
+          color="secondary"
+          class="mt-3"
+          @click="resetAllFeatureTooltips"
+        >
+          <v-icon start>mdi-restart</v-icon>
+          {{ $t('featureTooltips.settings.resetButton') }}
+        </v-btn>
+      </v-card-text>
+    </v-card>
+
     <!-- Success/Error Snackbar -->
     <v-snackbar v-model="snackbar.show" :color="snackbar.color" :timeout="3000">
       {{ snackbar.message }}
@@ -292,12 +326,24 @@
 <script setup lang="ts">
 import { useAnnouncements } from '~/composables/useAnnouncements'
 import { useElectron } from '~/composables/useElectron'
+import { useFeatureTooltipSettings } from '~/composables/useFeatureTooltips'
 
 const { t } = useI18n()
 
 // Announcements
 const { resetAnnouncements: doResetAnnouncements, hasSeenLatest: checkHasSeenLatest } = useAnnouncements()
 const hasSeenLatest = ref(true)
+
+// Feature tooltips
+const featureTooltipSettings = useFeatureTooltipSettings()
+const featureTooltipsEnabled = featureTooltipSettings.globallyEnabled
+function setFeatureTooltipsEnabled(value: boolean | null) {
+  featureTooltipSettings.setGloballyEnabled(value ?? false)
+}
+function resetAllFeatureTooltips() {
+  featureTooltipSettings.resetAllDismissed()
+  snackbar.value = { show: true, color: 'success', message: t('featureTooltips.settings.resetButton') }
+}
 
 function resetAnnouncements() {
   doResetAnnouncements()

--- a/packages/app/app/pages/settings.vue
+++ b/packages/app/app/pages/settings.vue
@@ -2,7 +2,7 @@
   <v-container>
     <!-- Page Header -->
     <div class="mb-6">
-      <h1 class="text-h4 mb-2">
+      <h1 class="text-headline-large mb-2">
         {{ $t('settings.title') }}
       </h1>
       <p class="text-medium-emphasis">
@@ -15,7 +15,7 @@
       <v-card-text>
         <!-- AI Integration Section -->
         <div class="mb-6">
-          <h2 class="text-h6 mb-4">
+          <h2 class="text-headline-small mb-4">
             {{ $t('settings.sections.ai') }}
           </h2>
 
@@ -59,7 +59,7 @@
               />
             </template>
             <template #details>
-              <a href="https://platform.openai.com/api-keys" target="_blank" class="text-caption text-primary">
+              <a href="https://platform.openai.com/api-keys" target="_blank" class="text-body-small text-primary">
                 {{ $t('settings.ai.openaiHowToGetKey') }}
                 <v-icon size="x-small">mdi-open-in-new</v-icon>
               </a>
@@ -91,7 +91,7 @@
               />
             </template>
             <template #details>
-              <a href="https://aistudio.google.com/apikey" target="_blank" class="text-caption text-primary">
+              <a href="https://aistudio.google.com/apikey" target="_blank" class="text-body-small text-primary">
                 {{ $t('settings.ai.geminiHowToGetKey') }}
                 <v-icon size="x-small">mdi-open-in-new</v-icon>
               </a>
@@ -148,7 +148,7 @@
             @click:close="testResult = null"
           >
             {{ testResult.message }}
-            <div v-if="testResult.success && testResult.modelsAvailable" class="text-caption mt-1">
+            <div v-if="testResult.success && testResult.modelsAvailable" class="text-body-small mt-1">
               {{ testResult.modelsAvailable }} {{ $t('settings.ai.modelsAvailable') }}
             </div>
           </v-alert>
@@ -173,17 +173,17 @@
     <v-card v-if="isElectron" class="mt-6">
       <v-card-text>
         <div class="mb-6">
-          <h2 class="text-h6 mb-2">
+          <h2 class="text-headline-small mb-2">
             {{ $t('settings.dataManagement.title') }}
           </h2>
-          <p class="text-medium-emphasis text-body-2">
+          <p class="text-medium-emphasis text-body-medium">
             {{ $t('settings.dataManagement.subtitle') }}
           </p>
         </div>
 
         <!-- Storage Path Info -->
         <v-alert v-if="dataPaths" type="info" variant="tonal" density="compact" class="mb-4">
-          <div class="text-caption">
+          <div class="text-body-small">
             <strong>{{ $t('settings.dataManagement.storagePath') }}:</strong><br />
             {{ dataPaths.databasePath }}
           </div>
@@ -213,7 +213,7 @@
         </div>
 
         <!-- Hints -->
-        <div class="mt-3 text-caption text-medium-emphasis">
+        <div class="mt-3 text-body-small text-medium-emphasis">
           <p>{{ $t('settings.dataManagement.exportDatabaseHint') }}</p>
           <p>{{ $t('settings.dataManagement.openUploadsFolderHint') }}</p>
         </div>
@@ -224,17 +224,17 @@
     <v-card class="mt-6">
       <v-card-text>
         <div class="mb-4">
-          <h2 class="text-h6 mb-2">
+          <h2 class="text-headline-small mb-2">
             {{ $t('settings.sections.logs') }}
           </h2>
-          <p class="text-medium-emphasis text-body-2">
+          <p class="text-medium-emphasis text-body-medium">
             {{ $t('settings.logs.subtitle') }}
           </p>
         </div>
 
         <!-- Log Path Info -->
         <v-alert v-if="logPath" type="info" variant="tonal" density="compact" class="mb-4">
-          <div class="text-caption">
+          <div class="text-body-small">
             <strong>{{ $t('settings.logs.logPath') }}:</strong><br />
             {{ logPath }}
           </div>
@@ -251,7 +251,7 @@
           {{ $t('settings.logs.openFolder') }}
         </v-btn>
 
-        <div class="mt-2 text-caption text-medium-emphasis">
+        <div class="mt-2 text-body-small text-medium-emphasis">
           {{ $t('settings.logs.hint') }}
         </div>
       </v-card-text>
@@ -261,7 +261,7 @@
     <v-card class="mt-6">
       <v-card-text>
         <div class="mb-4">
-          <h2 class="text-h6 mb-2">
+          <h2 class="text-headline-small mb-2">
             {{ $t('settings.sections.announcements') }}
           </h2>
         </div>
@@ -276,7 +276,7 @@
           {{ $t('announcements.resetButton') }}
         </v-btn>
 
-        <div class="mt-2 text-caption text-medium-emphasis">
+        <div class="mt-2 text-body-small text-medium-emphasis">
           {{ hasSeenLatest ? $t('settings.announcements.alreadySeen') : $t('settings.announcements.notSeen') }}
         </div>
       </v-card-text>

--- a/packages/app/app/plugins/vuetify.ts
+++ b/packages/app/app/plugins/vuetify.ts
@@ -94,6 +94,18 @@ export default defineNuxtPlugin((nuxtApp) => {
         dark: darkTheme,
       },
     },
+    // Pin the v3 breakpoint thresholds so layouts written against v3 still match v4.
+    // v4 default breakpoints are smaller and shift everything down — see #301.
+    display: {
+      thresholds: {
+        xs: 0,
+        sm: 600,
+        md: 960,
+        lg: 1280,
+        xl: 1920,
+        xxl: 2560,
+      },
+    },
     defaults: {
       global: {
         elevation: 0, // No elevation as requested

--- a/packages/app/app/plugins/vuetify.ts
+++ b/packages/app/app/plugins/vuetify.ts
@@ -4,81 +4,21 @@ import * as directives from 'vuetify/directives'
 import { de, en } from 'vuetify/locale'
 import '@mdi/font/css/materialdesignicons.css'
 import 'vuetify/styles'
-
-// DnD-inspired theme colors
-const lightTheme = {
-  dark: false,
-  colors: {
-    // "Aged Parchment" theme
-    'background': '#F5F1E8', // Warm parchment white
-    'surface': '#FFFFFF',
-    'surface-variant': '#E8DCC4',
-    'on-surface-variant': '#4A4035',
-    'primary': '#8B4513', // Saddle brown (leather binding)
-    'primary-darken-1': '#654321',
-    'secondary': '#B8860B', // Dark goldenrod (old gold)
-    'secondary-darken-1': '#996515',
-    'accent': '#8B0000', // Burgundy (sealing wax)
-    'error': '#C62828',
-    'info': '#5B7C99', // Gray-blue (ink)
-    'success': '#558B2F',
-    'warning': '#F57C00',
-    'on-background': '#2C1810',
-    'on-surface': '#2C1810',
-    'on-primary': '#FFFFFF',
-    'on-secondary': '#2C1810',
-  },
-  variables: {
-    // Custom CSS vars für md-editor-v3 (LIGHT)
-    'md-bg': '#FFFFFF',
-    'md-surface': '#F5F1E8',
-    'md-text': '#2C1810',
-    'md-muted': '#4A4035',
-    'md-border': '#E8DCC4',
-    'md-primary': '#8B4513',
-    'md-code-bg': '#FAF6EE',
-    'md-quote-bg': '#FFF9F0',
-    'md-table-stripe': '#FAF2E3',
-  },
-}
-
-const darkTheme = {
-  dark: true,
-  colors: {
-    // "Midnight Tavern" theme
-    'background': '#1A1D29', // Dark tavern
-    'surface': '#232632',
-    'surface-variant': '#2D3142',
-    'on-surface-variant': '#C5B8A0',
-    'primary': '#D4A574', // Warm gold
-    'primary-darken-1': '#B8935F',
-    'secondary': '#8B7355', // Dark leather
-    'secondary-darken-1': '#6B5742',
-    'accent': '#CC8844', // Amber
-    'error': '#D32F2F',
-    'info': '#7B92AB', // Moonlight blue
-    'success': '#689F38',
-    'warning': '#F57C00',
-    'on-background': '#E8DCC4',
-    'on-surface': '#E8DCC4',
-    'on-primary': '#1A1D29',
-    'on-secondary': '#E8DCC4',
-  },
-  variables: {
-    // Custom CSS vars für md-editor-v3 (DARK)
-    'md-bg': '#1A1D29',
-    'md-surface': '#232632',
-    'md-text': '#E8DCC4',
-    'md-muted': '#C5B8A0',
-    'md-border': '#2D3142',
-    'md-primary': '#D4A574',
-    'md-code-bg': '#11151F',
-    'md-quote-bg': '#202534',
-    'md-table-stripe': '#1F2330',
-  },
-}
+import { themes, DEFAULT_THEME, THEME_NAMES, type ThemeName } from '~/composables/themes'
+import { THEME_COOKIE } from '~/composables/useThemePreference'
 
 export default defineNuxtPlugin((nuxtApp) => {
+  // Read the saved theme cookie so SSR renders with the correct theme from
+  // the start — no flash of dark mode on first paint.
+  const savedTheme = useCookie<ThemeName>(THEME_COOKIE, {
+    default: () => DEFAULT_THEME,
+    maxAge: 60 * 60 * 24 * 365,
+    sameSite: 'lax',
+  })
+  const initialTheme = (THEME_NAMES as readonly string[]).includes(savedTheme.value)
+    ? savedTheme.value
+    : DEFAULT_THEME
+
   const vuetify = createVuetify({
     components,
     directives,
@@ -88,11 +28,8 @@ export default defineNuxtPlugin((nuxtApp) => {
       messages: { de, en },
     },
     theme: {
-      defaultTheme: 'dark',
-      themes: {
-        light: lightTheme,
-        dark: darkTheme,
-      },
+      defaultTheme: initialTheme,
+      themes,
     },
     // Pin the v3 breakpoint thresholds so layouts written against v3 still match v4.
     // v4 default breakpoints are smaller and shift everything down — see #301.

--- a/packages/app/i18n/locales/de.json
+++ b/packages/app/i18n/locales/de.json
@@ -34,7 +34,28 @@
     "referenceData": "Referenzdaten",
     "settings": "Einstellungen",
     "theme": "Theme",
+    "themePickerTitle": "Theme auswählen",
     "activeCampaign": "Aktive Kampagne"
+  },
+  "themes": {
+    "dark": "Dunkel (Mitternachts-Taverne)",
+    "hell": "Hell (Altes Pergament)",
+    "linux": "Linux (Aubergine)",
+    "green": "Grün (Wald)",
+    "blue": "Blau (Ozean)",
+    "purple": "Lila (Arkane Magie)",
+    "orange": "Orange (Lagerfeuer)"
+  },
+  "featureTooltips": {
+    "newBadge": "Neu",
+    "dontShowAgain": "Nicht mehr zeigen",
+    "themeSwitcher": "Wähle dein Lieblings-Theme aus 7 Farbvarianten. Du kannst diese Hinweise in den Einstellungen ausschalten.",
+    "settings": {
+      "title": "Hinweise für neue Funktionen",
+      "description": "Zeigt einen kleinen Hinweis an, wenn ein neues Feature verfügbar ist.",
+      "showToggle": "Hinweise für neue Funktionen zeigen",
+      "resetButton": "Alle ausgeblendeten Hinweise wieder anzeigen"
+    }
   },
   "search": {
     "placeholder": "Suche nach NPCs, Orten, Items, Gruppen...",
@@ -1476,6 +1497,7 @@
     "view": "Ansehen",
     "close": "Schließen",
     "ok": "OK",
+    "reset": "Zurücksetzen",
     "saveInTabHint": "Änderungen in diesem Tab direkt speichern",
     "unsavedTabChanges": "Erst Änderungen speichern oder abbrechen: {tabs}",
     "clear": "Löschen",

--- a/packages/app/i18n/locales/en.json
+++ b/packages/app/i18n/locales/en.json
@@ -34,7 +34,28 @@
     "referenceData": "Reference Data",
     "settings": "Settings",
     "theme": "Theme",
+    "themePickerTitle": "Pick a theme",
     "activeCampaign": "Active Campaign"
+  },
+  "themes": {
+    "dark": "Dark (Midnight Tavern)",
+    "hell": "Light (Aged Parchment)",
+    "linux": "Linux (Aubergine)",
+    "green": "Green (Forest)",
+    "blue": "Blue (Ocean)",
+    "purple": "Purple (Arcane)",
+    "orange": "Orange (Campfire)"
+  },
+  "featureTooltips": {
+    "newBadge": "New",
+    "dontShowAgain": "Don't show again",
+    "themeSwitcher": "Pick your favorite theme from 7 color variants. You can turn these hints off in Settings.",
+    "settings": {
+      "title": "New-feature hints",
+      "description": "Shows a small hint when a new feature is available.",
+      "showToggle": "Show new-feature hints",
+      "resetButton": "Show all dismissed hints again"
+    }
   },
   "search": {
     "placeholder": "Search for NPCs, locations, items, groups...",
@@ -1483,6 +1504,7 @@
     "view": "View",
     "close": "Close",
     "ok": "OK",
+    "reset": "Reset",
     "saveInTabHint": "Save changes directly in this tab",
     "unsavedTabChanges": "Save or cancel changes first: {tabs}",
     "clear": "Clear",

--- a/packages/app/nuxt.config.ts
+++ b/packages/app/nuxt.config.ts
@@ -12,6 +12,8 @@ export default defineNuxtConfig({
   },
 
   css: [
+    // MUST be first so the layer order is established before vuetify ships its layers
+    '@/assets/css/layer-order.css',
     'vuetify/styles',
     '@mdi/font/css/materialdesignicons.css',
     '@/assets/md-editor-theme.css',

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -172,7 +172,7 @@
     "vue-pdf-embed": "^2.1.4",
     "vue-router": "^5.0.7",
     "vuedraggable": "^4.1.0",
-    "vuetify": "^3.12.6"
+    "vuetify": "^4.0.7"
   },
   "devDependencies": {
     "@electron/notarize": "^3.1.1",

--- a/packages/app/test/unit/feature-tooltips.test.ts
+++ b/packages/app/test/unit/feature-tooltips.test.ts
@@ -2,8 +2,9 @@ import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { ref, computed } from 'vue'
 
 // Mock vue auto-imports used by the composable
-;(globalThis as Record<string, unknown>).ref = ref
-;(globalThis as Record<string, unknown>).computed = computed
+const globalThisRecord = globalThis as Record<string, unknown>
+globalThisRecord.ref = ref
+globalThisRecord.computed = computed
 
 Object.defineProperty(globalThis, 'window', { value: {}, configurable: true })
 
@@ -15,10 +16,10 @@ const localStorageMock = {
     storage[k] = v
   },
   removeItem: (k: string) => {
-    delete storage[k]
+    Reflect.deleteProperty(storage, k)
   },
   clear: () => {
-    for (const k of Object.keys(storage)) delete storage[k]
+    for (const k of Object.keys(storage)) Reflect.deleteProperty(storage, k)
   },
 }
 Object.defineProperty(globalThis, 'localStorage', { value: localStorageMock, configurable: true })

--- a/packages/app/test/unit/feature-tooltips.test.ts
+++ b/packages/app/test/unit/feature-tooltips.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { ref, computed } from 'vue'
+
+// Mock vue auto-imports used by the composable
+;(globalThis as Record<string, unknown>).ref = ref
+;(globalThis as Record<string, unknown>).computed = computed
+
+Object.defineProperty(globalThis, 'window', { value: {}, configurable: true })
+
+// In-memory localStorage mock
+const storage: Record<string, string> = {}
+const localStorageMock = {
+  getItem: (k: string) => (k in storage ? storage[k] : null),
+  setItem: (k: string, v: string) => {
+    storage[k] = v
+  },
+  removeItem: (k: string) => {
+    delete storage[k]
+  },
+  clear: () => {
+    for (const k of Object.keys(storage)) delete storage[k]
+  },
+}
+Object.defineProperty(globalThis, 'localStorage', { value: localStorageMock, configurable: true })
+
+describe('useFeatureTooltips', () => {
+  beforeEach(async () => {
+    localStorageMock.clear()
+    vi.resetModules()
+  })
+
+  it('shouldShow=true initially when not dismissed', async () => {
+    const { useFeatureTooltip } = await import('../../app/composables/useFeatureTooltips')
+    const { shouldShow } = useFeatureTooltip('test-key')
+    expect(shouldShow.value).toBe(true)
+  })
+
+  it('session dismiss hides for current session but does not persist', async () => {
+    const { useFeatureTooltip } = await import('../../app/composables/useFeatureTooltips')
+    const { shouldShow, dismissForSession } = useFeatureTooltip('test-key')
+
+    expect(shouldShow.value).toBe(true)
+    dismissForSession()
+    expect(shouldShow.value).toBe(false)
+    // Nothing written to localStorage
+    expect(localStorageMock.getItem('dm-hero-feature-tips-dismissed')).toBe(null)
+  })
+
+  it('permanent dismiss persists to localStorage', async () => {
+    const { useFeatureTooltip } = await import('../../app/composables/useFeatureTooltips')
+    const { shouldShow, dismissPermanent } = useFeatureTooltip('test-key')
+
+    dismissPermanent()
+    expect(shouldShow.value).toBe(false)
+    expect(localStorageMock.getItem('dm-hero-feature-tips-dismissed')).toContain('test-key')
+  })
+
+  it('permanent dismiss survives module reload', async () => {
+    const mod1 = await import('../../app/composables/useFeatureTooltips')
+    mod1.useFeatureTooltip('persistent-key').dismissPermanent()
+
+    vi.resetModules()
+    const mod2 = await import('../../app/composables/useFeatureTooltips')
+    const { shouldShow } = mod2.useFeatureTooltip('persistent-key')
+    expect(shouldShow.value).toBe(false)
+  })
+
+  it('session dismiss does NOT survive module reload', async () => {
+    const mod1 = await import('../../app/composables/useFeatureTooltips')
+    mod1.useFeatureTooltip('session-only').dismissForSession()
+
+    vi.resetModules()
+    const mod2 = await import('../../app/composables/useFeatureTooltips')
+    const { shouldShow } = mod2.useFeatureTooltip('session-only')
+    expect(shouldShow.value).toBe(true)
+  })
+
+  it('global disable hides all tooltips regardless of key', async () => {
+    const mod = await import('../../app/composables/useFeatureTooltips')
+    const a = mod.useFeatureTooltip('feature-a')
+    const b = mod.useFeatureTooltip('feature-b')
+    expect(a.shouldShow.value).toBe(true)
+    expect(b.shouldShow.value).toBe(true)
+
+    mod.useFeatureTooltipSettings().setGloballyEnabled(false)
+
+    expect(a.shouldShow.value).toBe(false)
+    expect(b.shouldShow.value).toBe(false)
+  })
+
+  it('global disable persists to localStorage', async () => {
+    const mod = await import('../../app/composables/useFeatureTooltips')
+    mod.useFeatureTooltipSettings().setGloballyEnabled(false)
+    expect(localStorageMock.getItem('dm-hero-feature-tips-disabled')).toBe('1')
+  })
+
+  it('resetAllDismissed clears both permanent and session dismissals', async () => {
+    const mod = await import('../../app/composables/useFeatureTooltips')
+    const { shouldShow: showA, dismissPermanent } = mod.useFeatureTooltip('a')
+    const { shouldShow: showB, dismissForSession } = mod.useFeatureTooltip('b')
+
+    dismissPermanent()
+    dismissForSession()
+    expect(showA.value).toBe(false)
+    expect(showB.value).toBe(false)
+
+    mod.useFeatureTooltipSettings().resetAllDismissed()
+
+    expect(showA.value).toBe(true)
+    expect(showB.value).toBe(true)
+    expect(localStorageMock.getItem('dm-hero-feature-tips-dismissed')).toBe('')
+  })
+
+  it('multiple composable calls for same key share state', async () => {
+    const { useFeatureTooltip } = await import('../../app/composables/useFeatureTooltips')
+    const a = useFeatureTooltip('shared')
+    const b = useFeatureTooltip('shared')
+
+    a.dismissForSession()
+    expect(b.shouldShow.value).toBe(false)
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,7 +86,7 @@ importers:
         version: 0.12.3
       vite-plugin-vuetify:
         specifier: ^2.1.3
-        version: 2.1.3(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3))(vuetify@3.12.6)
+        version: 2.1.3(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3))(vuetify@4.0.7)
       vue:
         specifier: ^3.5.35
         version: 3.5.35(typescript@6.0.3)
@@ -100,8 +100,8 @@ importers:
         specifier: ^4.1.0
         version: 4.1.0(vue@3.5.35(typescript@6.0.3))
       vuetify:
-        specifier: ^3.12.6
-        version: 3.12.6(typescript@6.0.3)(vite-plugin-vuetify@2.1.3)(vue@3.5.35(typescript@6.0.3))
+        specifier: ^4.0.7
+        version: 4.0.7(typescript@6.0.3)(vite-plugin-vuetify@2.1.3)(vue@3.5.35(typescript@6.0.3))
     devDependencies:
       '@electron/notarize':
         specifier: ^3.1.1
@@ -8434,6 +8434,21 @@ packages:
       webpack-plugin-vuetify:
         optional: true
 
+  vuetify@4.0.7:
+    resolution: {integrity: sha512-SV+YJkBmudY3s9qfZO2ZGUsrD0TDQU8pMBH1ERga9AEyjGvioZuXXh93V9wHxXJphvqRC2NW10Nt2lW9IZQcPw==}
+    peerDependencies:
+      typescript: '>=4.7'
+      vite-plugin-vuetify: '>=2.1.0'
+      vue: ^3.5.0
+      webpack-plugin-vuetify: '>=3.1.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+      vite-plugin-vuetify:
+        optional: true
+      webpack-plugin-vuetify:
+        optional: true
+
   w3c-keyname@2.2.8:
     resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
 
@@ -12865,6 +12880,12 @@ snapshots:
       upath: 2.0.1
       vue: 3.5.35(typescript@6.0.3)
       vuetify: 3.12.6(typescript@6.0.3)(vite-plugin-vuetify@2.1.3)(vue@3.5.35(typescript@6.0.3))
+
+  '@vuetify/loader-shared@2.1.2(vue@3.5.35(typescript@6.0.3))(vuetify@4.0.7)':
+    dependencies:
+      upath: 2.0.1
+      vue: 3.5.35(typescript@6.0.3)
+      vuetify: 4.0.7(typescript@6.0.3)(vite-plugin-vuetify@2.1.3)(vue@3.5.35(typescript@6.0.3))
 
   '@vueuse/core@13.9.0(vue@3.5.35(typescript@6.0.3))':
     dependencies:
@@ -18515,14 +18536,14 @@ snapshots:
       vite: 8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0)
       vue: 3.5.35(typescript@6.0.3)
 
-  vite-plugin-vuetify@2.1.3(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3))(vuetify@3.12.6):
+  vite-plugin-vuetify@2.1.3(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3))(vuetify@4.0.7):
     dependencies:
-      '@vuetify/loader-shared': 2.1.2(vue@3.5.35(typescript@6.0.3))(vuetify@3.12.6)
+      '@vuetify/loader-shared': 2.1.2(vue@3.5.35(typescript@6.0.3))(vuetify@4.0.7)
       debug: 4.4.3
       upath: 2.0.1
       vite: 8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0)
       vue: 3.5.35(typescript@6.0.3)
-      vuetify: 3.12.6(typescript@6.0.3)(vite-plugin-vuetify@2.1.3)(vue@3.5.35(typescript@6.0.3))
+      vuetify: 4.0.7(typescript@6.0.3)(vite-plugin-vuetify@2.1.3)(vue@3.5.35(typescript@6.0.3))
     transitivePeerDependencies:
       - supports-color
 
@@ -18766,7 +18787,14 @@ snapshots:
       vue: 3.5.35(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
-      vite-plugin-vuetify: 2.1.3(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3))(vuetify@3.12.6)
+      vite-plugin-vuetify: 2.1.3(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3))(vuetify@3.12.6)
+
+  vuetify@4.0.7(typescript@6.0.3)(vite-plugin-vuetify@2.1.3)(vue@3.5.35(typescript@6.0.3)):
+    dependencies:
+      vue: 3.5.35(typescript@6.0.3)
+    optionalDependencies:
+      typescript: 6.0.3
+      vite-plugin-vuetify: 2.1.3(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3))(vuetify@4.0.7)
 
   w3c-keyname@2.2.8: {}
 


### PR DESCRIPTION
closes #301.

big migration. app-only — landing stays on vuetify 3.

## migration

- **vuetify 3.12 → 4.0.7** with `vite-plugin-vuetify 2.1.3` (still compatible)
- **breakpoints pinned** to v3 thresholds via `display.thresholds` so layouts written against v3 still match (v4 defaults are smaller)
- **css layers**: `@layer base, vuetify, overrides;` declared first; `dashboard.css`, `animations.css`, `md-editor-theme.css` wrapped in `@layer overrides {}` so app styles win without `!important`
- **typography md2 → md3**: 400+ class renames across 90 files (`text-h1`…`text-h6` → `text-display-*`/`text-headline-*`, `text-body-1/2` → `text-body-large/medium`, `text-caption` → `text-body-small`, `text-subtitle-*` → `text-title-*`, `text-button/overline` → `text-label-*`)
- **slot prop rename `item` → `internalItem`** in all `#item` / `#selection` / `#chip` slots — 35 occurrences across 11 files (`v-select`, `v-autocomplete`, `v-combobox`)
- **v-treeview rebuild** (locations page): `TreeNode extends Location` so the flat shape works with v4's `item.raw = TreeNode` slot signature, standard expand/collapse icons, `padding-block` only (`padding` shorthand killed v4's `padding-inline-start` indent), `children: undefined` for leaves (v4 treats `[]` as expandable)

## new feature work on top

- **7 themes**: `dark` (default, midnight tavern), `hell` (aged parchment), `linux` (aubergine/ubuntu), `green` (forest), `blue` (ocean), `purple` (arcane), `orange` (campfire)
- **theme switcher** in navigation drawer with color swatches per theme + reset
- **cookie persistence**: theme is read on the server during ssr → no flash of dark mode on first paint
- **feature-tooltip bubble** (`components/shared/FeatureTooltip.vue`): reusable, teleport-to-body, smart auto-flip if no room on preferred side, arrow pinned to anchor center, rAF-throttled scroll/resize. **session-dismiss** on click (comes back next start) vs **permanent-dismiss** with the "don't show again" checkbox
- **settings page**: global toggle for new-feature hints + "show all dismissed hints again" button
- **drawer layout**: header (DM Hero + active campaign) is now sticky-top, settings/theme switcher sticky-bottom, only nav items scroll

## not in this pr (deferred)

- archiver 8 → done separately (#302, merged)
- electron 42 → blocked on better-sqlite3 incompat, parked at electron 41
- vuetify-side `v-form`, `v-date-picker` range, `v-img` attr pass-through breaking changes — not used in app code

## verified

- 1294 unit tests green (1285 + 9 new for `useFeatureTooltips`)
- tsc clean
- eslint clean (warnings only — pre-existing unused vars)
- both nuxt builds successful
- smoke-tested in dev:electron: locations tree (incl. archive + view dialog), npc edit dialog (type/status selects with icons), item edit dialog (currency symbol), map marker dialog, calendar event/settings, theme switcher + first-time bubble + persistence after reload

## smoke test checklist for review

- [ ] theme switcher reachable, all 7 themes selectable, persists after reload
- [ ] first launch shows the "neu" bubble next to the theme switcher; click closes it for the session, with checkbox closes it permanently
- [ ] settings page → "feature-tooltips" section toggles and resets correctly
- [ ] no flash of dark mode on hard reload when on a non-default theme
- [ ] locations tree: indent, expand arrows only on parents, archive icon toggles, view dialog opens with content

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Upgraded to Vuetify 4 with seven new themes (dark, hell, linux, green, blue, purple, orange)
  * Added persistent theme switcher to navigation
  * Introduced feature tooltip system for new-feature hints
  * Added global toggle and reset for feature tooltips in settings

* **Style**
  * Updated visual styling and typography throughout the app

* **Tests**
  * Added unit tests for feature tooltip functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->