### PR TITLE
fix: align docker uploads path with code

### DIFF
--- a/.changeset/fix-docker-uploads-path.md
+++ b/.changeset/fix-docker-uploads-path.md
@@ -1,0 +1,5 @@
+---
+"@dm-hero/app": patch
+---
+
+fix: persist uploaded files in docker — `docker-compose.yml` and the dockerfile now use `/app/uploads`, which is where the server actually writes. previously uploads landed in a directory that was not the docker volume mount and were lost on container restart.

--- a/Dockerfile
+++ b/Dockerfile
@@ -71,10 +71,13 @@ RUN cd $(find node_modules/.pnpm -type d -name "better-sqlite3" -path "*/node_mo
 # Go back to app root
 WORKDIR /app
 
-# Create data directory for SQLite database and upload directories
+# Create data directory for SQLite database and upload directories.
+# Uploads land in /app/uploads (process.cwd()/uploads) — the /uploads/*
+# route is served by server/middleware/uploads.ts, not by serving the
+# .output/public folder.
 RUN mkdir -p /app/data && \
-    mkdir -p /app/.output/public/uploads && \
-    mkdir -p /app/.output/public/uploads/audio && \
+    mkdir -p /app/uploads && \
+    mkdir -p /app/uploads/audio && \
     chown -R node:node /app
 
 # Use non-root user for security

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,8 +10,9 @@ services:
     volumes:
       # Persist SQLite database
       - ./data:/app/data
-      # Persist uploaded images (note: .output/public/ path in container)
-      - ./public/uploads:/app/.output/public/uploads
+      # Persist uploaded files (images, audio, etc.) — the server writes to
+      # process.cwd()/uploads, which is /app/uploads inside the container.
+      - ./uploads:/app/uploads
     environment:
       # Nuxt runtime config
       NODE_ENV: production


### PR DESCRIPTION
closes #310.

uploads in docker landed in \`/app/uploads\` (where the server writes them) but the volume mount in \`docker-compose.yml\` was on \`/app/.output/public/uploads\` — so every container restart wiped the uploads.

## change

- \`docker-compose.yml\`: \`./public/uploads:/app/.output/public/uploads\` → \`./uploads:/app/uploads\`
- \`Dockerfile\`: \`mkdir -p\` now creates \`/app/uploads\` (and \`/app/uploads/audio\`) instead of the unused \`.output\` path

\`uploads/\` is already in \`.gitignore\` so no host-side cleanup needed in the repo.

## migration note for existing self-hosters

if you ran the old compose file, your previously uploaded files were saved to your host's \`./public/uploads/\` directory. before upgrading, **move them** to \`./uploads/\` host-side:

```bash
mkdir -p ./uploads
mv ./public/uploads/* ./uploads/
```

(or copy if you want to keep the old one as a backup)

## verified

- not behavior-tested in a container locally — the change is purely path strings, no code paths touched. the server already reads/writes \`process.cwd()/uploads\` per \`server/utils/paths.ts\`.