### PR TITLE
fix: NPC search misses prefix matches that fuzzy-match a class (#313)

### DIFF
--- a/.changeset/fix-npc-search-prefix.md
+++ b/.changeset/fix-npc-search-prefix.md
@@ -1,0 +1,5 @@
+---
+"@dm-hero/app": patch
+---
+
+fix: NPC search no longer drops the typed term when it fuzzily matches a race/class (#313). A 5-character query like "Baldu" fuzzily matched the class "barde" (Levenshtein 2) and replaced the search, so the NPC "Balduwan" was never found. Race/class/type expansion now ADDS its variants alongside the literal term prefix instead of replacing it, so name prefix matches always survive.

--- a/packages/app/server/api/npcs/index.get.ts
+++ b/packages/app/server/api/npcs/index.get.ts
@@ -128,18 +128,23 @@ export default defineEventHandler(async (event) => {
         const classKey = await getClassKey(term, enableFuzzy, locale)
         const typeKey = getNpcTypeKey(term, locale)
 
-        // If we found a race/class/type key, use ALL search variants (key + localized names)
+        // If we found a race/class/type key, search its variants (key + localized
+        // names) — but ALWAYS keep the literal term as a prefix too. A fuzzy
+        // race/class hit must ADD matches, never REPLACE the name search: e.g.
+        // "Baldu" fuzzily matches the class "barde" (LD 2), but the user is
+        // looking for the NPC "Balduwan" — keeping "baldu*" finds them. (#313)
+        const literal = normalizeText(term)
         if (raceKey) {
           const variants = await getRaceSearchVariants(term, locale)
-          return { variants, isRaceClassKey: true }
+          return { variants: [...variants, literal], isRaceClassKey: true }
         }
         if (classKey) {
           const variants = await getClassSearchVariants(term, locale)
-          return { variants, isRaceClassKey: true }
+          return { variants: [...variants, literal], isRaceClassKey: true }
         }
         if (typeKey) {
           const variants = getNpcTypeSearchVariants(typeKey)
-          return { variants, isRaceClassKey: true }
+          return { variants: [...variants, literal], isRaceClassKey: true }
         }
 
         // No race/class/type match - use original term


### PR DESCRIPTION
Closes #313.

## Bug

A 5-character NPC search like `Baldu` failed to find "Balduwan" and returned unrelated results, while `Bald` (4) and `Balduw` (6) worked.

## Cause

Not FTS5 — the fuzzy race/class expansion. At length ≥ 5 fuzzy matching is enabled, and `baldu` is within Levenshtein 2 of the class **barde** (`l→r`, `u→e`). When a race/class/type key matched, the code **replaced** the search term with that key's variants — so `baldu*` was no longer in the FTS query at all, and the literal name prefix was lost. (At length 4 fuzzy is off; at length 6 nothing fuzzy-matches — so both kept their prefix.)

## Fix

Race/class/type expansion now **adds** its variants *alongside* the literal term prefix instead of replacing it. So `Baldu` searches `(barde variants) OR baldu*` — finding Balduwan again, while the fuzzy race/class feature still works. The literal term also flows into the post-FTS name filter, so the match is confirmed by name.

NPC-only: other entity types have no race/class fuzzy expansion.

## Validation

Full suite: **1367 passed**. Verified locally: `Baldu` now finds Balduwan; `Bald` / `Balduw` still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)