### PR TITLE
feat: per-theme dashboard ambient animations (#322)

### DIFF
--- a/.changeset/per-theme-ambient.md
+++ b/.changeset/per-theme-ambient.md
@@ -1,0 +1,5 @@
+---
+"@dm-hero/app": minor
+---
+
+feat: per-theme dashboard ambience (#322) — every theme now has its own fitting background animation on the dashboard. Seven themes use a parameterised particle field with distinct modes (rising embers/bubbles, falling dust, drifting motes, twinkling sparkles, fireflies, diagonal streaks), each in the theme's palette; the "emily" theme keeps its bespoke lightning (now a livelier cadence). All ambience sits behind the cards, is purely decorative, and is gated on the existing "Spielereien" setting + prefers-reduced-motion.

--- a/packages/app/app/components/shared/AmbientParticles.vue
+++ b/packages/app/app/components/shared/AmbientParticles.vue
@@ -1,0 +1,160 @@
+<template>
+  <div class="ambient-layer" aria-hidden="true">
+    <div
+      v-for="(p, i) in particles"
+      :key="i"
+      class="ambient-particle"
+      :class="`mode-${config.mode}`"
+      :style="p.style"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { AmbientConfig } from '~/composables/themeAmbient'
+
+/**
+ * A subtle, decorative particle field for the dashboard background. Driven
+ * entirely by a per-theme AmbientConfig (mode + colours + sizes + timing).
+ * Pointer-events: none, sits behind the content, honours prefers-reduced-motion.
+ *
+ * Particles are generated once on mount with randomised positions/timings and
+ * NEGATIVE animation delays, so the field looks alive immediately (no "all
+ * start together" moment) without any JS animation loop — pure CSS.
+ */
+const props = defineProps<{ config: AmbientConfig }>()
+
+interface Particle { style: Record<string, string> }
+
+const particles = ref<Particle[]>([])
+
+function prefersReducedMotion(): boolean {
+  if (typeof window === 'undefined' || !window.matchMedia) return false
+  return window.matchMedia('(prefers-reduced-motion: reduce)').matches
+}
+
+function rand(min: number, max: number): number {
+  return min + Math.random() * (max - min)
+}
+
+function build() {
+  const c = props.config
+  if (prefersReducedMotion()) {
+    particles.value = []
+    return
+  }
+  particles.value = Array.from({ length: c.count }, () => {
+    const size = rand(c.sizeMin, c.sizeMax)
+    const dur = rand(c.durationMin, c.durationMax)
+    const color = c.colors[Math.floor(Math.random() * c.colors.length)]!
+    const opacity = 0.35 + Math.random() * 0.5
+    const style: Record<string, string> = {
+      'left': `${rand(0, 100)}%`,
+      'top': `${rand(0, 100)}%`,
+      'width': `${size}px`,
+      'height': `${size}px`,
+      'background': color,
+      'opacity': '0',
+      'animationDuration': `${dur}s`,
+      'animationDelay': `${-rand(0, dur)}s`, // negative → mid-cycle start
+      '--drift': `${(Math.random() - 0.5) * 140}px`,
+      '--o': `${opacity}`,
+    }
+    if (c.glow) style.boxShadow = `0 0 ${(size * 2.5).toFixed(0)}px ${color}`
+    return { style }
+  })
+}
+
+// Rebuild when the theme (and thus config) changes, and once on mount.
+watch(() => props.config, build, { deep: true })
+onMounted(build)
+</script>
+
+<style scoped>
+.ambient-layer {
+  position: fixed;
+  inset: 0;
+  overflow: hidden;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.ambient-particle {
+  position: absolute;
+  border-radius: 50%;
+  will-change: transform, opacity;
+  animation-timing-function: ease-in-out;
+  animation-iteration-count: infinite;
+}
+
+/* Rise — embers / bubbles floating up and fading. */
+.mode-rise {
+  animation-name: ambient-rise;
+}
+@keyframes ambient-rise {
+  0% { transform: translate(0, 0); opacity: 0; }
+  12% { opacity: var(--o); }
+  88% { opacity: var(--o); }
+  100% { transform: translate(var(--drift), -110vh); opacity: 0; }
+}
+
+/* Drift — slow dust motes wandering in place. */
+.mode-drift {
+  animation-name: ambient-drift;
+  animation-timing-function: linear;
+}
+@keyframes ambient-drift {
+  0% { transform: translate(0, 0); opacity: 0; }
+  20% { opacity: var(--o); }
+  80% { opacity: var(--o); }
+  100% { transform: translate(var(--drift), -40px); opacity: 0; }
+}
+
+/* Fall — motes / dust settling down with a little sideways drift. */
+.mode-fall {
+  animation-name: ambient-fall;
+  animation-timing-function: linear;
+}
+@keyframes ambient-fall {
+  0% { transform: translate(0, 0); opacity: 0; }
+  12% { opacity: var(--o); }
+  88% { opacity: var(--o); }
+  100% { transform: translate(var(--drift), 110vh); opacity: 0; }
+}
+
+/* Streak — fast comet-like sparks shooting diagonally across. */
+.mode-streak {
+  animation-name: ambient-streak;
+  animation-timing-function: ease-in;
+}
+@keyframes ambient-streak {
+  0% { transform: translate(0, 0) scale(1); opacity: 0; }
+  10% { opacity: var(--o); }
+  100% { transform: translate(calc(var(--drift) + 42vw), 78vh) scale(0.6); opacity: 0; }
+}
+
+/* Twinkle — sparkles pulsing and gently scaling in place. */
+.mode-twinkle {
+  animation-name: ambient-twinkle;
+}
+@keyframes ambient-twinkle {
+  0%, 100% { transform: scale(0.6); opacity: 0; }
+  50% { transform: scale(1.2); opacity: var(--o); }
+}
+
+/* Firefly — drifts on a small loop while its glow breathes. */
+.mode-firefly {
+  animation-name: ambient-firefly;
+}
+@keyframes ambient-firefly {
+  0% { transform: translate(0, 0); opacity: 0; }
+  25% { opacity: var(--o); }
+  50% { transform: translate(var(--drift), -30px); opacity: calc(var(--o) * 0.4); }
+  75% { opacity: var(--o); }
+  100% { transform: translate(0, 0); opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ambient-particle { display: none; }
+}
+</style>

--- a/packages/app/app/components/shared/DashboardAmbient.vue
+++ b/packages/app/app/components/shared/DashboardAmbient.vue
@@ -1,0 +1,24 @@
+<template>
+  <!-- emily keeps its bespoke lightning; every other theme with a config gets
+       the generic particle field. Nothing renders when animations are off. -->
+  <template v-if="animationsEnabled">
+    <SharedEmilyLightning v-if="current === 'emily'" />
+    <SharedAmbientParticles v-else-if="config" :config="config" />
+  </template>
+</template>
+
+<script setup lang="ts">
+import { useThemePreference } from '~/composables/useThemePreference'
+import { useFolderAnimationSettings } from '~/composables/useFolderAnimations'
+import { THEME_AMBIENT } from '~/composables/themeAmbient'
+
+/**
+ * Picks the dashboard ambience for the active theme (#322). Shares the global
+ * "Spielereien" on/off with the folder hover animations, so one toggle governs
+ * all decorative motion.
+ */
+const { current } = useThemePreference()
+const { enabled: animationsEnabled } = useFolderAnimationSettings()
+
+const config = computed(() => THEME_AMBIENT[current.value] ?? null)
+</script>

--- a/packages/app/app/components/shared/EmilyLightning.vue
+++ b/packages/app/app/components/shared/EmilyLightning.vue
@@ -73,11 +73,11 @@
 import { useThemePreference } from '~/composables/useThemePreference'
 import { useFolderAnimationSettings } from '~/composables/useFolderAnimations'
 
-// Dashboard-only deployment: shorter cadence (4–15 s) because the user is
+// Dashboard-only deployment: lively cadence (2.5–8 s) because the user is
 // idling there and the strikes are part of the ambience. On work pages this
 // component is simply not mounted, so list/edit screens stay focused.
-const MIN_INTERVAL_MS = 4_000
-const MAX_INTERVAL_MS = 15_000
+const MIN_INTERVAL_MS = 2_500
+const MAX_INTERVAL_MS = 8_000
 const STRIKE_DURATION_MS = 900 // matches CSS keyframe length
 
 const { current } = useThemePreference()

--- a/packages/app/app/composables/themeAmbient.ts
+++ b/packages/app/app/composables/themeAmbient.ts
@@ -1,0 +1,48 @@
+import type { ThemeName } from './themes'
+
+/**
+ * Per-theme dashboard ambience (#322). Each theme gets its own subtle background
+ * animation that fits its mood. Most themes use the generic AmbientParticles
+ * component (a parameterised particle field); 'emily' is special and uses its
+ * bespoke lightning instead (see DashboardAmbient).
+ *
+ * All ambience is purely decorative, behind the content, and gated on the
+ * "Spielereien" toggle + prefers-reduced-motion.
+ */
+export type AmbientMode = 'rise' | 'drift' | 'fall' | 'twinkle' | 'firefly' | 'streak'
+
+export interface AmbientConfig {
+  /** How the particles move. */
+  mode: AmbientMode
+  /** Particle colours, picked at random per particle. */
+  colors: string[]
+  /** How many particles. */
+  count: number
+  /** Particle size range, px. */
+  sizeMin: number
+  sizeMax: number
+  /** Animation cycle range, seconds. */
+  durationMin: number
+  durationMax: number
+  /** Soft glow halo around each particle. */
+  glow?: boolean
+}
+
+// 'emily' is intentionally absent — it keeps its bespoke lightning.
+export const THEME_AMBIENT: Partial<Record<ThemeName, AmbientConfig>> = {
+  // Candlelit tavern — warm gold embers drifting up.
+  dark: { mode: 'rise', colors: ['#D4A574', '#CC8844', '#E0B080'], count: 22, sizeMin: 2, sizeMax: 4, durationMin: 8, durationMax: 16, glow: true },
+  // Daylit parchment — dust settling down through a sunbeam (darker motes so
+  // they read on the light background).
+  hell: { mode: 'fall', colors: ['#8B4513', '#B8860B', '#A9791C'], count: 26, sizeMin: 3, sizeMax: 6, durationMin: 9, durationMax: 16 },
+  // Ubuntu — energetic orange sparks streaking across.
+  linux: { mode: 'streak', colors: ['#E95420', '#DD4814', '#F0824E'], count: 14, sizeMin: 2, sizeMax: 4, durationMin: 4, durationMax: 8, glow: true },
+  // Forest — fireflies blinking and drifting.
+  green: { mode: 'firefly', colors: ['#7CFFB0', '#4CAF7C', '#FFE082'], count: 16, sizeMin: 2, sizeMax: 4, durationMin: 5, durationMax: 11, glow: true },
+  // Deep ocean — bubbles rising.
+  blue: { mode: 'rise', colors: ['#4FC3F7', '#81D4FA', '#B3E5FC'], count: 18, sizeMin: 3, sizeMax: 7, durationMin: 10, durationMax: 20, glow: true },
+  // Arcane — magic sparkles twinkling.
+  purple: { mode: 'twinkle', colors: ['#B388FF', '#D1C4E9', '#FFD740'], count: 26, sizeMin: 2, sizeMax: 4, durationMin: 4, durationMax: 9, glow: true },
+  // Forge fire — embers rising.
+  orange: { mode: 'rise', colors: ['#FF7043', '#FFCA28', '#FF8A65'], count: 24, sizeMin: 2, sizeMax: 4, durationMin: 6, durationMax: 13, glow: true },
+}

--- a/packages/app/app/pages/index.vue
+++ b/packages/app/app/pages/index.vue
@@ -1,13 +1,13 @@
 <template>
   <v-container>
-    <!-- Emily theme distant lightning — dashboard ambience only, self-gates
-         on theme + settings. -->
+    <!-- Per-theme dashboard ambience (#322) — picks the right animation for the
+         active theme; self-gates on theme + the "Spielereien" setting. -->
     <ClientOnly>
-      <SharedEmilyLightning />
+      <SharedDashboardAmbient />
     </ClientOnly>
 
     <!-- Redirect to campaigns if no campaign selected -->
-    <div v-if="!activeCampaignId" class="text-center py-16">
+    <div v-if="!activeCampaignId" class="text-center py-16 position-relative content-above">
       <v-icon icon="mdi-sword-cross" size="64" class="mb-4" color="primary" />
       <h2 class="text-headline-large mb-4">
         {{ $t('dashboard.noCampaign.title') }}
@@ -20,7 +20,7 @@
       </v-btn>
     </div>
 
-    <div v-else>
+    <div v-else class="position-relative content-above">
       <!-- Header -->
       <v-row>
         <v-col cols="12">
@@ -639,6 +639,14 @@ watch(activeCampaignId, (newId) => {
 <style scoped>
 .cursor-pointer {
   cursor: pointer;
+}
+
+/* Lift the dashboard content above the fixed ambient particle layer (z-index 0)
+   so the per-theme ambience stays behind the cards, showing only in the gaps.
+   position MUST be set here — z-index has no effect on static elements. */
+.content-above {
+  position: relative;
+  z-index: 1;
 }
 
 /* Dice overlay - positioned absolute so it doesn't take layout space */


### PR DESCRIPTION
Closes #322.

Every theme now has its own fitting ambient animation on the dashboard background.

## How

- **`DashboardAmbient.vue`** — dispatcher: picks the ambience for the active theme. `emily` keeps its bespoke lightning; every other theme renders the generic particle field.
- **`AmbientParticles.vue`** — one parameterised, pure-CSS particle field (no JS animation loop). Particles get randomised positions/timings with negative animation delays so the field looks alive immediately.
- **`themeAmbient.ts`** — per-theme config (mode + palette + sizes + timing).

## Per-theme effects

| Theme | Effect |
|------|--------|
| dark | gold embers rising |
| hell | dust falling (darker motes, visible on the light bg) |
| linux | orange sparks streaking diagonally |
| green | fireflies blinking |
| blue | bubbles rising |
| purple | arcane sparkles twinkling |
| orange | forge embers rising |
| emily | lightning ⚡ (livelier cadence, 2.5–8 s) |

5 distinct motion modes across the 8 themes.

## Behaviour

- Sits **behind** the cards (`z-index: 0` layer; the dashboard content is lifted with `position: relative; z-index: 1` — `z-index` needs a positioned element, which was the fix for particles showing over the tiles).
- Gated on the existing **"Spielereien"** toggle (shared with folder hover animations) + **prefers-reduced-motion**.
- Dashboard-only — not mounted on work pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dashboard now features decorative per-theme ambient background animations rendered behind cards.
  * Each of seven themes displays a unique particle animation style with theme-matched colors.
  * Emily theme includes an updated lightning animation with faster strike frequency.
  * Animations respect reduced motion preferences and are gated by the existing Spielereien setting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Flo0806/dm-hero/pull/327?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->