### PR TITLE
fix: bundle MCP in release builds + stable path (#332)

### DIFF
--- a/.changeset/fix-mcp-release-bundling.md
+++ b/.changeset/fix-mcp-release-bundling.md
@@ -1,0 +1,5 @@
+---
+"@dm-hero/app": patch
+---
+
+fix: the MCP server is now actually bundled in released builds and reachable at a stable path (#332). The release CI didn't build `@dm-hero/mcp` before packaging, so the shipped app showed "Connect your AI: not built". CI now builds the MCP before electron-builder on all platforms. Additionally, the bundled `mcp.mjs` is copied to userData on startup and that stable path is handed to the dialog — so on AppImage the registered `claude mcp add …` command no longer points at the per-launch `/tmp/.mount_*` directory and survives restarts.

--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -167,6 +167,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
+      - name: Build MCP server
+        run: pnpm --filter @dm-hero/mcp build
+
       - name: Build Nuxt
         run: pnpm --filter @dm-hero/app build
 
@@ -210,6 +213,9 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install
+
+      - name: Build MCP server
+        run: pnpm --filter @dm-hero/mcp build
 
       - name: Build Nuxt
         run: pnpm --filter @dm-hero/app build
@@ -260,6 +266,9 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install
+
+      - name: Build MCP server
+        run: pnpm --filter @dm-hero/mcp build
 
       - name: Build Nuxt
         run: pnpm --filter @dm-hero/app build

--- a/packages/app/electron/main.js
+++ b/packages/app/electron/main.js
@@ -140,6 +140,30 @@ async function startServer() {
   console.log('[Electron]   UPLOAD_PATH:', paths.uploadPath)
   console.log('[Electron]   LOG_PATH:', paths.logsPath)
 
+  // Make the bundled MCP reachable at a STABLE path. In an AppImage,
+  // process.resourcesPath lives under a per-launch /tmp/.mount_* directory that
+  // changes on every start — so the path a user registers in their MCP client
+  // (`claude mcp add … <path>`) would break after the next restart. Copy the
+  // bin into userData (stable across restarts/updates) on each launch and hand
+  // THAT path to the "Connect your AI" dialog instead.
+  let mcpPath = path.join(process.resourcesPath, 'mcp', 'mcp.mjs')
+  try {
+    if (existsSync(mcpPath)) {
+      const stableDir = path.join(app.getPath('userData'), 'mcp')
+      mkdirSync(stableDir, { recursive: true })
+      const stableMcp = path.join(stableDir, 'mcp.mjs')
+      copyFileSync(mcpPath, stableMcp)
+      mcpPath = stableMcp
+      console.log('[Electron] MCP staged at stable path:', stableMcp)
+    }
+    else {
+      console.warn('[Electron] Bundled MCP not found at', mcpPath)
+    }
+  }
+  catch (err) {
+    console.error('[Electron] Failed to stage MCP bin:', err)
+  }
+
   // Start server as utility process with environment variables
   serverProcess = utilityProcess.fork(serverPath, [], {
     env: {
@@ -152,9 +176,9 @@ async function startServer() {
       LOG_PATH: paths.logsPath,
       NITRO_OUTPUT_DIR: outputDir,
       // For the dashboard "Connect your AI" dialog: the app's API URL + the
-      // bundled MCP bin path (extraResources → resources/mcp/mcp.mjs).
+      // stable MCP bin path (copied from resources/mcp/mcp.mjs to userData).
       DM_HERO_APP_URL: `http://127.0.0.1:${PROD_SERVER_PORT}`,
-      DM_HERO_MCP_PATH: path.join(process.resourcesPath, 'mcp', 'mcp.mjs'),
+      DM_HERO_MCP_PATH: mcpPath,
     },
     cwd: outputDir,
     stdio: 'pipe',


### PR DESCRIPTION
Closes #332.

The released 1.4 app showed **"Connect your AI: not built"** and (on AppImage) would have handed out an ephemeral path. Two fixes:

## 1. CI didn't build the MCP
`release-app.yml` built only Nuxt before `electron-builder`, so `packages/mcp/dist/mcp.mjs` never existed and `extraResources` copied nothing. Added a **Build MCP server** step (`pnpm --filter @dm-hero/mcp build`) before electron-builder in all three jobs (win/linux/mac). The MCP build script is cross-platform (esbuild + a node-based chmod, no shell `chmod`).

## 2. Ephemeral path on AppImage
`DM_HERO_MCP_PATH` pointed at `process.resourcesPath/mcp/mcp.mjs`, which on AppImage is under a per-launch `/tmp/.mount_*` dir that changes every start. `electron/main.js` now copies the bundled `mcp.mjs` to `userData/mcp/mcp.mjs` on startup and hands **that** stable path to the dialog — so the registered `claude mcp add …` command survives restarts and updates.

## Verified
- **Bundling:** local `electron:build` (same step sequence as CI) → `resources/mcp/mcp.mjs` present (743 KB). The exact CI step `pnpm --filter @dm-hero/mcp build` from repo root produces `dist/mcp.mjs`.
- **Stable path:** ran the built app — `~/.config/dm-hero/mcp/mcp.mjs` is created on launch, the dialog shows the stable path (no more "not built", no `/tmp/.mount`), and it stays the same across restarts.

Ships in **1.4.1**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed MCP server bundling in released builds to ensure stable, persistent paths across application restarts.
  * Registered MCP commands no longer reference temporary directories and will persist correctly after updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Flo0806/dm-hero/pull/333?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->