### PR TITLE
fix: MCP build fails on Windows CI (esbuild quoting)

### DIFF
--- a/.changeset/mcp-windows-build.md
+++ b/.changeset/mcp-windows-build.md
@@ -1,0 +1,4 @@
+---
+---
+
+Build-tooling only: MCP now builds via the esbuild JS API so the Windows CI runner no longer breaks on shell quoting. No package release — stays 1.4.1.

--- a/packages/mcp/build.mjs
+++ b/packages/mcp/build.mjs
@@ -1,0 +1,27 @@
+import { chmodSync } from 'node:fs'
+import { build } from 'esbuild'
+
+/**
+ * Bundle the stdio MCP server into a single self-contained ESM file.
+ *
+ * Uses esbuild's JS API rather than the CLI so the shebang banner (which
+ * contains a space) needs no shell quoting — the previous `--banner:js='…'`
+ * form broke on Windows CI, where the shell doesn't strip single quotes and
+ * esbuild then saw two input files.
+ */
+await build({
+  entryPoints: ['src/index.ts'],
+  bundle: true,
+  platform: 'node',
+  format: 'esm',
+  target: 'node18',
+  outfile: 'dist/mcp.mjs',
+  banner: { js: '#!/usr/bin/env node' },
+  legalComments: 'none',
+})
+
+// Best-effort executable bit (no-op / non-fatal on Windows).
+try {
+  chmodSync('dist/mcp.mjs', 0o755)
+}
+catch {}

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -10,7 +10,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "esbuild src/index.ts --bundle --platform=node --format=esm --target=node18 --outfile=dist/mcp.mjs --banner:js='#!/usr/bin/env node' --legal-comments=none && node -e \"try{require('fs').chmodSync('dist/mcp.mjs',0o755)}catch{}\""
+    "build": "node build.mjs"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",


### PR DESCRIPTION
The 1.4.1 release build failed on the **Windows** runner:

```
[ERROR] Must use "outdir" when there are multiple input files
```

## Cause

The MCP build script passed the shebang banner via the esbuild **CLI** with single quotes:
`--banner:js='#!/usr/bin/env node'`. On Linux/macOS the shell strips the quotes; on **Windows (cmd)** it does not, so the space splits the value and esbuild sees two input files (`src/index.ts` + `node`). #333 added the MCP build step to CI, which first ran it on Windows and surfaced this pre-existing bug.

## Fix

Build via esbuild's **JS API** in `build.mjs` (`banner: { js: '#!/usr/bin/env node' }`) — no shell quoting at all. Cross-platform.

```
"build": "node build.mjs"
```

**No changeset** — pure build-tooling fix, so the version stays **1.4.1** (re-release, not a bump).

## Verified
Local `pnpm --filter @dm-hero/mcp build` → `dist/mcp.mjs` (743 KB, shebang, self-contained, all 8 tools).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Windows build process to eliminate shell quoting issues.
  * Optimized build tooling for enhanced cross-platform compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Flo0806/dm-hero/pull/335?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->