### PR TITLE
feat: emily teal theme (#318)

### DIFF
--- a/.changeset/emily-theme.md
+++ b/.changeset/emily-theme.md
@@ -1,0 +1,5 @@
+---
+"@dm-hero/app": minor
+---
+
+feat: emily teal "Deep Lagoon" theme (community tribute) with layered radial-gradient page background, coral-accented destructive actions, and a procedural distant-lightning easter egg on the dashboard (every 4–15 s, fresh bolt + branch each strike, screen-blend flash stays behind cards). Reduced-motion + animations toggle respected.

--- a/packages/app/app/assets/css/emily-theme.css
+++ b/packages/app/app/assets/css/emily-theme.css
@@ -1,0 +1,36 @@
+/*
+ * Emily theme — Deep Lagoon ambient layer.
+ *
+ * Active only when Vuetify applies `.v-theme--emily` on the root. A layered
+ * radial gradient turns the flat palette `background` color into something
+ * with depth — moonlight pooling at the top, darker water at the bottom,
+ * a hint of the coral accent up top-right. The lightning component handles
+ * the motion side of the theme; this file is purely the still picture.
+ */
+
+@layer overrides {
+  .v-theme--emily .v-application__wrap,
+  .v-theme--emily.v-application {
+    position: relative;
+    background-image:
+      /* Top-left moonlight pool */
+      radial-gradient(
+        ellipse 60% 50% at 20% 0%,
+        rgba(77, 208, 225, 0.10) 0%,
+        rgba(77, 208, 225, 0) 60%
+      ),
+      /* Bottom depth — pulls the eye downward into darker water */
+      radial-gradient(
+        ellipse 80% 60% at 50% 110%,
+        rgba(0, 0, 0, 0.35) 0%,
+        rgba(0, 0, 0, 0) 70%
+      ),
+      /* Subtle warm coral hint top-right — picks up the accent color */
+      radial-gradient(
+        ellipse 30% 30% at 90% 5%,
+        rgba(255, 123, 105, 0.06) 0%,
+        rgba(255, 123, 105, 0) 80%
+      );
+    background-attachment: fixed;
+  }
+}

--- a/packages/app/app/components/shared/EmilyLightning.vue
+++ b/packages/app/app/components/shared/EmilyLightning.vue
@@ -1,0 +1,300 @@
+<template>
+  <!-- All wrapped — strike state drives both the flash overlay and the bolt SVG -->
+  <div v-if="active" class="emily-strike" aria-hidden="true" :style="strikeStyle">
+    <!-- Atmospheric flash: a directional radial gradient from where the bolt
+         touched down. Multi-stage opacity is animated via keyframes so we get
+         pre-flash → peak → aftershocks → fade. -->
+    <div class="emily-strike__flash" />
+
+    <!-- Procedural bolt — a zig-zag path with one optional side branch,
+         freshly generated for every strike so no two ever look the same. -->
+    <svg
+      class="emily-strike__bolt"
+      :viewBox="`0 0 ${vw} ${vh}`"
+      preserveAspectRatio="none"
+    >
+      <defs>
+        <filter :id="filterId" x="-20%" y="-20%" width="140%" height="140%">
+          <feGaussianBlur stdDeviation="2.5" result="blur" />
+          <feMerge>
+            <feMergeNode in="blur" />
+            <feMergeNode in="SourceGraphic" />
+          </feMerge>
+        </filter>
+      </defs>
+      <!-- Outer glow stroke -->
+      <path
+        :d="boltPath"
+        stroke="rgba(232, 250, 255, 0.35)"
+        stroke-width="6"
+        fill="none"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        :filter="`url(#${filterId})`"
+      />
+      <!-- Branch (if any) — slightly thinner -->
+      <path
+        v-if="branchPath"
+        :d="branchPath"
+        stroke="rgba(232, 250, 255, 0.25)"
+        stroke-width="3"
+        fill="none"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        :filter="`url(#${filterId})`"
+      />
+      <!-- Inner bright core -->
+      <path
+        :d="boltPath"
+        stroke="rgba(255, 255, 255, 0.95)"
+        stroke-width="1.6"
+        fill="none"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+    </svg>
+  </div>
+</template>
+
+<script setup lang="ts">
+/**
+ * Emily theme's centerpiece easter egg: distant lightning.
+ *
+ * Each strike has its own personality:
+ *  - randomly placed origin near the top of the viewport
+ *  - procedural zig-zag bolt path (never repeats) with an optional side branch
+ *  - directional flash that brightens the whole scene from the bolt's side
+ *  - multi-stroke flicker (real lightning rarely is a single pulse)
+ *  - random screen rotation/offset per strike, never aligned with the last
+ *
+ * Gates on: theme === 'emily', prefers-reduced-motion off, animations toggle on.
+ * Self-cleans on unmount and on theme change mid-strike.
+ */
+import { useThemePreference } from '~/composables/useThemePreference'
+
+// Dashboard-only deployment: shorter cadence (4–15 s) because the user is
+// idling there and the strikes are part of the ambience. On work pages this
+// component is simply not mounted, so list/edit screens stay focused.
+const MIN_INTERVAL_MS = 4_000
+const MAX_INTERVAL_MS = 15_000
+const STRIKE_DURATION_MS = 900 // matches CSS keyframe length
+
+const ANIMATIONS_DISABLED_KEY = 'dm-hero-folder-animations-disabled'
+
+const { current } = useThemePreference()
+
+const active = ref(false)
+const boltPath = ref('')
+const branchPath = ref<string | null>(null)
+const vw = ref(1920)
+const vh = ref(1080)
+const animationsEnabled = ref(true)
+// Each strike rotates the flash origin slightly so a sequence feels alive.
+const strikeStyle = ref<Record<string, string>>({})
+const filterId = ref('emily-bolt-glow-0')
+
+let intervalTimer: ReturnType<typeof setTimeout> | null = null
+let endTimer: ReturnType<typeof setTimeout> | null = null
+let strikeCounter = 0
+
+function prefersReducedMotion(): boolean {
+  if (typeof window === 'undefined' || !window.matchMedia) return false
+  return window.matchMedia('(prefers-reduced-motion: reduce)').matches
+}
+
+function pickInterval(): number {
+  return MIN_INTERVAL_MS + Math.random() * (MAX_INTERVAL_MS - MIN_INTERVAL_MS)
+}
+
+function hydrateAnimationToggle() {
+  if (typeof localStorage === 'undefined') return
+  try {
+    animationsEnabled.value = localStorage.getItem(ANIMATIONS_DISABLED_KEY) !== '1'
+  }
+  catch {
+    // ignore quota / privacy errors
+  }
+}
+
+/**
+ * Generate a single jagged bolt path. We work in viewport-unit coordinates so
+ * the bolt scales naturally with the SVG's viewBox.
+ */
+function generateBolt(originX: number, height: number): string {
+  const segments = 7 + Math.floor(Math.random() * 5)
+  // Pulls the bolt toward the center so it doesn't always disappear sideways.
+  const targetX = vw.value * (0.3 + Math.random() * 0.4)
+  let x = originX
+  let y = 0
+  let path = `M ${x.toFixed(0)} 0`
+  for (let i = 1; i <= segments; i++) {
+    const ratio = i / segments
+    const expectedX = originX + (targetX - originX) * ratio
+    const jitter = (Math.random() - 0.5) * 80
+    x = expectedX + jitter
+    y = (height * ratio) * (0.85 + Math.random() * 0.3)
+    path += ` L ${x.toFixed(0)} ${y.toFixed(0)}`
+  }
+  return path
+}
+
+/**
+ * Optional side-branch — sprouts from a random mid-point of the main bolt and
+ * runs off at an angle. Only happens half the time, so strikes look varied.
+ */
+function generateBranch(mainBolt: string): string | null {
+  if (Math.random() > 0.5) return null
+  const points = mainBolt
+    .split(/[ML]\s*/)
+    .filter(Boolean)
+    .map((s) => {
+      const [x, y] = s.trim().split(/\s+/).map(Number)
+      return { x: x ?? 0, y: y ?? 0 }
+    })
+  if (points.length < 3) return null
+  const sproutIdx = 1 + Math.floor(Math.random() * (points.length - 2))
+  const sprout = points[sproutIdx]!
+  const branchSegments = 3 + Math.floor(Math.random() * 3)
+  // Random sideways drift for the branch direction
+  const direction = Math.random() < 0.5 ? -1 : 1
+  let x = sprout.x
+  let y = sprout.y
+  let path = `M ${x.toFixed(0)} ${y.toFixed(0)}`
+  for (let i = 1; i <= branchSegments; i++) {
+    x += direction * (40 + Math.random() * 60)
+    y += 40 + Math.random() * 80
+    path += ` L ${x.toFixed(0)} ${y.toFixed(0)}`
+  }
+  return path
+}
+
+function triggerStrike() {
+  if (current.value !== 'emily') return scheduleNext()
+  if (!animationsEnabled.value) return scheduleNext()
+  if (prefersReducedMotion()) return scheduleNext()
+  if (active.value) return scheduleNext()
+
+  // Refresh viewport size each strike (handles resize).
+  vw.value = window.innerWidth
+  vh.value = window.innerHeight
+
+  // Origin: anywhere across the top of the viewport.
+  const originX = vw.value * (0.15 + Math.random() * 0.7)
+  const main = generateBolt(originX, vh.value * 0.55)
+  boltPath.value = main
+  branchPath.value = generateBranch(main)
+
+  // Bias the flash gradient toward the bolt's side so the room "lights from
+  // that direction" rather than uniformly.
+  const flashFromLeft = originX < vw.value / 2
+  strikeStyle.value = {
+    '--emily-flash-from': `${(originX / vw.value) * 100}%`,
+    '--emily-flash-bias': flashFromLeft ? '0%' : '100%',
+  }
+  // Unique filter id per strike so React/Vue's diffing definitely re-creates it.
+  strikeCounter++
+  filterId.value = `emily-bolt-glow-${strikeCounter}`
+
+  active.value = true
+  if (endTimer) clearTimeout(endTimer)
+  endTimer = setTimeout(() => {
+    active.value = false
+    scheduleNext()
+  }, STRIKE_DURATION_MS)
+}
+
+function scheduleNext() {
+  if (intervalTimer) clearTimeout(intervalTimer)
+  intervalTimer = setTimeout(triggerStrike, pickInterval())
+}
+
+onMounted(() => {
+  if (!import.meta.client) return
+  hydrateAnimationToggle()
+  vw.value = window.innerWidth
+  vh.value = window.innerHeight
+  scheduleNext()
+})
+
+onBeforeUnmount(() => {
+  if (intervalTimer) {
+    clearTimeout(intervalTimer)
+    intervalTimer = null
+  }
+  if (endTimer) {
+    clearTimeout(endTimer)
+    endTimer = null
+  }
+})
+
+watch(current, (next) => {
+  if (next !== 'emily' && active.value) active.value = false
+})
+</script>
+
+<style scoped>
+.emily-strike {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  /* Background-layer only: must never paint over cards or main content. The
+     cards' own background-color + document-flow stacking cover this. The flash
+     uses mix-blend-mode: screen so it brightens the lagoon between cards
+     without bleeding through their opaque surfaces. */
+  z-index: 0;
+  overflow: hidden;
+}
+
+.emily-strike__flash {
+  position: absolute;
+  inset: 0;
+  /* Directional radial — `--emily-flash-from` is the X of the bolt origin */
+  background: radial-gradient(
+    ellipse 100% 70% at var(--emily-flash-from, 50%) 0%,
+    rgba(232, 250, 255, 0.55) 0%,
+    rgba(232, 250, 255, 0.15) 40%,
+    rgba(232, 250, 255, 0) 80%
+  );
+  opacity: 0;
+  animation: emily-flash 900ms ease-out forwards;
+  mix-blend-mode: screen;
+}
+
+.emily-strike__bolt {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  opacity: 0;
+  animation: emily-bolt 900ms ease-out forwards;
+}
+
+/* Multi-stroke flash — real lightning isn't a single pulse. The bolt fades
+   faster than the lingering glow so the brain reads "bright snap" then
+   "afterglow on the clouds". */
+@keyframes emily-flash {
+  0%   { opacity: 0; }
+  4%   { opacity: 0.15; }   /* pre-flash */
+  8%   { opacity: 0.02; }
+  12%  { opacity: 0.95; }   /* main strike */
+  20%  { opacity: 0.35; }
+  26%  { opacity: 0.75; }   /* secondary stroke */
+  34%  { opacity: 0.25; }
+  42%  { opacity: 0.55; }   /* tail flicker */
+  60%  { opacity: 0.15; }
+  100% { opacity: 0; }
+}
+
+@keyframes emily-bolt {
+  0%   { opacity: 0; }
+  10%  { opacity: 1; }
+  18%  { opacity: 0.1; }
+  24%  { opacity: 0.8; }
+  32%  { opacity: 0; }
+  100% { opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .emily-strike { display: none !important; }
+}
+</style>

--- a/packages/app/app/components/shared/EmilyLightning.vue
+++ b/packages/app/app/components/shared/EmilyLightning.vue
@@ -71,6 +71,7 @@
  * Self-cleans on unmount and on theme change mid-strike.
  */
 import { useThemePreference } from '~/composables/useThemePreference'
+import { useFolderAnimationSettings } from '~/composables/useFolderAnimations'
 
 // Dashboard-only deployment: shorter cadence (4–15 s) because the user is
 // idling there and the strikes are part of the ambience. On work pages this
@@ -79,16 +80,17 @@ const MIN_INTERVAL_MS = 4_000
 const MAX_INTERVAL_MS = 15_000
 const STRIKE_DURATION_MS = 900 // matches CSS keyframe length
 
-const ANIMATIONS_DISABLED_KEY = 'dm-hero-folder-animations-disabled'
-
 const { current } = useThemePreference()
+// Shares the global on/off ref with the folder hover animations — toggling
+// "Spielereien" in Settings affects both, and the composable handles
+// cross-tab storage events for us.
+const { enabled: animationsEnabled } = useFolderAnimationSettings()
 
 const active = ref(false)
 const boltPath = ref('')
 const branchPath = ref<string | null>(null)
 const vw = ref(1920)
 const vh = ref(1080)
-const animationsEnabled = ref(true)
 // Each strike rotates the flash origin slightly so a sequence feels alive.
 const strikeStyle = ref<Record<string, string>>({})
 const filterId = ref('emily-bolt-glow-0')
@@ -104,16 +106,6 @@ function prefersReducedMotion(): boolean {
 
 function pickInterval(): number {
   return MIN_INTERVAL_MS + Math.random() * (MAX_INTERVAL_MS - MIN_INTERVAL_MS)
-}
-
-function hydrateAnimationToggle() {
-  if (typeof localStorage === 'undefined') return
-  try {
-    animationsEnabled.value = localStorage.getItem(ANIMATIONS_DISABLED_KEY) !== '1'
-  }
-  catch {
-    // ignore quota / privacy errors
-  }
 }
 
 /**
@@ -210,7 +202,7 @@ function scheduleNext() {
 
 onMounted(() => {
   if (!import.meta.client) return
-  hydrateAnimationToggle()
+  // animationsEnabled hydration is handled by the shared composable.
   vw.value = window.innerWidth
   vh.value = window.innerHeight
   scheduleNext()

--- a/packages/app/app/composables/themes.ts
+++ b/packages/app/app/composables/themes.ts
@@ -1,7 +1,7 @@
 import type { ThemeDefinition } from 'vuetify'
 
 /**
- * DM Hero themes — 7 total: dark (default), hell, and 5 colored.
+ * DM Hero themes — 8 total: dark (default), hell, 5 colored, and emily.
  * Each defines vuetify palette + md-editor-v3 css vars.
  */
 
@@ -250,6 +250,45 @@ const orange: ThemeDefinition = {
   },
 }
 
+// "Emily" — Deep Lagoon. Community tribute. Brighter cyan-teal primary with
+// a sunset coral accent. Companion CSS (gradient bg, hover glow, swoosh) ships
+// alongside this palette; see issue #318.
+const emily: ThemeDefinition = {
+  dark: true,
+  colors: {
+    'background': '#0B2622',
+    'surface': '#143733',
+    'surface-variant': '#1D4A45',
+    'on-surface-variant': '#A8D5D0',
+    'primary': '#4DD0E1',
+    'primary-darken-1': '#26A8B8',
+    'secondary': '#6FA8B0',
+    'secondary-darken-1': '#4F858D',
+    'accent': '#FF7B69',
+    // Destructive actions use the theme's coral so they read as part of Emily
+    // rather than stock Material red.
+    'error': '#FF7B69',
+    'info': '#4FC3F7',
+    'success': '#66BB6A',
+    'warning': '#FFB74D',
+    'on-background': '#E0F5F3',
+    'on-surface': '#E0F5F3',
+    'on-primary': '#0B2622',
+    'on-secondary': '#0B2622',
+  },
+  variables: {
+    'md-bg': '#0B2622',
+    'md-surface': '#143733',
+    'md-text': '#E0F5F3',
+    'md-muted': '#A8D5D0',
+    'md-border': '#1D4A45',
+    'md-primary': '#4DD0E1',
+    'md-code-bg': '#061B17',
+    'md-quote-bg': '#133029',
+    'md-table-stripe': '#103127',
+  },
+}
+
 export const themes = {
   dark,
   hell,
@@ -258,11 +297,12 @@ export const themes = {
   blue,
   purple,
   orange,
+  emily,
 } as const
 
 export type ThemeName = keyof typeof themes
 
-export const THEME_NAMES: ThemeName[] = ['dark', 'hell', 'linux', 'green', 'blue', 'purple', 'orange']
+export const THEME_NAMES: ThemeName[] = ['dark', 'hell', 'linux', 'green', 'blue', 'purple', 'orange', 'emily']
 
 export const DEFAULT_THEME: ThemeName = 'dark'
 

--- a/packages/app/app/composables/useFolderAnimations.ts
+++ b/packages/app/app/composables/useFolderAnimations.ts
@@ -25,16 +25,27 @@ const COOLDOWN_MS = 10_000
 const globallyEnabled = ref(true)
 let hydratedFromStorage = false
 
-function hydrateFromLocalStorage() {
-  if (hydratedFromStorage) return
+function readFromLocalStorage() {
   if (typeof localStorage === 'undefined') return
-  hydratedFromStorage = true
   try {
     globallyEnabled.value = localStorage.getItem(SETTINGS_KEY) !== '1'
   }
   catch {
     // ignore quota / privacy errors
   }
+}
+
+function hydrateFromLocalStorage() {
+  if (hydratedFromStorage) return
+  if (typeof window === 'undefined') return
+  hydratedFromStorage = true
+  readFromLocalStorage()
+  // Cross-tab sync: another tab toggled the setting → mirror it here. Listener
+  // is attached once per browser session at module level since `globallyEnabled`
+  // is also module-scoped; no per-component cleanup needed.
+  window.addEventListener('storage', (event) => {
+    if (event.key === SETTINGS_KEY) readFromLocalStorage()
+  })
 }
 
 /** Stable hash for picking the deterministic egg per folder id. */

--- a/packages/app/app/pages/index.vue
+++ b/packages/app/app/pages/index.vue
@@ -1,5 +1,11 @@
 <template>
   <v-container>
+    <!-- Emily theme distant lightning — dashboard ambience only, self-gates
+         on theme + settings. -->
+    <ClientOnly>
+      <SharedEmilyLightning />
+    </ClientOnly>
+
     <!-- Redirect to campaigns if no campaign selected -->
     <div v-if="!activeCampaignId" class="text-center py-16">
       <v-icon icon="mdi-sword-cross" size="64" class="mb-4" color="primary" />

--- a/packages/app/i18n/locales/de.json
+++ b/packages/app/i18n/locales/de.json
@@ -44,7 +44,8 @@
     "green": "Grün (Wald)",
     "blue": "Blau (Ozean)",
     "purple": "Lila (Arkane Magie)",
-    "orange": "Orange (Lagerfeuer)"
+    "orange": "Orange (Lagerfeuer)",
+    "emily": "Emily (Tiefe Lagune)"
   },
   "featureTooltips": {
     "newBadge": "Neu",

--- a/packages/app/i18n/locales/de.json
+++ b/packages/app/i18n/locales/de.json
@@ -55,7 +55,7 @@
   "featureTooltips": {
     "newBadge": "Neu",
     "dontShowAgain": "Nicht mehr zeigen",
-    "themeSwitcher": "Wähle dein Lieblings-Theme aus 7 Farbvarianten. Du kannst diese Hinweise in den Einstellungen ausschalten.",
+    "themeSwitcher": "Wähle dein Lieblings-Theme aus 8 Farbvarianten. Du kannst diese Hinweise in den Einstellungen ausschalten.",
     "settings": {
       "title": "Hinweise für neue Funktionen",
       "description": "Zeigt einen kleinen Hinweis an, wenn ein neues Feature verfügbar ist.",

--- a/packages/app/i18n/locales/en.json
+++ b/packages/app/i18n/locales/en.json
@@ -55,7 +55,7 @@
   "featureTooltips": {
     "newBadge": "New",
     "dontShowAgain": "Don't show again",
-    "themeSwitcher": "Pick your favorite theme from 7 color variants. You can turn these hints off in Settings.",
+    "themeSwitcher": "Pick your favorite theme from 8 color variants. You can turn these hints off in Settings.",
     "settings": {
       "title": "New-feature hints",
       "description": "Shows a small hint when a new feature is available.",

--- a/packages/app/i18n/locales/en.json
+++ b/packages/app/i18n/locales/en.json
@@ -44,7 +44,8 @@
     "green": "Green (Forest)",
     "blue": "Blue (Ocean)",
     "purple": "Purple (Arcane)",
-    "orange": "Orange (Campfire)"
+    "orange": "Orange (Campfire)",
+    "emily": "Emily (Deep Lagoon)"
   },
   "featureTooltips": {
     "newBadge": "New",

--- a/packages/app/nuxt.config.ts
+++ b/packages/app/nuxt.config.ts
@@ -19,6 +19,7 @@ export default defineNuxtConfig({
     '@/assets/md-editor-theme.css',
     '@/assets/css/animations.css',
     '@/assets/css/dashboard.css',
+    '@/assets/css/emily-theme.css',
   ],
 
   runtimeConfig: {


### PR DESCRIPTION
Closes #318.

Adds an 8th theme called **emily** — a community tribute. Not just a hue swap on dark: the page reads like a still moonlit lagoon, and once in a while the storm on the horizon flashes.

## Palette — Deep Lagoon

```
BG       #0B2622   moonlit lagoon depth
Surface  #143733
Primary  #4DD0E1   bright cyan-teal
Accent   #FF7B69   sunset coral
Error    #FF7B69   coral too — destructive actions read as part of Emily, not stock Material red
```

## What's in

- Layered radial-gradient page background (moonlight pool top-left, depth shadow bottom, faint coral hint top-right). Static.
- Distant lightning easter egg on the dashboard:
  - procedural zig-zag bolt + optional side branch — never the same twice
  - multi-stroke flash (pre-flash → peak → aftershocks → fade)
  - directional radial light from the bolt's origin, `mix-blend-mode: screen`
  - mounted at `z-index: 0` so it lights the background between cards, never paints over them
  - random 4–15 s cadence on the dashboard, where ambience matters; not loaded on work pages
- Respects `prefers-reduced-motion` (lightning hidden, gradient stays)
- Honors the same animations toggle as the folder hover effects (#317) once both land

## What I left out

- The glitter / star field experiment — looked like display pixel errors in practice.
- A flying raven SVG — felt too cute for the "thunderstorm at the lagoon" mood.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Introduced the new "Emily (Deep Lagoon)" theme, featuring a layered radial-gradient page background and coral-accented destructive actions.
* Added an interactive lightning animation easter egg on the dashboard that respects reduced-motion accessibility preferences.
* Theme is now available in the theme switcher with localized support in English and German.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Flo0806/dm-hero/pull/319?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->