### PR TITLE
fix: show npc names in npc view relations tab

### DIFF
--- a/.changeset/fix-npc-view-relations.md
+++ b/.changeset/fix-npc-view-relations.md
@@ -1,0 +1,5 @@
+---
+"@dm-hero/app": patch
+---
+
+fix: show npc names and use correct id in the npc view relations tab (map api fields `related_npc_name` / `related_npc_id` instead of the non-existent `name` / `id`)

--- a/packages/app/app/components/npcs/NpcViewDialog.vue
+++ b/packages/app/app/components/npcs/NpcViewDialog.vue
@@ -192,7 +192,7 @@
                   :key="rel.relation_id"
                   class="mb-2"
                   style="cursor: pointer"
-                  @click="$emit('view-npc', rel.id)"
+                  @click="$emit('view-npc', rel.related_npc_id)"
                 >
                   <template #prepend>
                     <v-avatar color="primary" size="48">
@@ -201,7 +201,7 @@
                     </v-avatar>
                   </template>
                   <v-list-item-title class="font-weight-medium">
-                    {{ rel.name }}
+                    {{ rel.related_npc_name }}
                   </v-list-item-title>
                   <v-list-item-subtitle>
                     <div class="d-flex align-center ga-2 mt-1">
@@ -371,9 +371,9 @@ const counts = computed(() => (props.npc ? getCounts(props.npc.id) || props.npc.
 // Data refs
 const relations = ref<
   Array<{
-    id: number
     relation_id: number
-    name: string
+    related_npc_id: number
+    related_npc_name: string
     relation_type: string
     notes?: string
     image_url?: string
@@ -456,9 +456,9 @@ watch(
       const [relationsData, itemsData, locationsData, documentsData, imagesData, loreData, playersData] = await Promise.all([
         $fetch<
           Array<{
-            id: number
             relation_id: number
-            name: string
+            related_npc_id: number
+            related_npc_name: string
             relation_type: string
             notes?: string
             image_url?: string


### PR DESCRIPTION
closes #308.

the npc view dialog "relations" tab showed only avatars and chips — no names. cause was a field-name mismatch with the api response, not a vuetify 4 bug. the same code shape has been wrong for a while; vuetify 4's tighter md3 typography just made the empty title-slot more obvious.

## change

- api `/api/npcs/[id]/relations` returns `related_npc_name` and `related_npc_id`, not `name` / `id`
- updated the typescript types and template in `NpcViewDialog.vue` accordingly

only one call site was affected — `NpcRelationsTab.vue` (the edit dialog tab) already mapped the field correctly.

## verified

- 1294 unit tests green
- tsc clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the NPC relations tab to display related NPC names correctly and ensure clicking on a relation navigates to the proper related NPC.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Flo0806/dm-hero/pull/309?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->